### PR TITLE
Swap left/right parts of join condition when necessary.

### DIFF
--- a/core/src/main/scala/slamdata/engine/compiler.scala
+++ b/core/src/main/scala/slamdata/engine/compiler.scala
@@ -295,7 +295,7 @@ trait Compiler[F[_]] {
           if (Tag.unwrap(left.foldMap(x => Tags.Disjunction(x == lt))) && Tag.unwrap(right.foldMap(x => Tags.Disjunction(x == rt))))
             emit((f, left, right))
           else if (Tag.unwrap(left.foldMap(x => Tags.Disjunction(x == rt))) && Tag.unwrap(right.foldMap(x => Tags.Disjunction(x == lt))))
-            reverse(f).fold[CompilerM[(Mapping, Term[LogicalPlan], Term[LogicalPlan])]](fail(UnsupportedJoinCondition(clause)))(x => emit((x, right, left)))
+            flip(f).fold[CompilerM[(Mapping, Term[LogicalPlan], Term[LogicalPlan])]](fail(UnsupportedJoinCondition(clause)))(x => emit((x, right, left)))
           else fail(UnsupportedJoinCondition(clause))
         case _ => fail(UnsupportedJoinCondition(clause))
       })

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -366,7 +366,7 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
 
           def relDateOp2(conj: (Selector, Selector) => Selector, f1: Bson.Date => Selector.Condition, f2: Bson.Date => Selector.Condition, date: Data.Date, g1: Data.Date => Data.Timestamp, g2: Data.Date => Data.Timestamp, index: Int): Output =
             \/-((
-              { case x :: Nil => 
+              { case x :: Nil =>
                 conj(
                   Selector.Doc(x -> f1(Bson.Date(g1(date).value))),
                   Selector.Doc(x -> f2(Bson.Date(g2(date).value))))
@@ -390,26 +390,26 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
           }
 
           def reversibleRelop(f: Mapping): Output =
-            (relMapping(f) |@| reverse(f).flatMap(relMapping))(relop).getOrElse(-\/(PlannerError.InternalError("couldn’t decipher operation")))
+            (relMapping(f) |@| flip(f).flatMap(relMapping))(relop).getOrElse(-\/(PlannerError.InternalError("couldn’t decipher operation")))
 
           (func, args) match {
-            case (`Gt`, _ :: IsDate(d2) :: Nil)  => relDateOp1(Selector.Gte.apply, d2, date.startOfNextDay, 0)
-            case (`Lt`, IsDate(d1) :: _ :: Nil)  => relDateOp1(Selector.Gte.apply, d1, date.startOfNextDay, 1)
+            case (`Gt`, _ :: IsDate(d2) :: Nil)  => relDateOp1(Selector.Gte, d2, date.startOfNextDay, 0)
+            case (`Lt`, IsDate(d1) :: _ :: Nil)  => relDateOp1(Selector.Gte, d1, date.startOfNextDay, 1)
 
-            case (`Lt`, _ :: IsDate(d2) :: Nil)  => relDateOp1(Selector.Lt.apply,  d2, date.startOfDay, 0)
-            case (`Gt`, IsDate(d1) :: _ :: Nil)  => relDateOp1(Selector.Lt.apply,  d1, date.startOfDay, 1)
+            case (`Lt`, _ :: IsDate(d2) :: Nil)  => relDateOp1(Selector.Lt,  d2, date.startOfDay, 0)
+            case (`Gt`, IsDate(d1) :: _ :: Nil)  => relDateOp1(Selector.Lt,  d1, date.startOfDay, 1)
 
-            case (`Gte`, _ :: IsDate(d2) :: Nil) => relDateOp1(Selector.Gte.apply, d2, date.startOfDay, 0)
-            case (`Lte`, IsDate(d1) :: _ :: Nil) => relDateOp1(Selector.Gte.apply, d1, date.startOfDay, 1)
+            case (`Gte`, _ :: IsDate(d2) :: Nil) => relDateOp1(Selector.Gte, d2, date.startOfDay, 0)
+            case (`Lte`, IsDate(d1) :: _ :: Nil) => relDateOp1(Selector.Gte, d1, date.startOfDay, 1)
 
-            case (`Lte`, _ :: IsDate(d2) :: Nil) => relDateOp1(Selector.Lt.apply,  d2, date.startOfNextDay, 0)
-            case (`Gte`, IsDate(d1) :: _ :: Nil) => relDateOp1(Selector.Lt.apply,  d1, date.startOfNextDay, 1)
+            case (`Lte`, _ :: IsDate(d2) :: Nil) => relDateOp1(Selector.Lt,  d2, date.startOfNextDay, 0)
+            case (`Gte`, IsDate(d1) :: _ :: Nil) => relDateOp1(Selector.Lt,  d1, date.startOfNextDay, 1)
 
-            case (`Eq`, _ :: IsDate(d2) :: Nil) => relDateOp2(Selector.And.apply, Selector.Gte.apply, Selector.Lt.apply, d2, date.startOfDay, date.startOfNextDay, 0)
-            case (`Eq`, IsDate(d1) :: _ :: Nil) => relDateOp2(Selector.And.apply, Selector.Gte.apply, Selector.Lt.apply, d1, date.startOfDay, date.startOfNextDay, 1)
+            case (`Eq`, _ :: IsDate(d2) :: Nil) => relDateOp2(Selector.And, Selector.Gte, Selector.Lt, d2, date.startOfDay, date.startOfNextDay, 0)
+            case (`Eq`, IsDate(d1) :: _ :: Nil) => relDateOp2(Selector.And, Selector.Gte, Selector.Lt, d1, date.startOfDay, date.startOfNextDay, 1)
 
-            case (`Neq`, _ :: IsDate(d2) :: Nil) => relDateOp2(Selector.Or.apply, Selector.Lt.apply, Selector.Gte.apply, d2, date.startOfDay, date.startOfNextDay, 0)
-            case (`Neq`, IsDate(d1) :: _ :: Nil) => relDateOp2(Selector.Or.apply, Selector.Lt.apply, Selector.Gte.apply, d1, date.startOfDay, date.startOfNextDay, 1)
+            case (`Neq`, _ :: IsDate(d2) :: Nil) => relDateOp2(Selector.Or, Selector.Lt, Selector.Gte, d2, date.startOfDay, date.startOfNextDay, 0)
+            case (`Neq`, IsDate(d1) :: _ :: Nil) => relDateOp2(Selector.Or, Selector.Lt, Selector.Gte, d1, date.startOfDay, date.startOfNextDay, 1)
 
             case (`Eq`, _)  => reversibleRelop(Eq)
             case (`Neq`, _) => reversibleRelop(Neq)

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -327,6 +327,16 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
         }
       }
 
+      def relMapping(f: Func): Option[Bson => Selector.Condition] = f match {
+        case Eq  => Some(Selector.Eq)
+        case Neq => Some(Selector.Neq)
+        case Lt  => Some(Selector.Lt)
+        case Lte => Some(Selector.Lte)
+        case Gt  => Some(Selector.Gt)
+        case Gte => Some(Selector.Gte)
+        case _   => None
+      }
+
       Phase { (attr: Attr[LogicalPlan, A]) =>
       scanPara2(attr) { (fieldAttr: A, node: LogicalPlan[(Term[LogicalPlan], A, Output)]) =>
         def invoke(func: Func, args: List[(Term[LogicalPlan], A, Output)]): Output = {
@@ -379,6 +389,9 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
             }
           }
 
+          def reversibleRelop(f: Mapping): Output =
+            (relMapping(f) |@| reverse(f).flatMap(relMapping))(relop).getOrElse(-\/(PlannerError.InternalError("couldn’t decipher operation")))
+
           (func, args) match {
             case (`Gt`, _ :: IsDate(d2) :: Nil)  => relDateOp1(Selector.Gte.apply, d2, date.startOfNextDay, 0)
             case (`Lt`, IsDate(d1) :: _ :: Nil)  => relDateOp1(Selector.Gte.apply, d1, date.startOfNextDay, 1)
@@ -397,13 +410,13 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
 
             case (`Neq`, _ :: IsDate(d2) :: Nil) => relDateOp2(Selector.Or.apply, Selector.Lt.apply, Selector.Gte.apply, d2, date.startOfDay, date.startOfNextDay, 0)
             case (`Neq`, IsDate(d1) :: _ :: Nil) => relDateOp2(Selector.Or.apply, Selector.Lt.apply, Selector.Gte.apply, d1, date.startOfDay, date.startOfNextDay, 1)
-            
-            case (`Eq`, _)       => relop(Selector.Eq.apply _,  Selector.Eq.apply _)
-            case (`Neq`, _)      => relop(Selector.Neq.apply _, Selector.Neq.apply _)
-            case (`Lt`, _)       => relop(Selector.Lt.apply _,  Selector.Gt.apply _)
-            case (`Lte`, _)      => relop(Selector.Lte.apply _, Selector.Gte.apply _)
-            case (`Gt`, _)       => relop(Selector.Gt.apply _,  Selector.Lt.apply _)
-            case (`Gte`, _)      => relop(Selector.Gte.apply _, Selector.Lte.apply _)
+
+            case (`Eq`, _)  => reversibleRelop(Eq)
+            case (`Neq`, _) => reversibleRelop(Neq)
+            case (`Lt`, _)  => reversibleRelop(Lt)
+            case (`Lte`, _) => reversibleRelop(Lte)
+            case (`Gt`, _)  => reversibleRelop(Gt)
+            case (`Gte`, _) => reversibleRelop(Gte)
 
             case (`IsNull`, _ :: Nil) => \/-((
                 { case f :: Nil => Selector.Doc(f -> Selector.Eq(Bson.Null)) },
@@ -513,8 +526,8 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
 
       val HasLiteral: Ann => M[Bson] = ann => HasWorkflow(ann).flatMap { p =>
         asLiteral(p) match {
-          case Some(ExprOp.Literal(value)) => emit(value)
-          case _ => fail(FuncApply(func, "literal", p.toString))
+          case Some(value) => emit(value)
+          case _           => fail(FuncApply(func, "literal", p.toString))
         }
       }
 
@@ -779,17 +792,13 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
             WorkflowBuilder.pure)),
 
         join      = (left, right, tpe, comp, leftKey, rightKey) => {
-          def js(attr: Attr[LogicalPlan, (Input, Error \/ WorkflowBuilder)]): OutputM[JsMacro] = attr.unFix.attr._1._2
-          def workflow(attr: Attr[LogicalPlan, (Input, Error \/ WorkflowBuilder)]): Error \/ WorkflowBuilder = attr.unFix.attr._2
-        
-          val rez2 = for {
-            l   <- lift(workflow(left))
-            r   <- lift(workflow(right))
-            lk  <- lift(workflow(leftKey).flatMap(x => asExprOp(x) \/> InternalError("Can’t represent " + x + "as Expr.")))
-            rk  <- lift(js(rightKey))
-            rez <- join(l, r, tpe, comp, lk, rk)
-          } yield rez
-          State(s => rez2.run(s).fold(e => s -> -\/(e), t => t._1 -> \/-(t._2)))
+          val rez =
+            (HasWorkflow(left) |@|
+              HasWorkflow(right) |@|
+              HasWorkflow(leftKey) |@|
+              HasJs(rightKey))(
+            join(_, _, tpe, comp, _, _)).join
+          State(s => rez.run(s).fold(e => s -> -\/(e), t => t._1 -> \/-(t._2)))
         },
 
         invoke    = (func, args) => {

--- a/core/src/main/scala/slamdata/engine/std/relations.scala
+++ b/core/src/main/scala/slamdata/engine/std/relations.scala
@@ -166,5 +166,27 @@ trait RelationsLib extends Library {
   )
 
   def functions = Eq :: Neq :: Lt :: Lte :: Gt :: Gte :: Between :: IsNull :: And :: Or :: Not :: Cond :: Coalesce :: Nil
+
+  def reverse(f: Mapping): Option[Mapping] = f match {
+    case Eq  => Some(Eq)
+    case Neq => Some(Neq)
+    case Lt  => Some(Gt)
+    case Lte => Some(Gte)
+    case Gt  => Some(Lt)
+    case Gte => Some(Lte)
+    case And => Some(And)
+    case Or  => Some(Or)
+    case _   => None
+  }
+
+  def inverse(f: Mapping): Option[Mapping] = f match {
+    case Eq  => Some(Neq)
+    case Neq => Some(Eq)
+    case Lt  => Some(Gte)
+    case Lte => Some(Gt)
+    case Gt  => Some(Lte)
+    case Gte => Some(Lt)
+    case _   => None
+  }
 }
 object RelationsLib extends RelationsLib

--- a/core/src/main/scala/slamdata/engine/std/relations.scala
+++ b/core/src/main/scala/slamdata/engine/std/relations.scala
@@ -1,6 +1,7 @@
 package slamdata.engine.std
 
 import slamdata.engine.{Data, Func, Type, Mapping, SemanticError}
+
 import slamdata.engine.fp._
 
 import scalaz._
@@ -167,7 +168,7 @@ trait RelationsLib extends Library {
 
   def functions = Eq :: Neq :: Lt :: Lte :: Gt :: Gte :: Between :: IsNull :: And :: Or :: Not :: Cond :: Coalesce :: Nil
 
-  def reverse(f: Mapping): Option[Mapping] = f match {
+  def flip(f: Mapping): Option[Mapping] = f match {
     case Eq  => Some(Eq)
     case Neq => Some(Neq)
     case Lt  => Some(Gt)
@@ -179,7 +180,7 @@ trait RelationsLib extends Library {
     case _   => None
   }
 
-  def inverse(f: Mapping): Option[Mapping] = f match {
+  def negate(f: Mapping): Option[Mapping] = f match {
     case Eq  => Some(Neq)
     case Neq => Some(Eq)
     case Lt  => Some(Gte)

--- a/core/src/test/scala/slamdata/engine/compiler.scala
+++ b/core/src/test/scala/slamdata/engine/compiler.scala
@@ -985,12 +985,12 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
             Let('right2, read("baz"),
               Join(Free('left1), Free('right2),
                 JoinType.Inner, relations.Eq,
-                ObjectProject(Free('right2),
-                  Constant(Data.Str("bar_id"))),
                 ObjectProject(
                   ObjectProject(Free('left1),
                     Constant(Data.Str("right"))),
-                  Constant(Data.Str("id")))))),
+                  Constant(Data.Str("id"))),
+                ObjectProject(Free('right2),
+                  Constant(Data.Str("bar_id")))))),
           Let('tmp5,
             makeObj(
               "name" ->

--- a/it/src/test/resources/tests/joinWithReversedCondition.test
+++ b/it/src/test/resources/tests/joinWithReversedCondition.test
@@ -1,0 +1,27 @@
+{
+    "name": "join with reversed condition and complex condition expression",
+    "data": "slamengine_commits.data",
+    "query": "select l.sha as child, l.author.login as c_auth, r.sha as parent, r.author.login as p_auth from slamengine_commits l join slamengine_commits r on r.sha = l.parents[0].sha",
+    "predicate": "containsAtLeast",
+    "expected": [
+        { "child": "b29d8f254e5df2c4d1792f077625924cd1fde2db", "c_auth": "mossprescott",
+          "parent": "166f7337c8fd5db13941abf482de05accb8e9380", "p_auth": "mossprescott" },
+        { "child": "166f7337c8fd5db13941abf482de05accb8e9380", "c_auth": "mossprescott",
+          "parent": "0999da94bddcbc5bf536e3874aaba50582e96959", "p_auth": "mossprescott" },
+        { "child": "85c3368890be18a77c1bbfd645228de9f43acd43", "c_auth": "jdegoes",
+          "parent": "292c4259f72adffe922a99f97f7b15e5330bc77a", "p_auth": "jdegoes" },
+        { "child": "f362cb55d8a4ea8fa23bde416530344438a10144", "c_auth": "mossprescott",
+          "parent": "3bacb29203d499edc69f7ff2b1f5ea681411eb75", "p_auth": "mossprescott" },
+        { "child": "b8a2302e6a0659875d03bfe4988c000f2ed027a0", "c_auth": "sellout",
+          "parent": "3d44ce48fc0670aaf39ba1acd0e1c161f14cc2d6", "p_auth": "sellout" },
+        { "child": "ad8a6a73f898860b48f3d71ed6110b3506a8c898", "c_auth": "mossprescott",
+          "parent": "3de46760d45c4fd0db9a03ad978361df3e8f0998", "p_auth": "mossprescott" },
+        { "child": "3de46760d45c4fd0db9a03ad978361df3e8f0998", "c_auth": "mossprescott",
+          "parent": "43b4018ae5d1e40bbbc2babb8929ed247b5d2dcb", "p_auth": "mossprescott" },
+        { "child": "0999da94bddcbc5bf536e3874aaba50582e96959", "c_auth": "mossprescott",
+          "parent": "472dd80e8bdffae0c1bded28a91139941433550d", "p_auth": "jdegoes" },
+        { "child": "56d1caf5d082d1a6840090986e277d36d03f1859", "c_auth": "jdegoes",
+          "parent": "472dd80e8bdffae0c1bded28a91139941433550d", "p_auth": "jdegoes" },
+        { "child": "3d44ce48fc0670aaf39ba1acd0e1c161f14cc2d6", "c_auth": "sellout",
+          "parent": "53d2e5684d9403194dff1cc63423c2590038d1c0", "p_auth": "mossprescott" }]
+}


### PR DESCRIPTION
Fixes #585.

We now notice if the join condition looks like `right.field = left.field`
and then swap the sides for MongoDB. This also fixes an issue where
certain join conditions got mangled. EG, `left.parents[0].sha = right.sha`
would be treated as `left.sha = right.sha`. We now handle that correctly.

Also, eliminate the evil `asExprOp`.