### PR TITLE
disable Aesh's "export" feature (Fixes #473)

### DIFF
--- a/core/src/main/scala/slamdata/engine/repl/repl.scala
+++ b/core/src/main/scala/slamdata/engine/repl/repl.scala
@@ -117,7 +117,7 @@ object Repl {
   private def commandInput: Task[(Printer, Process[Task, Command])] =
     Task.delay {
       val console =
-        new Console(new SettingsBuilder().parseOperators(false).create())
+        new Console(new SettingsBuilder().parseOperators(false).enableExport(false).create())
       console.setPrompt(new Prompt("💪 $ "))
 
       val out = (s: String) => Task.delay { console.getShell.out().println(s) }


### PR DESCRIPTION
We do our own variable substitution, so don't need Aesh's weird `export` feature, which captures `$`s.