### PR TITLE
concat constant value with grouped expression

### DIFF
--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -599,6 +599,11 @@ object WorkflowBuilder {
               shape2)))
       case (DocBuilderF(_, _), ValueBuilderF(Bson.Doc(_))) => delegate
 
+      case (ValueBuilderF(Bson.Doc(map1)), GroupBuilderF(s1, k1, \&/-(c2), id2)) =>
+        unlessConflicts(map1.keySet.map(BsonField.Name(_)), c2.keySet,
+          emit(GroupBuilder(s1, k1, \&/-(map1.map { case (k, v) => BsonField.Name(k) -> -\/(Literal(v)) } ++ c2), id2)))
+      case (GroupBuilderF(_, _, \&/-(_), _), ValueBuilderF(_)) => delegate
+
       case (
         GroupBuilderF(s1, k1, c1 @ \&/-(_), id1),
         GroupBuilderF(s2, k2, c2 @ \&/-(_), id2))

--- a/it/src/test/resources/tests/constantAndGrouped.test
+++ b/it/src/test/resources/tests/constantAndGrouped.test
@@ -1,0 +1,16 @@
+{
+  "name": "constant and a grouped value",
+
+  "data": "zips.data",
+
+  "variables": {
+    "state": "'CO'"
+  },
+
+  "query": "select :state as state, count(*) as \"count\" from zips where state = :state",
+
+  "predicate": "containsExactly",
+  "expected": [
+    { "state": "CO", "count": 414 }
+  ]
+}


### PR DESCRIPTION
Fixes the most important cases related to #524, but not less useful cases like
`select min(1) …` and `select lower(‘ABC’) …`.