### PR TITLE
Don’t inline $project into $group when it changes the semantics.

### DIFF
--- a/core/src/main/scala/slamdata/engine/physical/mongodb/optimize/optimize.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/optimize/optimize.scala
@@ -105,23 +105,18 @@ package object optimize {
     }
     
     /** Map from old grouped names to new names and mapping of expressions. */
-    def renameProjectGroup(r: Reshape, g: Grouped): Option[ListMap[BsonField.Name, List[(BsonField.Name, DocVar => DocVar)]]] = {
+    def renameProjectGroup(r: Reshape, g: Grouped): Option[ListMap[BsonField.Name, List[BsonField.Name]]] = {
       val s = r match {
         case Reshape.Doc(value) => 
           value.toList.map {
             case (newName, -\/ (v @ DocVar(_, _))) =>
               v.path match {
-                case (oldHead @ BsonField.Name(_)) :: oldTail => 
-                  g.value.get(oldHead).map { op =>
-                    (oldHead -> (newName, (v: DocVar) => DocVar.ROOT(BsonField(v.path ++ oldTail))))
-                  }
-              
+                case List(oldHead @ BsonField.Name(_)) =>
+                  g.value.get(oldHead).map { _ => oldHead -> newName }
                 case _ => None
               }
-
             case _ => None
           }
-        
         case _ => None :: Nil
       }
 
@@ -131,13 +126,12 @@ package object optimize {
       s.sequenceU.map(multiListMap)
     }
     
-    
     def inlineProjectGroup(r: Reshape, g: Grouped): Option[Grouped] = {
       for {
         names   <- renameProjectGroup(r, g)
-        values1 = names.flatMap { case (oldName, ts ) => ts.map { case (newName, f) =>
-            (newName: BsonField.Leaf) -> g.value(oldName).mapUp { case v @ DocVar(_,_) => f(v) }.asInstanceOf[GroupOp]
-          }}
+        values1 = names.flatMap {
+          case (oldName, ts) => ts.map((_: BsonField.Leaf) -> g.value(oldName))
+        }
       } yield Grouped(values1)
     }
 
@@ -146,14 +140,14 @@ package object optimize {
         names    <- renameProjectGroup(r, g)
         unwound1 <- unwound.path match {
           case (name @ BsonField.Name(_)) :: Nil => names.get(name) match {
-            case Some((n, _) :: Nil) => Some(DocField(n))
+            case Some(n :: Nil) => Some(DocField(n))
             case _ => None
           }
           case _ => None 
         }
-        values1 = names.flatMap { case (oldName, ts ) => ts.map { case (newName, f) =>
-            (newName: BsonField.Leaf) -> g.value(oldName).mapUp { case v @ DocVar(_,_) => f(v) }.asInstanceOf[GroupOp]
-          }}
+        values1 = names.flatMap {
+          case (oldName, ts) => ts.map((_: BsonField.Leaf) -> g.value(oldName))
+        }
       } yield unwound1 -> Grouped(values1)
     }
 

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowop.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowop.scala
@@ -149,9 +149,8 @@ object Workflow {
       case $Project(src, shape, id) => src.unFix match {
         case $Project(src0, shape0, id0) =>
           inlineProject(shape, List(shape0)).map($project(_, id0 * id)(src0)).getOrElse(op)
-        // TODO: fix implementation of inlineProjectGroup (#435)
-        // case $Group(src, grouped, by) if id != ExcludeId =>
-        //   inlineProjectGroup(shape, grouped).map($group(_, by)(src)).getOrElse(op)
+        case $Group(src, grouped, by) if id != ExcludeId =>
+          inlineProjectGroup(shape, grouped).map($group(_, by)(src)).getOrElse(op)
         case $Unwind(Term($Group(src, grouped, by)), unwound)
             if id != ExcludeId =>
           inlineProjectUnwindGroup(shape, unwound, grouped).map { case (unwound, grouped) =>

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/optimize.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/optimize.scala
@@ -48,9 +48,7 @@ class OptimizeSpecs extends Specification with TreeMatchers {
           Grouped(ListMap(
             BsonField.Name("value") -> ExprOp.Push(ExprOp.DocField(BsonField.Name("foo"))))))
 
-          inlined must beSome(beTree(Grouped(ListMap(
-            BsonField.Name("bar") -> ExprOp.Push(ExprOp.DocField(BsonField.Name("foo") \ BsonField.Name("bar"))),
-            BsonField.Name("baz") -> ExprOp.Push(ExprOp.DocField(BsonField.Name("foo") \ BsonField.Name("baz")))))))
+          inlined must beNone
     }
   }
 }

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -727,10 +727,15 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             $read(Collection("zips")),
             $group(
               Grouped(ListMap(
-                BsonField.Name("city") -> ExprOp.Push(ExprOp.DocField(BsonField.Name("city"))),
-                BsonField.Name("cnt") -> ExprOp.Sum(ExprOp.Literal(Bson.Int32(1))))),
-              -\/ (ExprOp.Literal(Bson.Null))),
-            $unwind(ExprOp.DocField(BsonField.Name("city"))),
+                BsonField.Name("cnt") -> Sum(Literal(Bson.Int32(1))),
+                BsonField.Name("__tmp0") -> Push(DocVar.ROOT()))),
+              -\/(Literal(Bson.Null))),
+            $unwind(DocField(BsonField.Name("__tmp0"))),
+            $project(Reshape.Doc(ListMap(
+              BsonField.Name("cnt") -> -\/(DocField(BsonField.Name("cnt"))),
+              BsonField.Name("city") ->
+                -\/(DocField(BsonField.Name("__tmp0") \ BsonField.Name("city"))))),
+              IgnoreId),
             $sort(NonEmptyList(BsonField.Name("cnt") -> Descending)))
         }
     }

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -358,22 +358,12 @@ class WorkflowBuilderSpec
 
       op must beRightDisjOrDiff(
         chain($read(Collection("zips")),
-          $project(Reshape.Doc(ListMap(
-            BsonField.Name("lEft") -> \/- (Reshape.Doc(ListMap(
-              BsonField.Name("city") -> -\/ (DocField(BsonField.Name("city")))))),
-            BsonField.Name("rIght") -> -\/ (DocVar.ROOT()))),
-            IncludeId),
           $group(
             Grouped(ListMap(
-              BsonField.Name("total") -> Sum(DocField(BsonField.Name("rIght") \ BsonField.Name("pop"))),
-              BsonField.Name("__sd_tmp_1") -> Push(DocField(BsonField.Name("lEft"))))),
-            -\/ (DocField(BsonField.Name("rIght") \ BsonField.Name("city")))),
-          $unwind(
-            DocField(BsonField.Name("__sd_tmp_1"))),
-          $project(Reshape.Doc(ListMap(
-            BsonField.Name("total") -> -\/ (DocField(BsonField.Name("total"))),
-            BsonField.Name("city") -> -\/ (DocField(BsonField.Name("__sd_tmp_1") \ BsonField.Name("city"))))),
-            IncludeId)))
+              BsonField.Name("total") -> Sum(DocField(BsonField.Name("pop"))),
+              BsonField.Name("city") -> Push(DocField(BsonField.Name("city"))))),
+            -\/ (DocField(BsonField.Name("city")))),
+          $unwind(DocField(BsonField.Name("city")))))
     }
 
     "group in expression" in {

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/workflowop.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/workflowop.scala
@@ -78,7 +78,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
         $unwind(ExprOp.DocField(BsonField.Name("city"))))
       
       given must beTree(expected: Workflow)
-    }
+    }.pendingUntilFixed("#536")
     
     "not flatten project into group/unwind with _id excluded" in {
       val given = chain(


### PR DESCRIPTION
Fixes #435.