### PR TITLE
Include default case when checking type of Switch and Match (Fixes #565)

### DIFF
--- a/core/src/main/scala/slamdata/engine/semantics.scala
+++ b/core/src/main/scala/slamdata/engine/semantics.scala
@@ -504,9 +504,9 @@ trait SemanticAnalysis {
           case InvokeFunction(name, args) => typecheckFunc(args.toList)
           case Case(cond, expr) => succeed(typeOf(expr))
           case Match(expr, cases, default) => 
-            succeed(cases.map(typeOf).foldLeft[Type](Type.Top)(_ | _).lub)
+            succeed((cases ++ default).map(typeOf).foldLeft[Type](Type.Top)(_ | _).lub)
           case Switch(cases, default) => 
-            succeed(cases.map(typeOf).foldLeft[Type](Type.Top)(_ | _).lub)
+            succeed((cases ++ default).map(typeOf).foldLeft[Type](Type.Top)(_ | _).lub)
           case IntLiteral(value) => succeed(Type.Const(Data.Int(value)))
           case FloatLiteral(value) => succeed(Type.Const(Data.Dec(value)))
           case StringLiteral(value) => succeed(Type.Const(Data.Str(value)))

--- a/core/src/main/scala/slamdata/engine/std/string.scala
+++ b/core/src/main/scala/slamdata/engine/std/string.scala
@@ -59,7 +59,7 @@ trait StringLib extends Library {
       case Type.Const(Data.Str(str)) :: Type.Const(Data.Str(pattern)) :: Nil =>
         success(Type.Const(Data.Bool(matchAnywhere(str, pattern))))
       case strT :: patternT :: Nil =>
-        (Type.typecheck(strT, Type.Str) |@| Type.typecheck(patternT, Type.Str))((_, _) => Type.Bool)
+        (Type.typecheck(Type.Str, strT) |@| Type.typecheck(Type.Str, patternT))((_, _) => Type.Bool)
       case _ =>
         failure(nel(GenericError("expected arguments"), Nil))
     },

--- a/core/src/main/scala/slamdata/engine/types.scala
+++ b/core/src/main/scala/slamdata/engine/types.scala
@@ -1,13 +1,7 @@
 package slamdata.engine
 
 import scalaz._
-
-import scalaz.std.vector._
-import scalaz.std.list._
-import scalaz.std.indexedSeq._
-import scalaz.std.anyVal._
-import scalaz.syntax.monad._
-import scalaz.std.option._
+import Scalaz._
 
 import SemanticError.{TypeError, MissingField, MissingIndex}
 import NonEmptyList.nel
@@ -15,8 +9,6 @@ import Validation.{success, failure}
 
 sealed trait Type { self =>
   import Type._
-  import scalaz.std.option._
-  import scalaz.syntax.traverse._
 
   final def & (that: Type) = Type.Product(this, that)
 
@@ -79,7 +71,7 @@ sealed trait Type { self =>
     
     if (Type.lub(field, Str) != Str) failure(nel(TypeError(Str, field), Nil))
     else (field, this) match {
-      case (Str, Const(Data.Obj(map))) => success(map.values.map(_.dataType).foldLeft[Type](Top)(Type.lub _))
+      case (Str, Const(Data.Obj(map))) => success(map.values.map(_.dataType).foldLeft[Type](Bottom)(Type.lub _))
       case (Const(Data.Str(field)), Const(Data.Obj(map))) => 
         // TODO: import toSuccess as method on Option (via ToOptionOps)?
         toSuccess(map.get(field).map(Const(_)))(nel(MissingField(field), Nil))
@@ -218,30 +210,31 @@ case object Type extends TypeInstances {
     case x => x
   }
 
-  def glb(left: Type, right: Type): Type = (left, right) match {
-    case (left, right) if left == right => left
-
-    case (left, right) if left contains right => left
-    case (left, right) if right contains left => right
-
-    case _ => Bottom
+  def glb(left: Type, right: Type): Type = {
+    if (left == right) left
+    else if (left contains right) right
+    else if (right contains left) left
+    else Bottom
   }
 
   def lub(left: Type, right: Type): Type = (left, right) match {
-    case (left, right) if left == right => left
+    case _ if left == right       => left
 
-    case (left, right) if left contains right => right
-    case (left, right) if right contains left => left
+    case _ if left contains right => left
+    case _ if right contains left => right
 
-    case _ => Top
+    case (Const(l), Const(r))
+      if l.dataType == r.dataType => l.dataType
+
+    case _                        => Top
   }
 
   def typecheck(expected: Type, actual: Type): ValidationNel[TypeError, Unit] = (expected, actual) match {
     case (expected, actual) if (expected == actual) => succeed(Unit)
 
-    case (Top, actual) => succeed(Unit)
+    case (Top, _)    => succeed(Unit)
+    case (_, Bottom) => succeed(Unit)
 
-    case (Const(expected), actual) => typecheck(expected.dataType, actual)
     case (expected, Const(actual)) => typecheck(expected, actual.dataType)
 
     case (expected : Product, actual : Product) => typecheckPP(expected.flatten, actual.flatten)

--- a/core/src/test/scala/slamdata/engine/TypeGen.scala
+++ b/core/src/test/scala/slamdata/engine/TypeGen.scala
@@ -15,10 +15,11 @@ trait TypeGen {
 
   def arbitraryConst = Arbitrary { constGen } 
 
-  def arbitraryNonnestedType = Arbitrary { Gen.oneOf(simpleGen, objectGen, arrayGen) }
+  def arbitraryNonnestedType = Arbitrary { Gen.oneOf(Gen.const(Top), Gen.const(Bottom), simpleGen, objectGen, arrayGen) }
   
   def typeGen(depth: Int): Gen[Type] = {
-    val gens = List(terminalGen, constGen, objectGen, arrayGen).map(complexGen(depth, _))
+    // NB: never nests Top or Bottom inside any complex type, because that's mostly nonsensical.
+    val gens = Gen.oneOf(Top, Bottom) :: List(terminalGen, constGen, objectGen, arrayGen).map(complexGen(depth, _))
 
     Gen.oneOf(gens(0), gens(1), gens.drop(2): _*)
   }
@@ -39,7 +40,7 @@ trait TypeGen {
     
   def simpleGen: Gen[Type] = Gen.oneOf(terminalGen, constGen, setGen)    
   
-  def terminalGen: Gen[Type] = Gen.oneOf(Top, Bottom, Null, Str, Int, Dec, Bool, Binary, DateTime, Interval)
+  def terminalGen: Gen[Type] = Gen.oneOf(Null, Str, Int, Dec, Bool, Binary, DateTime, Interval)
     
   def constGen: Gen[Type] = 
     Gen.oneOf(Const(Data.Null), Const(Data.Str("a")), Const(Data.Int(1)), 

--- a/core/src/test/scala/slamdata/engine/compiler.scala
+++ b/core/src/test/scala/slamdata/engine/compiler.scala
@@ -10,7 +10,7 @@ import org.specs2.matcher.{Matcher, Expectable}
 import slamdata.specs2._
 
 @org.junit.runner.RunWith(classOf[org.specs2.runner.JUnitRunner])
-class CompilerSpec extends Specification with CompilerHelpers with PendingWithAccurateCoverage {
+class CompilerSpec extends Specification with CompilerHelpers with PendingWithAccurateCoverage with DisjunctionMatchers {
   import StdLib._
   import agg._
   import array._
@@ -1145,5 +1145,17 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
         "select distinct(city, state) from zips",
         read("zips"))
     }.pendingUntilFixed
+
+    "fail with ambiguous reference" in {
+      compile("select foo from bar, baz") must beAnyLeftDisj
+    }
+    
+    "fail with ambiguous reference in cond" in {
+      compile("select (case when a = 1 then 'ok' else 'reject' end) from bar, baz") must beAnyLeftDisj
+    }
+    
+    "fail with ambiguous reference in else" in {
+      compile("select (case when bar.a = 1 then 'ok' else foo end) from bar, baz") must beAnyLeftDisj
+    }
   }
 }


### PR DESCRIPTION
This turned out be a very small bug in the typing of the query, and
a very long expedition into the shortcomings of `Type.typecheck`.
I ended fixing a couple of things and writing up the rest as a separate 
defect.