### PR TITLE
Improve handling of object splicing.

### DIFF
--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -43,6 +43,13 @@ object WorkflowBuilder {
   type WorkflowBuilder = Term[WorkflowBuilderF]
 
   type Expr = ExprOp \/ JsMacro
+  private def exprToJs(expr: Expr) = expr.fold(ExprOp.toJs(_), \/-(_))
+  implicit def ExprRenderTree = new RenderTree[Expr] {
+      override def render(x: Expr) =
+        x.fold(
+          op => Terminal(op.toString, List("ExprBuilder", "ExprOp")),
+          js => Terminal(js(JsCore.Ident("_").fix).toJs.render(0), List("ExprBuilder", "Js")))
+    }
 
   case class CollectionBuilderF(
     graph: Workflow,
@@ -111,7 +118,6 @@ object WorkflowBuilder {
           case Doc(b) => NonTerminal("", RB.render(b) :: Nil, "Doc" :: Nil)
         }
     }
-
   }
   import Contents._
 
@@ -143,6 +149,18 @@ object WorkflowBuilder {
   object FlatteningBuilder {
     def apply(src: WorkflowBuilder, typ: StructureType, field: DocVar) =
       Term[WorkflowBuilderF](new FlatteningBuilderF(src, typ, field))
+  }
+
+  /**
+    Holds a partially-unknown structure. `Expr` entries are unknown and `Doc`
+    entries are known. There should be at least one Expr in the list, otherwise
+    it should be a DocBuilder.
+    */
+  case class SpliceBuilderF[A](src: A, structure: List[Contents[Expr]])
+      extends WorkflowBuilderF[A]
+  object SpliceBuilder {
+    def apply(src: WorkflowBuilder, structure: List[Contents[Expr]]) =
+      Term[WorkflowBuilderF](new SpliceBuilderF(src, structure))
   }
 
   private def rewriteObjRefs(
@@ -447,6 +465,32 @@ object WorkflowBuilder {
               base,
               struct)
         }
+      case SpliceBuilderF(src, structure) =>
+        workflow(src).flatMap { case (wf, base) =>
+          emitSt(freshId("arg")).flatMap { name =>
+            lift(structure.map {
+              case Expr(unknown) =>
+                exprToJs(rewriteExprPrefix(unknown, base)).map(x =>
+                  List($Reduce.copyAllFields(x(JsCore.Ident(name).fix))))
+              case Doc(known) =>
+                rewriteDocPrefix(known, base).toList.map { case (k, v) =>
+                  exprToJs(v).map(js =>
+                    $Reduce.copyOneField(
+                      JsMacro(JsCore.Select(_, k.asText).fix),
+                      js(JsCore.Ident(name).fix)))
+                }.sequenceU
+            }.sequenceU.map(lists =>
+              CollectionBuilderF(
+                chain(wf,
+                  $map($Map.mapMap(name,
+                    Js.Call(
+                      Js.AnonFunDecl(List("rez"),
+                        lists.foldMap().map(_(JsCore.Ident("rez").fix)) :+ Js.Return(Js.Ident("rez"))),
+                      List(Js.AnonObjDecl(Nil)))))),
+                DocVar.ROOT(),
+                SchemaChange.Init)))
+          }
+        }
     }
 
   def workflow(wb: WorkflowBuilder): M[(Workflow, DocVar)] =
@@ -701,58 +745,8 @@ object WorkflowBuilder {
         }
 
       def generalMerge =
-        emitSt(freshId("arg")).flatMap { name =>
-          def builderWithUnknowns(
-            src: WorkflowBuilder,
-            fields: List[Term[JsCore] => Js.Stmt]) =
-            // TODO: replace with ExprBuilder using JsMacro
-            chainBuilder(src, DocVar.ROOT(), SchemaChange.Init)(
-              $map($Map.mapMap(name,
-                Js.Call(
-                  Js.AnonFunDecl(List("rez"),
-                    fields.map(_(JsCore.Ident("rez").fix)) :+ Js.Return(Js.Ident("rez"))),
-                  List(Js.AnonObjDecl(Nil))))))
-
-          def side(wb: WorkflowBuilder, base: DocVar):
-              Error \/ ((Term[JsCore] => Js.Stmt) \/ List[BsonField.Name])=
-            wb.unFix match {
-              case CollectionBuilderF(_, _, _) =>
-                \/-(-\/($Reduce.copyAllFields(base.toJs(JsCore.Ident(name).fix))))
-              case ValueBuilderF(Bson.Doc(map)) =>
-                \/-(\/-(map.keys.map(BsonField.Name(_)).toList))
-              case DocBuilderF(_, shape) => \/-(\/-(shape.keys.toList))
-              // TODO: Restrict to DocVar, Literal, Let, Cond, and IfNull (see #471)
-              case ExprBuilderF(_, _) =>
-                \/-(-\/($Reduce.copyAllFields(base.toJs(JsCore.Ident(name).fix))))
-              case _ =>
-                -\/(WorkflowBuilderError.InvalidOperation(
-                  "objectConcat",
-                  "values are not both documents: " + wb))
-            }
-
-          merge(wb1, wb2).flatMap { case (left, right, list) =>
-            lift((side(wb1, left) |@| side(wb2, right))((_, _) match {
-              case (\/-(f1), \/-(f2)) =>
-                unlessConflicts(f1.toSet, f2.toSet) {
-                  emit(DocBuilder(list,
-                    combine(
-                      f1.map(k => k -> -\/(left \ k)).toListMap,
-                      f2.map(k => k -> -\/(right \ k)).toListMap)(_ ++ _)))
-                }
-              case (\/-(_), -\/(_)) => delegate
-              case (-\/(f1), \/-(f2)) =>
-                builderWithUnknowns(
-                  list,
-                  combine(
-                    List(f1),
-                    f2.map(k =>
-                      (t: Term[JsCore]) => $Reduce.copyOneField(
-                        JsMacro(JsCore.Select(_, k.asText).fix),
-                        (right \ k).toJs(JsCore.Ident(name).fix))(t)))(_ ++ _))
-              case (-\/(f1), -\/(f2)) =>
-                builderWithUnknowns(list, combine(f1, f2)(List(_, _)))
-            })).join
-          }
+        merge(wb1, wb2).map { case (left, right, list) =>
+          SpliceBuilder(list, List(Expr(-\/(left)), Expr(-\/(right))))
         }
 
       (wb1.unFix, wb2.unFix) match {
@@ -860,9 +854,31 @@ object WorkflowBuilder {
 
         // NB: these cases come up when wildcards are used, and require a more general
         // approach, which we don't know to be correct and efficient in all cases.
+        case (DocBuilderF(src1, shape), ExprBuilderF(src2, expr)) =>
+          merge(src1, src2).map { case (left, right, list) =>
+            SpliceBuilder(list, combine(
+              Doc(rewriteDocPrefix(shape, left)),
+              Expr(rewriteExprPrefix(expr, right)))(List(_, _)))
+          }
+        case (ExprBuilderF(_, _), DocBuilderF(_, _)) => delegate
+
+        case (ExprBuilderF(src1, expr1), ExprBuilderF(src2, expr2)) =>
+          merge(src1, src2).map { case (left, right, list) =>
+            SpliceBuilder(list, combine(
+              Expr(rewriteExprPrefix(expr1, left)),
+              Expr(rewriteExprPrefix(expr2, right)))(List(_, _)))
+          }
+
+        case (DocBuilderF(src, shape), _) =>
+          merge(src, wb2).map { case (left, right, list) =>
+            SpliceBuilder(list, combine(
+              Doc(rewriteDocPrefix(shape, left)),
+              Expr(-\/(right))) (List(_, _)))
+          }
+        case (_, DocBuilderF(_, _)) => delegate
+
         case (CollectionBuilderF(_, _, _), _) => generalMerge
         case (_, CollectionBuilderF(_, _, _)) => generalMerge
-        case (ExprBuilderF(_, _), ExprBuilderF(_, _)) => generalMerge
 
         case _ => fail(WorkflowBuilderError.InvalidOperation(
           "objectConcat",
@@ -979,7 +995,7 @@ object WorkflowBuilder {
           "projectIndex",
           "value is not an array."))
       case ExprBuilderF(wb0, expr) =>
-        lift(expr.fold(ExprOp.toJs, \/-(_)).map(js =>
+        lift(exprToJs(expr).map(js =>
           ExprBuilder(wb0,
             \/-(JsMacro(base =>
               JsCore.Access(js(base),
@@ -1357,6 +1373,17 @@ object WorkflowBuilder {
           }
         }
 
+      case (SpliceBuilderF(src, structure), _) =>
+        merge(src, right).flatMap { case (lbase, rbase, wb) =>
+          emitSt(freshName.map(name =>
+            (DocVar.ROOT(), DocField(name),
+              SpliceBuilder(wb, structure.map {
+                case Expr(expr) => Expr(rewriteExprPrefix(expr, lbase))
+                case Doc(doc)  => Doc(rewriteDocPrefix(doc, lbase))
+              } :+ Doc(ListMap(name -> -\/(rbase)))))))
+        }
+      case (_, SpliceBuilderF(_, _)) => delegate
+
       case (ExprBuilderF(src, expr), _) =>
         merge(src, right).flatMap { case (lbase, rbase, wb) =>
           mergeContents(Expr(rewriteExprPrefix(expr, lbase)), Expr(-\/(rbase))).map {
@@ -1454,18 +1481,7 @@ object WorkflowBuilder {
       case (_, ArrayBuilderF(_, _)) => delegate
 
       case _ =>
-        (toCollectionBuilder(left) |@| toCollectionBuilder(right))((_, _) match {
-          case (
-            CollectionBuilderF(graph1, base1, struct1),
-            CollectionBuilderF(graph2, base2, struct2)) =>
-            emitSt(Workflow.merge(graph1, graph2).map { case ((lbase, rbase), op) =>
-              (lbase \\ base1, rbase \\ base2,
-                CollectionBuilder(
-                  op,
-                  DocVar.ROOT(),
-                  if (struct1 == struct2) struct1 else SchemaChange.Init))
-            })
-        }).join
+        fail(PlannerError.InternalError("failed to merge:\n" + left.show + "\n" + right.show))
     }
   }
 
@@ -1473,12 +1489,7 @@ object WorkflowBuilder {
     CollectionBuilder($read(coll), DocVar.ROOT(), SchemaChange.Init)
   def pure(bson: Bson) = ValueBuilder(bson)
 
-  implicit def WorkflowBuilderRenderTree(implicit RO: RenderTree[Workflow], RE: RenderTree[ExprOp], RC: RenderTree[GroupContents]): RenderTree[WorkflowBuilder] = new RenderTree[WorkflowBuilder] {
-    def renderExpr(x: Expr) =
-      x.fold(
-        op => Terminal(op.toString, List("ExprBuilder", "ExprOp")),
-        js => Terminal(js(JsCore.Ident("_").fix).toJs.render(0), List("ExprBuilder", "Js")))
-
+  implicit def WorkflowBuilderRenderTree(implicit RO: RenderTree[Workflow], RE: RenderTree[ExprOp], REx: RenderTree[Expr], RC: RenderTree[GroupContents], RCE: RenderTree[Contents[Expr]]): RenderTree[WorkflowBuilder] = new RenderTree[WorkflowBuilder] {
     def render(v: WorkflowBuilder) = v.unFix match {
       case CollectionBuilderF(graph, base, struct) =>
         NonTerminal("",
@@ -1497,20 +1508,20 @@ object WorkflowBuilder {
         Terminal(value.toString, "ValueBuilder" :: Nil)
       case ExprBuilderF(src, expr) =>
         NonTerminal("",
-          render(src) :: renderExpr(expr) :: Nil,
+          render(src) :: REx.render(expr) :: Nil,
           List("ExprBuilder"))
       case DocBuilderF(src, shape) =>
         NonTerminal("",
           render(src) ::
             NonTerminal("",
-              shape.toList.map { case (name, expr) => renderExpr(expr).relabel(name.asText + " -> " + _) },
+              shape.toList.map { case (name, expr) => REx.render(expr).relabel(name.asText + " -> " + _) },
               List("DocBuilder", "Shape")) ::
             Nil,
           List("DocBuilder"))
       case ArrayBuilderF(src, shape) =>
         NonTerminal("",
           render(src) ::
-            NonTerminal("", shape.map(renderExpr), List("ArrayBuilder", "Shape")) ::
+            NonTerminal("", shape.map(REx.render), List("ArrayBuilder", "Shape")) ::
             Nil,
           List("ArrayBuilder"))
       case GroupBuilderF(src, keys, content, id) =>
@@ -1528,6 +1539,10 @@ object WorkflowBuilder {
             RE.render(field) ::
             Nil,
           List("FlatteningBuilder"))
+      case SpliceBuilderF(src, structure) =>
+        NonTerminal("",
+          render(src) :: structure.map(RCE.render(_)),
+          List("SpliceBuilder"))
     }
   }
 }

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -600,25 +600,15 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
       plan("select *, pop from zips") must
         beWorkflow(chain(
           $read(Collection("zips")),
-          $project(
-            Reshape.Doc(ListMap(
-              BsonField.Name("__tmp1") -> -\/(DocVar.ROOT()),
-              BsonField.Name("pop") -> -\/(DocField(BsonField.Name("pop"))))),
-            IgnoreId),
           $map($Map.mapMap("__arg0",
             Js.Call(Js.AnonFunDecl(List("rez"),
               List(
-                Js.ForIn(
-                  Js.Ident("attr"),
-                  Select(Ident("__arg0").fix, "__tmp1").fix.toJs,
+                Js.ForIn(Js.Ident("attr"), Ident("__arg0").fix.toJs,
                   Js.If(
-                    Call(
-                      Select(Select(Ident("__arg0").fix, "__tmp1").fix,
-                        "hasOwnProperty").fix,
+                    Call(Select(Ident("__arg0").fix, "hasOwnProperty").fix,
                       List(Ident("attr").fix)).fix.toJs,
                     safeAssign(Access(Ident("rez").fix, Ident("attr").fix).fix,
-                      Access(Select(Ident("__arg0").fix, "__tmp1").fix,
-                        Ident("attr").fix).fix),
+                      Access(Ident("__arg0").fix, Ident("attr").fix).fix),
                     None)),
                 safeAssign(Select(Ident("rez").fix, "pop").fix,
                   Select(Ident("__arg0").fix, "pop").fix),
@@ -630,25 +620,21 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
       plan("select * from zips order by pop/10 desc") must
         beWorkflow(chain(
           $read(Collection("zips")),
-          $project(
-            Reshape.Doc(ListMap(
-              BsonField.Name("__tmp1") -> -\/(DocVar.ROOT()),
-              BsonField.Name("__sd__0") -> -\/(ExprOp.Divide(
-                  DocField(BsonField.Name("pop")),
-                  ExprOp.Literal(Bson.Int64(10)))))),
-            IgnoreId),
-          $map($Map.mapMap("__arg0",
+          $map($Map.mapMap("__arg1",
             Js.Call(Js.AnonFunDecl(List("rez"),
               List(
-                Js.ForIn(Js.Ident("attr"),
-                  Select(Ident("__arg0").fix, "__tmp1").fix.toJs,
-                  Js.If(Call(Select(Select(Ident("__arg0").fix, "__tmp1").fix, "hasOwnProperty").fix, List(Ident("attr").fix)).fix.toJs,
+                Js.ForIn(Js.Ident("attr"), Ident("__arg1").fix.toJs,
+                  Js.If(
+                    Call(Select(Ident("__arg1").fix, "hasOwnProperty").fix,
+                      List(Ident("attr").fix)).fix.toJs,
                     safeAssign(
                       Access(Ident("rez").fix, Ident("attr").fix).fix,
-                      Access(Select(Ident("__arg0").fix, "__tmp1").fix, Ident("attr").fix).fix),
+                      Access(Ident("__arg1").fix, Ident("attr").fix).fix),
                     None)),
                 safeAssign(Select(Ident("rez").fix, "__sd__0").fix,
-                  Select(Ident("__arg0").fix, "__sd__0").fix),
+                  BinOp(Div,
+                    Select(Ident("__arg1").fix, "pop").fix,
+                    JsCore.Literal(Js.Num(10, false)).fix).fix),
                 Js.Return(Js.Ident("rez")))),
               List(Js.AnonObjDecl(Nil))))),
           $sort(NonEmptyList(BsonField.Name("__sd__0") -> Descending))))

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -375,13 +375,13 @@ class WorkflowBuilderSpec
         chain($read(Collection("zips")),
           $group(
             Grouped(ListMap(
-              BsonField.Name("__tmp4") ->
+              BsonField.Name("__tmp2") ->
                 Sum(DocField(BsonField.Name("pop"))))),
             -\/(Literal(Bson.Null))),
             $project(Reshape.Doc(ListMap(
               BsonField.Name("totalInK") ->
                 -\/(Divide(
-                  DocField(BsonField.Name("__tmp4")),
+                  DocField(BsonField.Name("__tmp2")),
                   Literal(Bson.Int32(1000)))))),
           IgnoreId)))
     }

--- a/it/src/test/resources/tests/groupedJoin.test
+++ b/it/src/test/resources/tests/groupedJoin.test
@@ -1,9 +1,9 @@
 {
     "name": "count grouped joined tables",
     "data": "slamengine_commits.data",
-    "query": "SELECT COUNT(*) FROM slamengine_commits p INNER JOIN slamengine_commits c ON p.sha = c.sha GROUP BY p.author.login",
+    "query": "SELECT distinct p.author.login, COUNT(*) FROM slamengine_commits p INNER JOIN slamengine_commits c ON p.sha = c.sha GROUP BY p.author.login",
     "predicate": "containsExactly",
-    "expected": [{ "0":  6 },
-                 { "0": 15 },
-                 { "0":  9 }]
+    "expected": [{ "login": "mossprescott", "1": 15 },
+                 { "login": "sellout",      "1":  9 },
+                 { "login": "jdegoes",      "1":  6 }]
 }


### PR DESCRIPTION
Adds a new SpliceBuilder for objects with partially-unknown structure.

This builds on the fix for #587 – that made those precise queries pass,
but minor changes to them could result in other failures. This gives a
more robust solution.

It also finally eliminates the need for `WorkflowBuilder.merge` to ever
fall back to `Workflow.merge` (although `Workflow.merge` still has a
call site elsewhere, so it’s still not quite dead).