### PR TITLE
Improve rendering of JsMacros

### DIFF
--- a/core/src/main/scala/slamdata/engine/javascript/javascript.scala
+++ b/core/src/main/scala/slamdata/engine/javascript/javascript.scala
@@ -8,19 +8,19 @@ import slamdata.engine.{Terminal, RenderTree}
 
 /*
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2013 Alexander Nemish.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -96,9 +96,9 @@ object Js {
   // Because they're not just identifiers.
   val This = Ident("this")
   val Undefined = Ident("undefined")
-  
+
   /** Pattern matching valid identifiers. */
-  val SimpleNamePattern = "[_a-zA-Z][_a-zA-Z0-9]+".r
+  val SimpleNamePattern = "[_a-zA-Z][_a-zA-Z0-9]*".r
 
   // Some functional-style helpers
   def Let(bindings: Map[String, Expr], stmts: List[Stmt], expr: Expr) = {

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -44,11 +44,11 @@ object WorkflowBuilder {
 
   type Expr = ExprOp \/ JsMacro
   private def exprToJs(expr: Expr) = expr.fold(ExprOp.toJs(_), \/-(_))
-  implicit def ExprRenderTree = new RenderTree[Expr] {
+  implicit def ExprRenderTree(implicit RJM: RenderTree[JsMacro]) = new RenderTree[Expr] {
       override def render(x: Expr) =
         x.fold(
           op => Terminal(op.toString, List("ExprBuilder", "ExprOp")),
-          js => Terminal(js(JsCore.Ident("_").fix).toJs.render(0), List("ExprBuilder", "Js")))
+          js => RJM.render(js))
     }
 
   case class CollectionBuilderF(
@@ -87,7 +87,7 @@ object WorkflowBuilder {
     def apply(src: WorkflowBuilder, expr: Expr) =
       Term[WorkflowBuilderF](new ExprBuilderF(src, expr))
   }
-  
+
   // NB: The shape is more restrictive than $project because we may need to
   //     convert it to a GroupBuilder, and a nested Reshape can be realized with
   //     a chain of DocBuilders, leaving the collapsing to Workflow.coalesce.
@@ -837,7 +837,7 @@ object WorkflowBuilder {
           DocBuilderF(Term(GroupBuilderF(_, Nil, _, _)), _),
           DocBuilderF(_, _)) =>
           delegate
-        
+
         case (DocBuilderF(s1, shape1), DocBuilderF(s2, shape2)) =>
           unlessConflicts(shape1.keySet, shape2.keySet) {
             merge(s1, s2).map { case (lbase, rbase, src) =>
@@ -1438,9 +1438,9 @@ object WorkflowBuilder {
       case (_, FlatteningBuilderF(_, _, _)) => delegate
 
       case (
-        mib1 @ ShapePreservingBuilderF(src1, inputs1, op1),
-        mib2 @ ShapePreservingBuilderF(src2, inputs2, _))
-          if inputs1 == inputs2 && ShapePreservingBuilder.dummyOp(mib1) == ShapePreservingBuilder.dummyOp(mib2) =>
+        spb1 @ ShapePreservingBuilderF(src1, inputs1, op1),
+        spb2 @ ShapePreservingBuilderF(src2, inputs2, _))
+          if inputs1 == inputs2 && ShapePreservingBuilder.dummyOp(spb1) == ShapePreservingBuilder.dummyOp(spb2) =>
         merge(src1, src2).map { case (lbase, rbase, wb) =>
           (lbase, rbase, ShapePreservingBuilder(wb, inputs1, op1))
         }
@@ -1495,11 +1495,11 @@ object WorkflowBuilder {
             Terminal(struct.toString, "CollectionBuilder" :: "SchemaChange" :: Nil) ::
             Nil,
           "CollectionBuilder" :: Nil)
-      case mib @ ShapePreservingBuilderF(src, inputs, op) =>
+      case spb @ ShapePreservingBuilderF(src, inputs, op) =>
         NonTerminal("",
           render(src) ::
             (inputs.map(render) :+
-              Terminal(ShapePreservingBuilder.dummyOp(mib).toString, "ShapePreservingBuilder" :: "Op" :: Nil)),
+              Terminal(ShapePreservingBuilder.dummyOp(spb).toString, "ShapePreservingBuilder" :: "Op" :: Nil)),
           "ShapePreservingBuilder" :: Nil)
       case ValueBuilderF(value) =>
         Terminal(value.toString, "ValueBuilder" :: Nil)


### PR DESCRIPTION
Use "unsafe" Js conversion in JsMacro's toString and RenderTree
instance. This makes the physical plan a lot easier to read.
You can still see the actual generated JS in the "Mongo" plan.

Fix a bug where single-character names weren't recognized as
simple names, so you would see things like `_["x"]`instead of
`_.x`.