### PR TITLE
Fix object-flattening ($flatMap) merging.

### DIFF
--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -384,18 +384,8 @@ object WorkflowBuilder {
             val field = base.toJs(JsCore.Ident("value").fix)
             CollectionBuilderF(
               chain(graph,
-                $flatMap(
-                  Js.AnonFunDecl(List("key", "value"),
-                    List(
-                      Js.VarDef(List("rez" -> Js.AnonElem(Nil))),
-                      Js.ForIn(Js.Ident("attr"), field.toJs,
-                        Call(Select(Ident("rez").fix, "push").fix,
-                          List(
-                            Arr(List(
-                              Call(Ident("ObjectId").fix, Nil).fix,
-                              Access(field, Ident("attr").fix).fix)).fix)).fix.toJs),
-                      Js.Return(Js.Ident("rez")))))),
-              DocVar.ROOT(),
+                $simpleFlatMap(Predef.identity, JsMacro(base.toJs(_)))),
+              base,
               struct)
         }
     }
@@ -1335,8 +1325,8 @@ object WorkflowBuilder {
             case ((lbase, rbase), cont) =>
               (lbase, rbase,
                 cont match {
-                  case Expr(expr) => ExprBuilder(src1, expr)
-                  case Doc(doc)   => DocBuilder(src1, doc)
+                  case Expr(expr) => ExprBuilder(wb, expr)
+                  case Doc(doc)   => DocBuilder(wb, doc)
                 })
           }
         }
@@ -1347,8 +1337,8 @@ object WorkflowBuilder {
             case ((lbase, rbase), cont) =>
               (lbase, rbase,
                 cont match {
-                  case Expr(expr) => ExprBuilder(src1, expr)
-                  case Doc(doc)   => DocBuilder(src1, doc)
+                  case Expr(expr) => ExprBuilder(wb, expr)
+                  case Doc(doc)   => DocBuilder(wb, doc)
                 })
           }
         }

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -994,22 +994,9 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         beWorkflow {
           chain(
             $read(Collection("usa_factbook")),
-            $flatMap(
-              Js.AnonFunDecl(List("key", "value"), List(
-                Js.VarDef(List("rez" -> Js.AnonElem(Nil))),
-                Js.ForIn(
-                  Js.Ident("attr"),
-                  Select(Ident("value").fix, "geo").fix.toJs,
-                  Call(Select(Ident("rez").fix, "push").fix,
-                    List(
-                      JsCore.Arr(List(
-                        Call(Ident("ObjectId").fix, Nil).fix,
-                        Access(
-                          Select(Ident("value").fix, "geo").fix,
-                          Ident("attr").fix).fix)).fix)).fix.toJs),
-                Js.Return(Js.Ident("rez"))))),
+            $simpleFlatMap(Predef.identity, JsMacro(Select(_, "geo").fix)),
             $project(Reshape.Doc(ListMap(
-              BsonField.Name("geo") -> -\/(DocVar.ROOT()))),
+              BsonField.Name("geo") -> -\/(DocField(BsonField.Name("geo"))))),
               IgnoreId))
         }
     }

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/workflowop.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/workflowop.scala
@@ -639,23 +639,18 @@ class WorkflowSpec extends Specification with TreeMatchers {
         $flatMap($FlatMap.mapCompose(
           $Map.mapNOP,
           Js.AnonFunDecl(List("key", "value"), List(
-            Js.VarDef(List("each" -> Js.AnonObjDecl(Nil))),
-            Js.ForIn(Js.Ident("attr"), Js.Ident("value"),
-              Js.If(
-                Call(Select(Ident("value").fix, "hasOwnProperty").fix,
-                  List(Ident("attr").fix)).fix.toJs,
-                safeAssign(Access(Ident("each").fix, Ident("attr").fix).fix,
-                  Access(Ident("value").fix, Ident("attr").fix).fix),
-                None)),
-            Js.Return(
-              Js.safeCall(Select(Ident("value").fix, "loc").fix.toJs, "map", List(
-                Js.AnonFunDecl(List("elem"), List(
-                  safeAssign(Select(Ident("each").fix, "loc").fix,
-                    Ident("elem").fix),
-                  Js.Return(
+            Js.VarDef(List("rez" -> Js.AnonElem(Nil))),
+            Js.ForIn(Js.Ident("elem"), Select(Ident("value").fix, "loc").fix.toJs,
+              Js.Block(List(
+                Js.VarDef(List("each" -> Js.AnonObjDecl(Nil))),
+                $Reduce.copyAllFields(Ident("value").fix)(Ident("each").fix),
+                safeAssign(Select(Ident("each").fix, "loc").fix, Access(Select(Ident("value").fix, "loc").fix, Ident("elem").fix).fix),
+                Call(Select(Ident("rez").fix, "push").fix,
+                  List(
                     Arr(List(
                       Call(Ident("ObjectId").fix, Nil).fix,
-                      Ident("each").fix)).fix.toJs)))))))))))
+                      Ident("each").fix)).fix)).fix.toJs))),
+            Js.Return(Js.Ident("rez")))))))
       Workflow.finalize(given) must beTree(expected)
     }
 
@@ -696,23 +691,18 @@ class WorkflowSpec extends Specification with TreeMatchers {
                       Ident("attr").fix).fix)).fix)).fix.toJs),
             Js.Return(Js.Ident("rez")))),
           Js.AnonFunDecl(List("key", "value"), List(
-            Js.VarDef(List("each" -> Js.AnonObjDecl(Nil))),
-            Js.ForIn(Js.Ident("attr"), Js.Ident("value"),
-              Js.If(
-                Call(Select(Ident("value").fix, "hasOwnProperty").fix, List(
-                  Ident("attr").fix)).fix.toJs,
-                safeAssign(Access(Ident("each").fix, Ident("attr").fix).fix,
-                  Access(Ident("value").fix, Ident("attr").fix).fix),
-                None)),
-            Js.Return(
-              Js.safeCall(Select(Ident("value").fix, "loc").fix.toJs, "map", List(
-                Js.AnonFunDecl(List("elem"), List(
-                  safeAssign(Select(Ident("each").fix, "loc").fix,
-                    Ident("elem").fix),
-                  Js.Return(
+            Js.VarDef(List("rez" -> Js.AnonElem(Nil))),
+            Js.ForIn(Js.Ident("elem"), Select(Ident("value").fix, "loc").fix.toJs,
+              Js.Block(List(
+                Js.VarDef(List("each" -> Js.AnonObjDecl(Nil))),
+                $Reduce.copyAllFields(Ident("value").fix)(Ident("each").fix),
+                safeAssign(Select(Ident("each").fix, "loc").fix, Access(Select(Ident("value").fix, "loc").fix, Ident("elem").fix).fix),
+                Call(Select(Ident("rez").fix, "push").fix,
+                  List(
                     Arr(List(
                       Call(Ident("ObjectId").fix, Nil).fix,
-                      Ident("each").fix)).fix.toJs)))))))))))
+                      Ident("each").fix)).fix)).fix.toJs))),
+            Js.Return(Js.Ident("rez")))))))
       Workflow.finalize(given) must beTree(expected)
     }
 
@@ -727,24 +717,18 @@ class WorkflowSpec extends Specification with TreeMatchers {
         readZips,
         $flatMap(
           Js.AnonFunDecl(List("key", "value"), List(
-            Js.VarDef(List("each" -> Js.AnonObjDecl(Nil))),
-            Js.ForIn(Js.Ident("attr"), Js.Ident("value"),
-              Js.If(
-                Call(Select(Ident("value").fix, "hasOwnProperty").fix, List(
-                  Ident("attr").fix)).fix.toJs,
-                safeAssign(
-                  Access(Ident("each").fix, Ident("attr").fix).fix,
-                  Access(Ident("value").fix, Ident("attr").fix).fix),
-                None)),
-            Js.Return(
-              Js.safeCall(Select(Ident("value").fix, "loc").fix.toJs, "map", List(
-                Js.AnonFunDecl(List("elem"), List(
-                  safeAssign(Select(Ident("each").fix, "loc").fix,
-                    Ident("elem").fix),
-                  Js.Return(
+            Js.VarDef(List("rez" -> Js.AnonElem(Nil))),
+            Js.ForIn(Js.Ident("elem"), Select(Ident("value").fix, "loc").fix.toJs,
+              Js.Block(List(
+                Js.VarDef(List("each" -> Js.AnonObjDecl(Nil))),
+                $Reduce.copyAllFields(Ident("value").fix)(Ident("each").fix),
+                safeAssign(Select(Ident("each").fix, "loc").fix, Access(Select(Ident("value").fix, "loc").fix, Ident("elem").fix).fix),
+                Call(Select(Ident("rez").fix, "push").fix,
+                  List(
                     Arr(List(
                       Call(Ident("ObjectId").fix, Nil).fix,
-                      Ident("each").fix)).fix.toJs))))))))),
+                      Ident("each").fix)).fix)).fix.toJs))),
+            Js.Return(Js.Ident("rez"))))),
         $reduce($Reduce.reduceNOP))
       Workflow.finalize(given) must beTree(expected)
     }

--- a/it/src/test/resources/tests/projectFieldWithFlatten.test
+++ b/it/src/test/resources/tests/projectFieldWithFlatten.test
@@ -1,0 +1,8 @@
+{
+    "name": "project unrelated field with object flatten",
+    "data": "usa_factbook.data",
+    "query": "select intro from usa_factbook where geo{*}.text = '19,924 km'",
+    "predicate": "containsExactly",
+    "expected": [
+        { "intro": { "background": { "text": "Britain's American colonies broke with the mother country in 1776 and were recognized as the new nation of the United States of America following the Treaty of Paris in 1783. During the 19th and 20th centuries, 37 new states were added to the original 13 as the nation expanded across the North American continent and acquired a number of overseas possessions. The two most traumatic experiences in the nation's history were the Civil War (1861-65), in which a northern Union of states defeated a secessionist Confederacy of 11 southern slave states, and the Great Depression of the 1930s, an economic downturn during which about a quarter of the labor force lost its jobs. Buoyed by victories in World Wars I and II and the end of the Cold War in 1991, the US remains the world''s most powerful nation state. Since the end of World War II, the economy has achieved relatively steady growth, low unemployment and inflation, and rapid advances in technology." } } }]
+}


### PR DESCRIPTION
Fixes #488.

* Add [`$SimpleFlatMap`][†], which takes an expression (that hopefully
  evaluates to an array or object) and a function that is called on each
  entry in that array or object;
* add `coalesce`/`finalize` cases for `$Simple*Map` (`coalesce` combines
  adjacent `$Simple*Map`s, `finalize` merges `$Simple*Map`s into
  adjacent `$[Flat]Map`s);
* convert `$Unwind.flatmapop` to use [`$SimpleFlatMap`][‡]; and
* fix `toCollectionBuilder(FlatteningBuilder(Object))` to return the
  entire object, not just the flattened field and to pass the `base`
  through rather than always using `$$ROOT`.

[†]: I wanted to just replace `$FlatMap`, but since we still have
     non-simple `$Map`, `coalesce`/`finalize` can create non-simple
     `$FlatMap`s, even though we never create one directly.
[‡]: This change is potentially pessimizing, as it uses `for (i in arr) …`
     rather than `arr.map(function (i) { … })`, but this allows us to use
     the same code (IE, `$SimpleFlatMap`) for objects (which require the
     `for … in`) and arrays.