### PR TITLE
Add nonAtomic option for $foldLeft operations.

### DIFF
--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowop.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowop.scala
@@ -589,7 +589,10 @@ object Workflow {
                 // FIXME: $FoldLeft currently always reduces, but in future we’ll
                 //        want to have more control.
                 MapReduceTask(src,
-                  mr applyLens MapReduce._out set Some(MapReduce.WithAction(MapReduce.Action.Reduce)))
+                  mr applyLens MapReduce._out set
+                    Some(MapReduce.WithAction(
+                      MapReduce.Action.Reduce,
+                      nonAtomic = Some(true))))
               // NB: `finalize` should ensure that the final op is always a
               //     $Reduce.
               case src => sys.error("not a mapReduce: " + src)

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/evaluator.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/evaluator.scala
@@ -156,7 +156,7 @@ class EvaluatorSpec extends Specification with DisjunctionMatchers {
           |  function (key, values) {
           |    return Array.sum(values);
           |  },
-          |  { "out" : { "reduce" : "tmp.gen_0"} , "query" : { "pop" : { "$lte" : 1000}}})
+          |  { "out" : { "reduce" : "tmp.gen_0" , "nonAtomic" : true} , "query" : { "pop" : { "$lte" : 1000}}})
           |db.tmp.gen_0.find()""".stripMargin)
     }
   }


### PR DESCRIPTION
Fixes #534.

This avoids a database-level lock when a map/reduce is
happening. Unfortunately, the Java `mapReduce()` function doesn’t
support this option, so when it’s provided we have to use the
`command()` interface.