### PR TITLE
report consistent and complete coverage when running all tests

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -10,7 +10,7 @@ outputStrategy := Some(StdoutOutput)
 
 import ScoverageSbtPlugin._
 
-ScoverageKeys.coverageExcludedPackages := "slamdata.engine.repl;.*RenderTree;.*MongoDbExecutor;.*MongoWrapper"
+ScoverageKeys.coverageExcludedPackages := "slamdata.engine.repl;.*RenderTree"
 
 ScoverageKeys.coverageMinimum := 70
 

--- a/scripts/build
+++ b/scripts/build
@@ -47,7 +47,10 @@ if [[ ${LOCAL_MONGODB:-} == "true" ]] ; then
 fi 
 
 # Build and run all tests everywhere (including integration)
-"$SBT" -DisCoverageRun=true coverage test
+# Note: scoverage is brain-dead, so each project's tests have to be run 
+# separately, and 'core' should be last, so that its report will include
+# coverage in the core code provided by tests in other projects.
+"$SBT" -DisCoverageRun=true coverage 'project it' test 'project admin' test 'project web' test 'project core' test
 
 # Build completed, copy oneJar to right location:
 mkdir -p $SLAM_WEB_JAR_DIR


### PR DESCRIPTION
scoverage collects coverage data in the project where the source
resides, regardless of which project’s test is running when it occurs.

That means we were formerly collecting coverage data for a portion of
the tests from the other projects (mainly `it`), non-deterministically.
How much coverage was reported just depended on how many of the `it`
tests happened to have already run at the moment that the `core` tests
finished and the report got generated.

Running `core` last means that all the other projects’ coverage data
has already been collected by the time the report is run, which should
give consistent results, and also ensure that the greatest amount of
coverage is included (win!)

Since we now get coverage for the `it` tests, removed the exclusion for
the MongoDB evaluator.