### PR TITLE
Postpone merging src and keys in GroupBuilder.

### DIFF
--- a/core/src/main/scala/slamdata/engine/physical/mongodb/exprop.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/exprop.scala
@@ -148,6 +148,10 @@ object ExprOp {
       case Multiply(l, r)        => binop(JsCore.Mult, l, r)
       case Neq(l, r)             => binop(JsCore.Neq, l, r)
       case Not(a)                => unop(JsCore.Not, a)
+      case Substr(f, start, len) =>
+        (toJs(f) |@| toJs(start) |@| toJs(len))((f, s, l) =>
+          JsMacro(x =>
+            JsCore.Call(JsCore.Select(f(x), "substr").fix, List(s(x), l(x))).fix))
       case Subtract(l, r)        => binop(JsCore.Sub, l, r)
       case ToLower(a)            => invoke(a, "toLowerCase")
       case ToUpper(a)            => invoke(a, "toUpperCase")

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -171,6 +171,11 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
                 Literal(Js.Num(-1, false)).fix,
                 Call(Select(array(arg), "indexOf").fix, List(value(arg))).fix).fix)
           }
+        case `Substring` =>
+          Arity3(HasJs, HasJs, HasJs).map { case (field, start, len) =>
+            JsMacro(x =>
+              Call(Select(field(x), "substr").fix, List(start(x), len(x))).fix)
+          }
         case `Search` =>
           Arity2(HasJs, HasJs).map { case (field, pattern) =>
             JsMacro(x => Call(Select(New("RegExp", List(pattern(x))).fix, "test").fix, List(field(x))).fix)
@@ -593,7 +598,7 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
         case `Cross` =>
           Arity2(HasWorkflow, HasWorkflow).flatMap((cross(_, _)).tupled)
         case `GroupBy` =>
-          Arity2(HasWorkflow, HasKeys).flatMap((groupBy(_, _)).tupled)
+          Arity2(HasWorkflow, HasKeys).map((groupBy(_, _)).tupled)
         case `OrderBy` =>
           Arity3(HasWorkflow, HasKeys, HasSortDirs).map {
             case (p1, p2, dirs) => sortBy(p1, p2, dirs)

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -112,18 +112,15 @@ object WorkflowBuilder {
   type GroupContents = Contents[GroupValue]
 
   case class GroupBuilderF[A](
-    src: A,
-    key: ExprOp \/ Reshape,
-    contents: GroupContents,
-    id: GroupId)
+    src: A, keys: List[A], contents: GroupContents, id: GroupId)
       extends WorkflowBuilderF[A]
   object GroupBuilder {
     def apply(
       src: WorkflowBuilder,
-      key: ExprOp \/ Reshape,
+      keys: List[WorkflowBuilder],
       contents: GroupContents,
       id: GroupId) =
-      Term[WorkflowBuilderF](new GroupBuilderF(src, key, contents, id))
+      Term[WorkflowBuilderF](new GroupBuilderF(src, keys, contents, id))
   }
 
   sealed trait StructureType
@@ -227,7 +224,21 @@ object WorkflowBuilder {
             }).sequence.fold(
               foldBuilders(src, inputs).flatMap { case (wb, base, fields) =>
                 fields.map(_.deref).sequence.fold(
-                  fail[CollectionBuilderF](WorkflowBuilderError.InvalidOperation("filter", "can’t filter without field")))(
+                  emitSt(freshName).flatMap(name =>
+                    fields.map(f => (DocField(name) \\ f).deref).sequence.fold(
+                      sys.error("prefixed ${name}, but still no field"))(
+                      op.lift(_).fold(
+                        fail[CollectionBuilderF](WorkflowBuilderError.InvalidOperation("filter", "failed to build operation")))(
+                        op =>
+                        (toCollectionBuilder(src) |@| toCollectionBuilder(DocBuilder(wb, ListMap(name -> -\/(DocVar.ROOT()))))) {
+                          case (
+                            CollectionBuilderF(_,     _,    srcStruct),
+                            CollectionBuilderF(graph, base0, bothStruct)) =>
+                            CollectionBuilderF(
+                              chain(graph, op),
+                              DocField(name),
+                              srcStruct)
+                        }))))(
                   op.lift(_).fold(
                     fail[CollectionBuilderF](WorkflowBuilderError.InvalidOperation("filter", "failed to build operation")))(
                     op =>
@@ -303,74 +314,91 @@ object WorkflowBuilder {
                 case (k, _) => k.asText -> SchemaChange.Init
               }))))
         }
-      case GroupBuilderF(src, _, Expr(-\/(expr)), _) =>
-        // NB: This case just winds up a single value, then unwinds it. It’s
-        //     effectively a no-op, so we just use the src and expr
-        toCollectionBuilder(ExprBuilder(src, -\/(expr)))
-      case GroupBuilderF(src, key, Expr(\/-(grouped)), _) =>
-        for {
-          cb <- toCollectionBuilder(src)
-          rootName <- emitSt(freshName)
-        } yield cb match {
-          case CollectionBuilderF(wf, base, struct) =>
-            CollectionBuilderF(
-              chain(wf,
-                $group(Grouped(ListMap(rootName -> grouped)).rewriteRefs(prefixBase(base)),
-                  key.bimap(_.rewriteRefs(prefixBase(base)), _.rewriteRefs(prefixBase(base))))),
-              DocField(rootName),
-              struct)
-        }
-      case GroupBuilderF(src, key, Doc(obj), _) =>
-        val (ungrouped, grouped) =
-          obj.foldLeft[(ListMap[BsonField.Name, ExprOp], ListMap[BsonField.Leaf, GroupOp])]((ListMap.empty[BsonField.Name, ExprOp], ListMap.empty[BsonField.Leaf, GroupOp]))((acc, item) =>
-            item match {
-              case (k, -\/(v)) =>
-                ((x: ListMap[BsonField.Name, ExprOp]) => x + (k -> v)).first(acc)
-              case (k, \/-(v)) =>
-                ((x: ListMap[BsonField.Leaf, GroupOp]) => x + (k -> v)).second(acc)
-            })
+      case GroupBuilderF(src, keys, content, _) =>
+        foldBuilders(src, keys).flatMap { case (wb, base, fields) =>
+          def key(base: DocVar) = keys match {
+                case Nil        => -\/(Literal(Bson.Null))
+                case key :: Nil => -\/(key.unFix match {
+                  // NB: normalize to Null, to ease merging
+                  case ValueBuilderF(_)                 => Literal(Bson.Null)
+                  case ExprBuilderF(_, -\/(Literal(_))) => Literal(Bson.Null)
+                  case _                                => fields.head.rewriteRefs(prefixBase(base))
+                })
+                case _          => \/-(Reshape.Arr(fields.zipWithIndex.map {
+                  case (field, index) =>
+                    BsonField.Index(index) -> -\/(field)
+                }.toListMap).rewriteRefs(prefixBase(base)))
+          }
 
-        workflow(src).flatMap {
-          case (wf, base) =>
-            emitSt(ungrouped.size match {
-              case 0 =>
-                state[NameGen, Workflow](chain(wf,
-                  $group(Grouped(grouped).rewriteRefs(prefixBase(base)),
-                    key.bimap(_.rewriteRefs(prefixBase(base)), _.rewriteRefs(prefixBase(base))))))
-              case 1 =>
-                state[NameGen, Workflow](chain(wf,
-                  $group(Grouped(
-                    obj.transform {
-                      case (_, -\/ (v)) => Push(v.rewriteRefs(prefixBase(base)))
-                      case (_,  \/-(v)) => v.rewriteRefs(prefixBase(base))
-                    }),
-                    key.bimap(_.rewriteRefs(prefixBase(base)), _.rewriteRefs(prefixBase(base)))),
-                  $unwind(DocField(ungrouped.head._1))))
-              case _ => for {
-                ungroupedName <- freshName
-                groupedName <- freshName
-              } yield
-                chain(wf,
-                  $project(Reshape.Doc(ListMap(
-                    ungroupedName -> \/-(Reshape.Doc(ungrouped.map {
-                      case (k, v) => k -> -\/(v.rewriteRefs(prefixBase(base)))
-                    })),
-                    groupedName -> -\/(DocVar.ROOT())))),
-                  $group(Grouped(
-                    (grouped ∘ (_.rewriteRefs(prefixBase(DocField(groupedName))))) +
-                      (ungroupedName -> Push(DocField(ungroupedName)))),
-                    key.bimap(_.rewriteRefs(prefixBase(DocField(groupedName))), _.rewriteRefs(prefixBase(DocField(groupedName))))),
-                  $unwind(DocField(ungroupedName)),
-                  $project(Reshape.Doc(obj.transform {
-                    case (k, -\/(_)) => -\/(DocField(ungroupedName \ k))
-                    case (k, \/-(_)) => -\/(DocField(k))
+          content match {
+            case Expr(-\/(expr)) =>
+              // NB: This case just winds up a single value, then unwinds it.
+              //     It’s effectively a no-op, so we just use the src and expr.
+              toCollectionBuilder(ExprBuilder(src, -\/(expr)))
+            case Expr(\/-(grouped)) =>
+              for {
+                cb <- toCollectionBuilder(wb)
+                rootName <- emitSt(freshName)
+              } yield cb match {
+                case CollectionBuilderF(wf, base0, struct) =>
+                  CollectionBuilderF(
+                    chain(wf,
+                      $group(Grouped(ListMap(rootName -> grouped)).rewriteRefs(prefixBase(base0 \\ base)),
+                        key(base0))),
+                    DocField(rootName),
+                    struct)
+              }
+            case Doc(obj) =>
+              val (ungrouped, grouped) =
+                obj.foldLeft[(ListMap[BsonField.Name, ExprOp], ListMap[BsonField.Leaf, GroupOp])]((ListMap.empty[BsonField.Name, ExprOp], ListMap.empty[BsonField.Leaf, GroupOp]))((acc, item) =>
+                  item match {
+                    case (k, -\/(v)) =>
+                      ((x: ListMap[BsonField.Name, ExprOp]) => x + (k -> v)).first(acc)
+                    case (k, \/-(v)) =>
+                      ((x: ListMap[BsonField.Leaf, GroupOp]) => x + (k -> v)).second(acc)
+                  })
+
+              workflow(wb).flatMap { case (wf, base0) =>
+                emitSt(ungrouped.size match {
+                  case 0 =>
+                    state[NameGen, Workflow](chain(wf,
+                      $group(Grouped(grouped).rewriteRefs(prefixBase(base0 \\ base)), key(base0))))
+                  case 1 =>
+                    state[NameGen, Workflow](chain(wf,
+                      $group(Grouped(
+                        obj.transform {
+                          case (_, -\/ (v)) => Push(v.rewriteRefs(prefixBase(base0 \\ base)))
+                          case (_,  \/-(v)) => v.rewriteRefs(prefixBase(base0 \\ base))
+                        }),
+                        key(base0)),
+                      $unwind(DocField(ungrouped.head._1))))
+                  case _ => for {
+                    ungroupedName <- freshName
+                    groupedName <- freshName
+                  } yield
+                    chain(wf,
+                      $project(Reshape.Doc(ListMap(
+                        ungroupedName -> \/-(Reshape.Doc(ungrouped.map {
+                          case (k, v) => k -> -\/(v.rewriteRefs(prefixBase(base0 \\ base)))
+                        })),
+                        groupedName -> -\/(DocVar.ROOT())))),
+                      $group(Grouped(
+                        (grouped ∘ (_.rewriteRefs(prefixBase(DocField(groupedName))))) +
+                          (ungroupedName -> Push(DocField(ungroupedName)))),
+                        key(DocField(groupedName))),
+                      $unwind(DocField(ungroupedName)),
+                      $project(Reshape.Doc(obj.transform {
+                        case (k, -\/(_)) => -\/(DocField(ungroupedName \ k))
+                        case (k, \/-(_)) => -\/(DocField(k))
+                      })))
+                }).map(CollectionBuilderF(
+                  _,
+                  DocVar.ROOT(),
+                  SchemaChange.MakeObject(obj.map {
+                    case (k, _) => (k.asText -> SchemaChange.Init)
                   })))
-            }).map(CollectionBuilderF(
-              _,
-              DocVar.ROOT(),
-              SchemaChange.MakeObject(obj.map {
-                case (k, _) => (k.asText -> SchemaChange.Init)
-              })))
+              }
+          }
         }
       case FlatteningBuilderF(src, Array, field) =>
         toCollectionBuilder(src).map {
@@ -455,6 +483,8 @@ object WorkflowBuilder {
     wb.unFix match {
       case ShapePreservingBuilderF(src, inputs, op) =>
         expr1(src)(f).map(ShapePreservingBuilder(_, inputs, op))
+      case GroupBuilderF(wb0, key, Expr(-\/(DocVar.ROOT(None))), id) =>
+        expr1(wb0)(f).map(GroupBuilder(_, key, Expr(-\/(DocVar.ROOT())), id))
       case GroupBuilderF(wb0, key, Expr(-\/(expr)), id) =>
         \/-(GroupBuilder(wb0, key, Expr(-\/(f(expr))), id))
       case ExprBuilderF(wb0, -\/ (expr1)) =>
@@ -608,15 +638,14 @@ object WorkflowBuilder {
   def objectConcat(wb1: WorkflowBuilder, wb2: WorkflowBuilder):
       M[WorkflowBuilder] = {
     def delegate = objectConcat(wb2, wb1)
-    def mergeGroups(s1: WorkflowBuilder, s2: WorkflowBuilder, c1: GroupContents, c2: GroupContents, k1: ExprOp \/ Reshape, id1: GroupId):
+    def mergeGroups(s1: WorkflowBuilder, s2: WorkflowBuilder, c1: GroupContents, c2: GroupContents, keys: List[WorkflowBuilder], id1: GroupId):
         M[((DocVar, DocVar), WorkflowBuilder)] =
       merge(s1, s2).flatMap { case (lbase, rbase, src) =>
-        val key = k1.bimap(_.rewriteRefs(prefixBase(lbase)), _.rewriteRefs(prefixBase(lbase)))
         mergeContents(
           rewriteGroupRefs(c1)(prefixBase(lbase)),
           rewriteGroupRefs(c2)(prefixBase(rbase))).map {
           case ((lb, rb), contents) =>
-            (lb, rb) -> GroupBuilder(src, key, contents, id1)
+            (lb, rb) -> GroupBuilder(src, keys, contents, id1)
         }
       }
 
@@ -709,16 +738,16 @@ object WorkflowBuilder {
       case (GroupBuilderF(_, _, Doc(_), _), ValueBuilderF(_)) => delegate
 
       case (
-        GroupBuilderF(s1, k1, c1 @ Doc(_), id1),
-        GroupBuilderF(s2, k2, c2 @ Doc(_), id2))
+        GroupBuilderF(s1, keys, c1 @ Doc(_), id1),
+        GroupBuilderF(s2, _,    c2 @ Doc(_), id2))
           if id1 == id2 =>
-        mergeGroups(s1, s2, c1, c2, k1, id1).map(_._2)
+        mergeGroups(s1, s2, c1, c2, keys, id1).map(_._2)
 
       case (
-        GroupBuilderF(s1, k1, c1 @ Doc(d1), id1),
-        DocBuilderF(Term(GroupBuilderF(s2, k2, c2, id2)), shape2))
+        GroupBuilderF(s1, keys, c1 @ Doc(d1), id1),
+        DocBuilderF(Term(GroupBuilderF(s2, _, c2, id2)), shape2))
           if id1 == id2 =>
-        mergeGroups(s1, s2, c1, c2, k1, id1).map { case ((glbase, grbase), g) =>
+        mergeGroups(s1, s2, c1, c2, keys, id1).map { case ((glbase, grbase), g) =>
           val shape = d1.transform { case (n, _) => -\/(DocField(n)) } ++
           (shape2 ∘ (rewriteExprPrefix(_, grbase)))
           DocBuilder(g, shape)
@@ -730,11 +759,11 @@ object WorkflowBuilder {
         delegate
 
       case (
-        DocBuilderF(Term(GroupBuilderF(s1, k1, c1, id1)), shape1),
-        DocBuilderF(Term(GroupBuilderF(s2, k2, c2, id2)), shape2))
+        DocBuilderF(Term(GroupBuilderF(s1, keys, c1, id1)), shape1),
+        DocBuilderF(Term(GroupBuilderF(s2, _,    c2, id2)), shape2))
           if id1 == id2 =>
         unlessConflicts(shape1.keySet, shape2.keySet,
-          mergeGroups(s1, s2, c1, c2, k1, id1).flatMap {
+          mergeGroups(s1, s2, c1, c2, keys, id1).flatMap {
             case ((glbase, grbase), g) =>
               val shape = (shape1 ∘ (rewriteExprPrefix(_, glbase))) ++ (shape2 ∘ (rewriteExprPrefix(_, grbase)))
               emit(DocBuilder(g, shape))
@@ -742,23 +771,23 @@ object WorkflowBuilder {
 
       case (
         DocBuilderF(s1, shape),
-        GroupBuilderF(_, -\/(Literal(Bson.Null)), _, id2)) =>
+        GroupBuilderF(_, Nil, _, id2)) =>
         objectConcat(
-          DocBuilder(GroupBuilder(s1, -\/(Literal(Bson.Null)), Expr(-\/(DocVar.ROOT())), id2), shape),
+          DocBuilder(GroupBuilder(s1, Nil, Expr(-\/(DocVar.ROOT())), id2), shape),
           wb2)
       case (
-        GroupBuilderF(_, -\/(Literal(Bson.Null)), _, _),
+        GroupBuilderF(_, Nil, _, _),
         DocBuilderF(_, _)) =>
         delegate
 
       case (
         DocBuilderF(s1, shape),
-        DocBuilderF(Term(GroupBuilderF(_, -\/(Literal(Bson.Null)), _, id2)), _)) =>
+        DocBuilderF(Term(GroupBuilderF(_, Nil, _, id2)), _)) =>
         objectConcat(
-          DocBuilder(GroupBuilder(s1, -\/(Literal(Bson.Null)), Expr(-\/(DocVar.ROOT())), id2), shape),
+          DocBuilder(GroupBuilder(s1, Nil, Expr(-\/(DocVar.ROOT())), id2), shape),
           wb2)
       case (
-        DocBuilderF(Term(GroupBuilderF(_, -\/(Literal(Bson.Null)), _, _)), _),
+        DocBuilderF(Term(GroupBuilderF(_, Nil, _, _)), _),
         DocBuilderF(_, _)) =>
         delegate
         
@@ -770,27 +799,27 @@ object WorkflowBuilder {
 
       // NB: JS-exprs cannot be rolled into $group ops, leading to this somewhat exceptional case
       case (
-        GroupBuilderF(s1, k1, c1 @ Doc(d1), id1),
+        GroupBuilderF(s1, keys, c1 @ Doc(d1), id1),
         GroupBuilderF(Term(
-          ExprBuilderF(Term(GroupBuilderF(s2, k2, c2, id2)), \/-(expr2))),
-          -\/(Literal(Bson.Null)),
+          ExprBuilderF(Term(GroupBuilderF(s2, _, c2, id2)), \/-(expr2))),
+          Nil,
           Doc(c2a), id2a))
           if id1 == id2 =>
-        mergeGroups(s1, s2, c1, c2, k1, id1).flatMap { case ((glbase, grbase), g) =>
+        mergeGroups(s1, s2, c1, c2, keys, id1).flatMap { case ((glbase, grbase), g) =>
           emitSt(for {
             rName <- freshName
           } yield {
             val doc = DocBuilder(g,
               d1.transform { case (n, _) => -\/(DocField(n)) } +
                 (rName -> \/-(grbase.toJs >>> expr2)))
-            GroupBuilder(doc, -\/(Literal(Bson.Null)),
+            GroupBuilder(doc, Nil,
               Doc(d1.transform { case (n, _) => -\/(DocField(n)) } ++
                 rewriteObjRefs(c2a)(prefixBase(DocField(rName)))),
               id2a)
           })
         }
       case (
-        GroupBuilderF(Term(ExprBuilderF(Term(GroupBuilderF(_, _, _, id1)), \/-(_))), -\/(Literal(Bson.Null)), Doc(_), _),
+        GroupBuilderF(Term(ExprBuilderF(Term(GroupBuilderF(_, _, _, id1)), \/-(_))), Nil, Doc(_), _),
         GroupBuilderF(_, _, Doc(_), id2))
           if id1 == id2 =>
         delegate
@@ -880,12 +909,16 @@ object WorkflowBuilder {
   def flattenObject(wb: WorkflowBuilder): WorkflowBuilder = wb.unFix match {
     case ShapePreservingBuilderF(src, inputs, op) =>
       ShapePreservingBuilder(flattenObject(src), inputs, op)
+    case GroupBuilderF(src, keys, contents, id) =>
+      GroupBuilder(flattenObject(src), keys, contents, id)
     case _ => FlatteningBuilder(wb, Object, DocVar.ROOT())
   }
 
   def flattenArray(wb: WorkflowBuilder): WorkflowBuilder = wb.unFix match {
     case ShapePreservingBuilderF(src, inputs, op) =>
       ShapePreservingBuilder(flattenArray(src), inputs, op)
+    case GroupBuilderF(src, keys, Expr(-\/(DocVar.ROOT(None))), id) =>
+      GroupBuilder(flattenArray(src), keys, Expr(-\/(DocVar.ROOT())), id)
     case _ => FlatteningBuilder(wb, Array, DocVar.ROOT())
   }
 
@@ -908,6 +941,8 @@ object WorkflowBuilder {
         -\/(WorkflowBuilderError.InvalidOperation(
           "projectField",
           "value is not a document."))
+      case GroupBuilderF(wb0, key, Expr(-\/(DocVar.ROOT(None))), id) =>
+        projectField(wb0, name).map(GroupBuilder(_, key, Expr(-\/(DocVar.ROOT())), id))
       case GroupBuilderF(wb0, key, Expr(-\/(dv @ DocVar(_, _))), id) =>
         // TODO: check structure of wb0 (#436)
         \/-(GroupBuilder(wb0, key, Expr(-\/(dv \ BsonField.Name(name))), id))
@@ -959,31 +994,13 @@ object WorkflowBuilder {
     }
 
   def groupBy(src: WorkflowBuilder, keys: List[WorkflowBuilder]):
-      M[WorkflowBuilder] =
-    foldBuilders(src, keys).map { case (wb, base, fields) =>
-      GroupBuilder(
-        wb,
-        keys match {
-          case Nil        => -\/(Literal(Bson.Null))
-          case key :: Nil => -\/(key.unFix match {
-            // NB: normalize to Null, to ease merging
-            case ValueBuilderF(_)                 => Literal(Bson.Null)
-            case ExprBuilderF(_, -\/(Literal(_))) => Literal(Bson.Null)
-            case _                                => fields.head
-          })
-          case _          => \/-(Reshape.Arr(fields.zipWithIndex.map {
-            case (field, index) =>
-              BsonField.Index(index) -> -\/(field)
-          }.toListMap))
-        },
-        Expr(-\/(base)),
-        GroupId(wb :: keys))
-    }
+      WorkflowBuilder =
+    GroupBuilder(src, keys, Expr(-\/(DocVar.ROOT())), GroupId(src :: keys))
 
   def reduce(wb: WorkflowBuilder)(f: ExprOp => GroupOp): WorkflowBuilder =
     wb.unFix match {
-      case GroupBuilderF(wb0, key, Expr(-\/(expr)), id) =>
-        GroupBuilder(wb0, key, Expr(\/-(f(expr))), id)
+      case GroupBuilderF(wb0, keys, Expr(-\/(expr)), id) =>
+        GroupBuilder(wb0, keys, Expr(\/-(f(expr))), id)
       case ShapePreservingBuilderF(src @ Term(GroupBuilderF(_, _, Expr(-\/(_)), _)), inputs, op) =>
         ShapePreservingBuilder(reduce(src)(f), inputs, op)
       case _ =>
@@ -995,7 +1012,7 @@ object WorkflowBuilder {
           case DocBuilderF(wb0, _) => GroupId(List(wb0))
           case _ => GroupId(List(wb))
         }
-        GroupBuilder(wb, -\/(Literal(Bson.Null)), Expr(\/-(f(DocVar.ROOT()))), id)
+        GroupBuilder(wb, Nil, Expr(\/-(f(DocVar.ROOT()))), id)
     }
 
   def sortBy(
@@ -1388,10 +1405,12 @@ object WorkflowBuilder {
       case (_, ShapePreservingBuilderF(src, inputs, op)) => delegate
 
       case (GroupBuilderF(src1, key1, cont1, id1), GroupBuilderF(src2, key2, cont2, id2))
-          if src1 == src2 && id1 == id2 =>
-        mergeContents(cont1, cont2).map {
-          case ((lb, rb), contents) =>
-            (lb, rb, GroupBuilder(src1, key1, contents, id1))
+          if id1 == id2 =>
+        merge(src1, src2).flatMap { case (lbase, rbase, wb) =>
+          mergeContents(rewriteGroupRefs(cont1)(prefixBase(lbase)), rewriteGroupRefs(cont2)(prefixBase(rbase))).map {
+            case ((lb, rb), contents) =>
+              (lb, rb, GroupBuilder(wb, key1, contents, id1))
+          }
         }
       case _ =>
         (toCollectionBuilder(left) |@| toCollectionBuilder(right))((_, _) match {
@@ -1447,10 +1466,10 @@ object WorkflowBuilder {
               List("DocBuilder", "Shape")) ::
             Nil,
           List("DocBuilder"))
-      case GroupBuilderF(src, key, content, id) =>
+      case GroupBuilderF(src, keys, content, id) =>
         NonTerminal("",
           render(src) ::
-            Terminal(key.toString, "GroupBuilder" :: "By" :: Nil) ::
+            NonTerminal("", keys.map(render), List("GroupBuilder", "By")) ::
             RC.render(content).copy(nodeType = "GroupBuilder" :: "Content" :: Nil) ::
             Terminal(id.toString, "GroupBuilder" :: "Id" :: Nil) ::
             Nil,

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -797,13 +797,13 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           $read(Collection("caloriesBurnedData")),
           $project(
             Reshape.Doc(ListMap(
-              BsonField.Name("__tmp1") -> -\/(DocVar.ROOT()),
+              BsonField.Name("__tmp1") -> -\/(DocField(BsonField.Name("score"))),
               BsonField.Name("__tmp2") -> -\/(Month(DocField(BsonField.Name("date")))))),
             IgnoreId),
           $group(
             Grouped(ListMap(
-              BsonField.Name("a") -> Avg(DocField(BsonField.Name("__tmp1") \ BsonField.Name("score"))),
-              BsonField.Name("m") -> Push(Month(DocField(BsonField.Name("__tmp1") \ BsonField.Name("date")))))),
+              BsonField.Name("a") -> Avg(DocField(BsonField.Name("__tmp1"))),
+              BsonField.Name("m") -> Push(DocField(BsonField.Name("__tmp2"))))),
             -\/(DocField(BsonField.Name("__tmp2")))),
           $unwind(DocField(BsonField.Name("m")))))
     }
@@ -917,7 +917,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         $group(
           Grouped(ListMap(
             BsonField.Name("city") -> Push(DocField(BsonField.Name("city"))),
-            BsonField.Name("__tmp0") -> Sum(ExprOp.Subtract(DocField(BsonField.Name("pop")), ExprOp.Literal(Bson.Int64(1)))))),
+            BsonField.Name("__tmp2") -> Sum(ExprOp.Subtract(DocField(BsonField.Name("pop")), ExprOp.Literal(Bson.Int64(1)))))),
           -\/(DocField(BsonField.Name("city")))),
         $unwind(DocField(BsonField.Name("city"))),
         $project(
@@ -925,7 +925,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             BsonField.Name("city") -> -\/(DocField(BsonField.Name("city"))),
             BsonField.Name("1") ->
               -\/(ExprOp.Divide(
-                DocField(BsonField.Name("__tmp0")),
+                DocField(BsonField.Name("__tmp2")),
                 ExprOp.Literal(Bson.Int64(1000)))))),
           IgnoreId)))
     }
@@ -951,14 +951,13 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           $read(Collection("zips")),
           $simpleMap(JsMacro(js => 
             Obj(ListMap(
-              "__tmp3" -> Select(Select(js, "city").fix, "length").fix,
-              "__tmp1" -> js,
-              "__tmp2" -> Select(Select(js, "city").fix, "length").fix)).fix)),
+              "__tmp1" -> Select(Select(js, "city").fix, "length").fix,
+              "__tmp2" -> js)).fix)),
           $group(
             Grouped(ListMap(
-              BsonField.Name("len") -> Push(DocField(BsonField.Name("__tmp3"))),
+              BsonField.Name("len") -> Push(DocField(BsonField.Name("__tmp1"))),
               BsonField.Name("cnt") -> Sum(ExprOp.Literal(Bson.Int32(1))))),
-              -\/(DocField(BsonField.Name("__tmp2")))),
+              -\/(DocField(BsonField.Name("__tmp1")))),
           $unwind(DocField(BsonField.Name("len")))))
     }
     

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -126,7 +126,7 @@ class WorkflowBuilderSpec
       val op = (for {
         city    <- lift(projectField(read, "city"))
         state   <- lift(projectField(read, "state"))
-        grouped <- groupBy(read, List(city, state))
+        grouped =  groupBy(read, List(city, state))
         sum     <- lift(projectField(grouped, "pop")).map(reduce(_)(Sum(_)))
         rez     <- build(sum)
       } yield rez).evalZero
@@ -173,7 +173,7 @@ class WorkflowBuilderSpec
       val read = WorkflowBuilder.read(Collection("zips"))
       val op = (for {
         city1   <- lift(projectField(read, "city"))
-        grouped <- groupBy(read, List(city1))
+        grouped =  groupBy(read, List(city1))
         total   =  reduce(grouped)(Sum(_))
         proj0   =  makeObject(total, "total")
         city2   <- lift(projectField(grouped, "city"))
@@ -260,7 +260,7 @@ class WorkflowBuilderSpec
       val read = WorkflowBuilder.read(Collection("zips"))
       val op = (for {
         pop     <- lift(projectField(read, "pop"))
-        grouped <- groupBy(pop, List(pure(Bson.Int32(1))))
+        grouped =  groupBy(pop, List(pure(Bson.Int32(1))))
         total   =  reduce(grouped)(Sum(_))
         obj     =  makeObject(total, "total")
         rez     <- build(obj)
@@ -278,7 +278,7 @@ class WorkflowBuilderSpec
       val read = WorkflowBuilder.read(Collection("zips"))
       val op = (for {
         one     <- lift(expr1(read)(κ(Literal(Bson.Int32(1)))))
-        grouped <- groupBy(one, List(one))
+        grouped =  groupBy(one, List(one))
         total   =  reduce(grouped)(Sum(_))
         obj     =  makeObject(total, "total")
         rez     <- build(obj)
@@ -322,7 +322,7 @@ class WorkflowBuilderSpec
       val op = (for {
         city    <- lift(projectField(read, "city"))
         pop     <- lift(projectField(read, "pop"))
-        grouped <- groupBy(pop, List(city))
+        grouped =  groupBy(pop, List(city))
         total   =  reduce(grouped)(Sum(_))
         obj     =  makeObject(total, "total")
         rez     <- build(obj)
@@ -340,7 +340,7 @@ class WorkflowBuilderSpec
       val read = WorkflowBuilder.read(Collection("zips"))
       val op = (for {
         city    <- lift(projectField(read, "city"))
-        grouped <- groupBy(read, List(city))
+        grouped =  groupBy(read, List(city))
         city2   <- lift(projectField(grouped, "city"))
         pop     <- lift(projectField(grouped, "pop"))
         total   =  reduce(pop)(Sum(_))
@@ -361,9 +361,9 @@ class WorkflowBuilderSpec
     }
 
     "group in expression" in {
-      val read = WorkflowBuilder.read(Collection("zips"))
+      val read    = WorkflowBuilder.read(Collection("zips"))
+      val grouped = groupBy(read, List(pure(Bson.Int32(1))))
       val op = (for {
-        grouped <- groupBy(read, List(pure(Bson.Int32(1))))
         pop     <- lift(projectField(grouped, "pop"))
         total   =  reduce(pop)(Sum(_))
         expr    <- expr2(total, pure(Bson.Int32(1000)))(Divide(_, _))
@@ -395,26 +395,24 @@ class WorkflowBuilderSpec
     val read = WorkflowBuilder.read(Collection("zips"))
 
     "render in-process group" in {
-      val op = (for {
-        grouped <- groupBy(read, List(pure(Bson.Int32(1))))
-        pop     <- lift(projectField(grouped, "pop"))
-      } yield reduce(pop)(Sum(_))).evalZero
+      val grouped = groupBy(read, List(pure(Bson.Int32(1))))
+      val op = for {
+        pop <- projectField(grouped, "pop")
+      } yield reduce(pop)(Sum(_))
       op.map(render) must beRightDisj(
         """GroupBuilder
-          |├─ CollectionBuilder
-          |│  ├─ Chain
+          |├─ ExprBuilder
+          |│  ├─ CollectionBuilder
           |│  │  ├─ $Read(zips)
-          |│  │  ╰─ $Project
-          |│  │     ├─ Name(__tmp0 -> { "$literal" : 1})
-          |│  │     ├─ Name(__tmp1 -> $$ROOT)
-          |│  │     ╰─ IncludeId
-          |│  ├─ ExprOp(DocVar.ROOT())
-          |│  ╰─ SchemaChange(Init)
-          |├─ By(-\/(Literal(Null)))
+          |│  │  ├─ ExprOp(DocVar.ROOT())
+          |│  │  ╰─ SchemaChange(Init)
+          |│  ╰─ ExprOp(DocField(BsonField.Name("pop")))
+          |├─ By
+          |│  ╰─ ValueBuilder(Int32(1))
           |├─ Content
           |│  ╰─ \/-
-          |│     ╰─ GroupOp(Sum(DocField(BsonField.Name("__tmp1") \ BsonField.Name("pop"))))
-          |╰─ Id(fe46cdb3)""".stripMargin)
+          |│     ╰─ GroupOp(Sum(DocVar.ROOT()))
+          |╰─ Id(cd1348c9)""".stripMargin)
     }
 
   }

--- a/it/src/test/resources/tests/groupByFlatten.test
+++ b/it/src/test/resources/tests/groupByFlatten.test
@@ -1,0 +1,22 @@
+{
+    "name": "group by flattened field",
+    "data": "slamengine_commits.data",
+    "query": "select distinct substring(parents[*].sha, 0, 1) from slamengine_commits group by substring(parents[*].sha, 0, 1)",
+    "predicate": "containsExactly",
+    "expected": [{ "0": "0" },
+                 { "0": "1" },
+                 { "0": "2" },
+                 { "0": "3" },
+                 { "0": "4" },
+                 { "0": "5" },
+                 { "0": "6" },
+                 { "0": "7" },
+                 { "0": "8" },
+                 { "0": "9" },
+                 { "0": "a" },
+                 { "0": "b" },
+
+                 { "0": "d" },
+                 { "0": "e" },
+                 { "0": "f" }]
+}


### PR DESCRIPTION
Fixes #590.

Also,

* implement `substring` in JS,
* improve handling of filter when some fields are $$ROOT (used to not be
  able to hit this spot),
* `simplify` JsCore in more places, and
* identify more case that don’t need undefined checks.