### PR TITLE
Implement `In` for SelectorPhase.

### DIFF
--- a/core/src/main/scala/slamdata/engine/physical/mongodb/findquery.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/findquery.scala
@@ -96,11 +96,9 @@ object Selector {
     def bson = Bson.Doc(ListMap(op -> rhs))
   }
 
-  case class Literal(bson: Bson) extends Condition
-
   sealed trait Comparison extends Condition
-  case class Eq(rhs: Bson) extends SimpleCondition("$eq") with Comparison {
-    override def toString = s"Selector.Eq($rhs)"
+  case class Eq(bson: Bson) extends Condition with Comparison {
+    override def toString = s"Selector.Eq($bson)"
   }
   case class Gt(rhs: Bson) extends SimpleCondition("$gt") with Comparison {
     override def toString = s"Selector.Gt($rhs)"

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/findquery.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/findquery.scala
@@ -99,9 +99,7 @@ object Selector {
   case class Literal(bson: Bson) extends Condition
 
   sealed trait Comparison extends Condition
-  case class Eq(rhs: Bson) extends Comparison {
-    def bson = rhs
-
+  case class Eq(rhs: Bson) extends SimpleCondition("$eq") with Comparison {
     override def toString = s"Selector.Eq($rhs)"
   }
   case class Gt(rhs: Bson) extends SimpleCondition("$gt") with Comparison {
@@ -217,8 +215,9 @@ object Selector {
 
     override def toString = s"Selector.All($selectors)"
   }
-  case class ElemMatch(selector: Selector) extends SimpleCondition("$elemMatch") with Arr {
-    protected def rhs = selector.bson
+  case class ElemMatch(selector: Selector \/ SimpleCondition)
+      extends SimpleCondition("$elemMatch") with Arr {
+    protected def rhs = selector.fold(_.bson, _.bson)
 
     override def toString = s"Selector.ElemMatch($selector)"
   }

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -360,7 +360,7 @@ object MongoDbPlanner extends Planner[Workflow] {
             case `In`  =>
               relop(
                 Selector.In.apply _,
-                x => Selector.ElemMatch(\/-(Selector.Eq(x))))
+                x => Selector.ElemMatch(\/-(Selector.In(Bson.Arr(List(x))))))
 
             case `Search`   => stringOp(s => Selector.Regex(s, false, false, false, false))
 

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -357,6 +357,10 @@ object MongoDbPlanner extends Planner[Workflow] {
                   List(there(0, here))))
               case _ => -\/(PlannerError.UnsupportedPlan(node))
             }
+            case `In`  =>
+              relop(
+                Selector.In.apply _,
+                x => Selector.ElemMatch(\/-(Selector.Eq(x))))
 
             case `Search`   => stringOp(s => Selector.Regex(s, false, false, false, false))
 

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/evaluator.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/evaluator.scala
@@ -127,7 +127,7 @@ class EvaluatorSpec extends Specification with DisjunctionMatchers {
           chain(
             $read(Collection("zips1")),
             $match(Selector.Doc(
-              BsonField.Name("city") -> Selector.Eq(Bson.Text("BOULDER"))))),
+              BsonField.Name("city") -> Selector.Literal(Bson.Text("BOULDER"))))),
           chain(
             $read(Collection("zips2")),
             $match(Selector.Doc(

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/evaluator.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/evaluator.scala
@@ -127,7 +127,7 @@ class EvaluatorSpec extends Specification with DisjunctionMatchers {
           chain(
             $read(Collection("zips1")),
             $match(Selector.Doc(
-              BsonField.Name("city") -> Selector.Literal(Bson.Text("BOULDER"))))),
+              BsonField.Name("city") -> Selector.Eq(Bson.Text("BOULDER"))))),
           chain(
             $read(Collection("zips2")),
             $match(Selector.Doc(

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -405,7 +405,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         beWorkflow(chain(
           $read(Collection("zips")),
           $match(Selector.Doc(BsonField.Name("loc") ->
-            Selector.ElemMatch(\/-(Selector.Eq(Bson.Dec(43.058514))))))))
+            Selector.ElemMatch(\/-(Selector.In(Bson.Arr(List(Bson.Dec(43.058514))))))))))
     }
 
     "plan filter with field containing other field" in {

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/workflowop.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/workflowop.scala
@@ -853,8 +853,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
             ExprOp.DocField(BsonField.Name("b")))))),
           IncludeId),
         $match(Selector.Doc(
-          BsonField.Name("equal") ->
-            Selector.Literal(Bson.Bool(true)))),
+          BsonField.Name("equal") -> Selector.Eq(Bson.Bool(true)))),
         $sort(NonEmptyList(BsonField.Name("a") -> Descending)),
         $limit(100),
         $skip(5),
@@ -880,7 +879,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
               IncludeId),
             $Match((),
               Selector.Doc(
-                BsonField.Name("equal") -> Selector.Literal(Bson.Bool(true)))),
+                BsonField.Name("equal") -> Selector.Eq(Bson.Bool(true)))),
             $Sort((), NonEmptyList(BsonField.Name("a") -> Descending)),
             $Limit((), 100),
             $Skip((), 5),

--- a/it/src/test/resources/tests/filterOnContains.test
+++ b/it/src/test/resources/tests/filterOnContains.test
@@ -1,0 +1,7 @@
+{
+    "name": "filter on contains",
+    "data": "zips.data",
+    "query": "select * from zips where 43.058514 in loc",
+    "predicate": "equalsExactly",
+    "expected": [{ "city": "CANDIA", "state": "NH", "pop": 3557, "loc": [-71.304857, 43.058514] }]
+}

--- a/it/src/test/scala/slamdata/engine/regression.scala
+++ b/it/src/test/scala/slamdata/engine/regression.scala
@@ -197,9 +197,9 @@ object Predicate extends Specification {
         case (Some(expected), 
               Some(actual))   =>  (actual.obj |@| expected.obj) { (actual, expected) =>
                                     if (actual.toList == expected.toList) success(s"matches $expected", s)    
-                                    else if (actual == expected) failure(s"matches $expected, but order is not the same", s)    
-                                    else failure(s"does not match $expected", s)
-                                  }.getOrElse(result(actual == expected, s"matches $expected", s"does not match $expected", s))
+                                    else if (actual == expected) failure(s"$actual matches $expected, but order differs", s)    
+                                    else failure(s"$actual does not match $expected", s)
+                                  }.getOrElse(result(actual == expected, s"matches $expected", s"$actual does not match $expected", s))
         case (Some(_), None)  =>  failure(s"ran out before expected", s)
         case (None, Some(v))  =>  failure(s"had more than expected: ${v}", s)
         case (None, None)     =>  success(s"matches (empty)", s)


### PR DESCRIPTION
`where field in <constant array>` and `where <constant> in field` are
both normal selectors now, rather than requiring `$where` (which is only
used for `where field1 in field2` now).

Some other changes required to implement this:

* distingish `Selector.Eq` from `Selector.Literal` – both used to
  generate the same selector, but `Eq` is now for the (undocumented)
  `$eq` comparator, which is needed for `$elemMatch`;
* `Selector.ElemMatch` now takes `Selector \/ SimpleCondition` rather
  than just `Selector`, which is at least _closer_ to its true type; and
* regression test failures now print out the actual result to make it
  easier to see what went wrong.