### PR TITLE
match groups followed by shape-preserving ops

### DIFF
--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -74,7 +74,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     "plan count(*)" in {
-      plan("select count(*) from foo") must beWorkflow( 
+      plan("select count(*) from foo") must beWorkflow(
         chain(
           $read(Collection("foo")),
           $group(
@@ -99,7 +99,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
            BsonField.Name("bar") -> -\/(DocField(BsonField.Name("bar"))))),
            IgnoreId)))
     }
-    
+
     "plan multiple field projection on single set when table name is inferred" in {
       plan("select bar, baz from foo") must
        beWorkflow(chain(
@@ -120,7 +120,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
              DocField(BsonField.Name("bar")))))),
            IgnoreId)))
     }
-    
+
     "plan concat" in {
       plan("select concat(bar, baz) from foo") must
        beWorkflow(chain(
@@ -298,7 +298,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
          $match(
            Selector.Doc(BsonField.Name("bar") -> Selector.Gt(Bson.Int64(10))))))
     }
-    
+
     "plan simple reversed filter" in {
       plan("select * from foo where 10 < bar") must
        beWorkflow(chain(
@@ -306,7 +306,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
          $match(
            Selector.Doc(BsonField.Name("bar") -> Selector.Gt(Bson.Int64(10))))))
     }
-    
+
     "plan simple filter with expression in projection" in {
       plan("select a + b from foo where bar > 10") must
        beWorkflow(chain(
@@ -364,7 +364,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
              Selector.Doc(BsonField.Name("bar") ->
                Selector.Lte(Bson.Int64(100)))))))
     }
-    
+
     "plan filter with like" in {
       plan("select * from foo where bar like 'A%'") must
        beWorkflow(chain(
@@ -373,7 +373,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
            BsonField.Name("bar") ->
              Selector.Regex("^A.*$", false, false, false, false)))))
     }
-    
+
     "plan filter with LIKE and OR" in {
       plan("select * from foo where bar like 'A%' or bar like 'Z%'") must
        beWorkflow(chain(
@@ -457,7 +457,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
              Selector.Doc(BsonField.Name("baz") ->
                Selector.Gt(Bson.Dec(-1.0)))))))
     }
-    
+
     "plan complex filter" in {
       plan("select * from foo where bar > 10 and (baz = 'quux' or foop = 'zebra')") must
        beWorkflow(chain(
@@ -569,7 +569,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
                 -\/(ExprOp.DocField(BsonField.Name("bar"))))),
             IgnoreId)))
     }
-    
+
     "plan simple sort with wildcard" in {
       plan("select * from zips order by pop") must
         beWorkflow(chain(
@@ -639,7 +639,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               List(Js.AnonObjDecl(Nil))))),
           $sort(NonEmptyList(BsonField.Name("__sd__0") -> Descending))))
     }
-    
+
     "plan simple sort with field not in projections" in {
       plan("select name from person order by height") must
         beWorkflow(chain(
@@ -650,7 +650,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               -\/(DocField(BsonField.Name("name"))))),
             IgnoreId)))
     }
-    
+
     "plan sort with expression and alias" in {
       plan("select pop/1000 as popInK from zips order by popInK") must
         beWorkflow(chain(
@@ -663,7 +663,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             IgnoreId),
           $sort(NonEmptyList(BsonField.Name("popInK") -> Ascending))))
     }
-    
+
     "plan sort with filter" in {
       plan("select city, pop from zips where pop <= 1000 order by pop desc, city") must
         beWorkflow(chain(
@@ -678,7 +678,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             BsonField.Name("pop") -> Descending,
             BsonField.Name("city") -> Ascending))))
     }
-    
+
     "plan sort with expression, alias, and filter" in {
       plan("select pop/1000 as popInK from zips where pop >= 1000 order by popInK") must
         beWorkflow(chain(
@@ -702,7 +702,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
            BsonField.Name("pop") -> Ascending,
            BsonField.Name("city") -> Descending))))
     }
-    
+
     "plan many sort columns" in {
       plan("select * from zips order by pop, state, city, a4, a5, a6") must
        beWorkflow(chain(
@@ -793,7 +793,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             -\/(DocField(BsonField.Name("__tmp1")))),
           $unwind(DocField(BsonField.Name("m")))))
     }
-    
+
     "plan expr3 with grouping" in {
       plan("select case when pop > 1000 then city else lower(city) end, count(*) from zips group by city") must
         beRight
@@ -930,12 +930,12 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             "state" -> Select(x, "state").fix,
             "shortest" -> Select(Select(x, "__tmp0").fix, "length").fix)).fix))))
     }
-    
+
     "plan js expr grouped by js expr" in {
-      plan("select length(city) as len, count(*) as cnt from zips group by length(city)") must 
+      plan("select length(city) as len, count(*) as cnt from zips group by length(city)") must
         beWorkflow(chain(
           $read(Collection("zips")),
-          $simpleMap(JsMacro(js => 
+          $simpleMap(JsMacro(js =>
             Obj(ListMap(
               "__tmp0" -> Select(Select(js, "city").fix, "length").fix,
               "__tmp1" -> js)).fix)),
@@ -946,9 +946,9 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               -\/(DocField(BsonField.Name("__tmp0")))),
           $unwind(DocField(BsonField.Name("len")))))
     }
-    
+
     "plan simple JS inside expression" in {
-      plan("select length(city) + 1 from zips") must 
+      plan("select length(city) + 1 from zips") must
         beWorkflow(chain(
           $read(Collection("zips")),
           $simpleMap(JsMacro(x => Obj(ListMap(
@@ -1106,7 +1106,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             $sort(NonEmptyList(BsonField.Name("pop") -> Ascending)))
         }
     }
-    
+
     "plan filter and expressions with IS NULL" in {
       plan("select foo is null from zips where foo is null") must
         beWorkflow(chain(
@@ -1119,8 +1119,21 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             IgnoreId)))
     }
 
+    "plan implicit group by with filter" in {
+      plan("select avg(pop), min(city) from zips where state = 'CO'") must
+        beWorkflow(chain(
+          $read(Collection("zips")),
+          $match(Selector.Doc(
+            BsonField.Name("state") -> Selector.Eq(Bson.Text("CO")))),
+          $group(
+            Grouped(ListMap(
+              BsonField.Name("0") -> Avg(DocField(BsonField.Name("pop"))),
+              BsonField.Name("1") -> Min(DocField(BsonField.Name("city"))))),
+            -\/(ExprOp.Literal(Bson.Null)))))
+    }
+
     "plan simple distinct" in {
-      plan("select distinct city, state from zips") must 
+      plan("select distinct city, state from zips") must
       beWorkflow(
         chain(
           $read(Collection("zips")),
@@ -1141,7 +1154,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     "plan distinct as expression" in {
-      plan("select count(distinct(city)) from zips") must 
+      plan("select count(distinct(city)) from zips") must
         beWorkflow(chain(
           $read(Collection("zips")),
           $group(
@@ -1155,7 +1168,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     "plan distinct of expression as expression" in {
-      plan("select count(distinct substring(city, 0, 1)) from zips") must 
+      plan("select count(distinct substring(city, 0, 1)) from zips") must
         beWorkflow(chain(
           $read(Collection("zips")),
           $group(
@@ -1172,13 +1185,13 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     "plan distinct of wildcard" in {
-      plan("select distinct * from zips") must 
+      plan("select distinct * from zips") must
         beWorkflow(
           $read(Collection("zips")))
     }.pendingUntilFixed("#283")
 
     "plan distinct of wildcard as expression" in {
-      plan("select count(distinct *) from zips") must 
+      plan("select count(distinct *) from zips") must
         beWorkflow(
           $read(Collection("zips")))
     }.pendingUntilFixed("#283")
@@ -1236,11 +1249,11 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     "plan distinct as function with group" in {
-      plan("select state, count(distinct(city)) from zips group by state") must 
+      plan("select state, count(distinct(city)) from zips group by state") must
         beWorkflow(
           $read(Collection("zips")))
     }.pendingUntilFixed
-    
+
     "plan distinct with sum and group" in {
       plan("SELECT DISTINCT SUM(pop) AS totalPop, city FROM zips GROUP BY city") must
         beWorkflow(chain(
@@ -1267,7 +1280,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
                 -\/(DocField(BsonField.Name("__tmp0") \ BsonField.Name("city"))))),
               ExcludeId)))
     }
-    
+
     "plan distinct with sum, group, and orderBy" in {
       plan("SELECT DISTINCT SUM(pop) AS totalPop, city FROM zips GROUP BY city ORDER BY totalPop DESC") must
         beWorkflow(
@@ -1294,7 +1307,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
                 ExcludeId)))
 
     }
-    
+
     "plan select length()" in {
       plan("select length(city) from zips") must
         beWorkflow(chain(
@@ -1302,7 +1315,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           $simpleMap(JsMacro(x => Obj(ListMap(
             "0" -> Select(Select(x, "city").fix, "length").fix)).fix))))
     }
-    
+
     "plan select length() and simple field" in {
       plan("select city, length(city) from zips") must
       beWorkflow(chain(
@@ -1311,16 +1324,16 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           "city" -> Select(value, "city").fix,
           "1" -> Select(Select(value, "city").fix, "length").fix)).fix))))
     }
-    
+
     "plan combination of two distinct sets" in {
       plan("SELECT (DISTINCT foo.bar) + (DISTINCT foo.baz) FROM foo") must
         beWorkflow(
           $read(Collection("zips")))
     }.pendingUntilFixed
-    
+
     "plan expression with timestamp, date, time, and interval" in {
       import org.threeten.bp.{Instant, LocalDateTime, ZoneOffset}
-      
+
       plan("select timestamp '2014-11-17T22:00:00Z' + interval 'PT43M40S', date '2015-01-19', time '14:21' from foo") must
         beWorkflow(
           $pure(Bson.Doc(ListMap(
@@ -1328,10 +1341,10 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             "1" -> Bson.Date(LocalDateTime.parse("2015-01-19T00:00:00").atZone(ZoneOffset.UTC).toInstant),
             "2" -> Bson.Text("14:21:00.000")))))
     }
-    
+
     "plan filter with timestamp and interval" in {
       import org.threeten.bp.Instant
-      
+
       plan("select * from days where \"date\" < timestamp '2014-11-17T22:00:00Z' and \"date\" - interval 'PT12H' > timestamp '2014-11-17T00:00:00Z'") must
         beWorkflow(chain(
           $read(Collection("days")),
@@ -1356,18 +1369,18 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               -\/(DocField(BsonField.Name("__tmp5"))))),
             ExcludeId)))
     }
-    
+
     "plan time_of_day" in {
-      plan("select time_of_day(ts) from foo") must 
+      plan("select time_of_day(ts) from foo") must
         beRight  // NB: way too complicated to spell out here, and will change as JS generation improves
     }
-    
+
     "plan filter on date" in {
       import org.threeten.bp.Instant
-      
+
       // Note: both of these boundaries require comparing with the start of the *next* day.
-      plan("select * from logs " + 
-        "where ((ts > date '2015-01-22' and ts <= date '2015-01-27') and ts != date '2015-01-25') " + 
+      plan("select * from logs " +
+        "where ((ts > date '2015-01-22' and ts <= date '2015-01-27') and ts != date '2015-01-25') " +
         "or ts = date '2015-01-29'") must
         beWorkflow(chain(
           $read(Collection("logs")),
@@ -1389,9 +1402,9 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               Selector.Doc(
                 BsonField.Name("ts") -> Selector.Lt(Bson.Date(Instant.parse("2015-01-30T00:00:00Z")))))))))
     }
-    
+
     "plan js and filter with id" in {
-      plan("select length(city) < oid '0123456789abcdef01234567' from days where _id = oid '0123456789abcdef01234567'") must 
+      plan("select length(city) < oid '0123456789abcdef01234567' from days where _id = oid '0123456789abcdef01234567'") must
         beWorkflow(chain(
           $read(Collection("days")),
           $match(Selector.Doc(
@@ -1407,7 +1420,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               -\/(DocField(BsonField.Name("__tmp0") \ BsonField.Name("0"))))),
             ExcludeId)))
     }
-    
+
     def joinStructure(
       left: Workflow, leftName: String, right: Workflow,
       leftKey: ExprOp, rightKey: Term[JsCore],
@@ -1455,7 +1468,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
                             List(Js.Select(Js.Ident("value"), "right")))))))),
                   Js.Return(Js.Ident("result"))))))))
     }
-            
+
     "plan simple join" in {
       plan("select zips2.city from zips join zips2 on zips._id = zips2._id") must
         beWorkflow(
@@ -1572,7 +1585,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               BsonField.Name("address") -> -\/(DocField(BsonField.Name("right") \ BsonField.Name("address"))))),
               IgnoreId))))  // Note: becomes ExcludeId in conversion to WorkflowTask
     }
- 
+
     "plan 3-way equi-join" in {
       plan(
         "select foo.name, bar.address " +
@@ -1636,11 +1649,11 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               BsonField.Name("city") -> -\/(DocField(BsonField.Name("city"))))),
               ExcludeId))))
     }
-    
+
     def countOps(wf: Workflow, p: PartialFunction[WorkflowF[Term[WorkflowF]], Boolean]): Int = {
       wf.foldMap(op => if (p.lift(op.unFix).getOrElse(false)) 1 else 0)
     }
-    
+
     def noConsecutiveProjectOps(wf: Workflow) =
       countOps(wf, { case $Project(Term($Project(_, _, _)), _, _) => true }) aka "the occurrences of consecutive $project ops:" must_== 0
     def noConsecutiveSimpleMapOps(wf: Workflow) =
@@ -1652,7 +1665,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     def maxMatchOps(wf: Workflow, max: Int) =
       countOps(wf, { case $Match(_, _) => true }) aka "the number of $match ops:" must beLessThanOrEqualTo(max)
 
-    "plan multiple reducing projections without explicit group by" ! Prop.forAll(select(maybeReducingExpr, noFilter, noGroupBy)) { q => 
+    "plan multiple reducing projections without explicit group by" ! Prop.forAll(select(maybeReducingExpr, noFilter, noGroupBy)) { q =>
       plan(q.value) must beRight.which { wf =>
         noConsecutiveProjectOps(wf)
         noConsecutiveSimpleMapOps(wf)
@@ -1754,17 +1767,17 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
   implicit def shrinkQuery(implicit SS: Shrink[SelectStmt]): Shrink[Query] = Shrink { q =>
     (new SQLParser).parse(q).fold(κ(Stream.empty), SS.shrink(_).map(sel => Query(sel.sql)))
   }
-    
-  /** 
+
+  /**
    Shrink a query by reducing the number of projections or grouping expressions. Do not
-   change the "shape" of the query, by removing the group by entirely, etc. 
+   change the "shape" of the query, by removing the group by entirely, etc.
    */
   implicit def shrinkSelect: Shrink[SelectStmt] = {
     /** Shrink a list, removing a single item at a time, but never producing an empty list. */
-    def shortened[A](as: List[A]): Stream[List[A]] = 
+    def shortened[A](as: List[A]): Stream[List[A]] =
       if (as.length <= 1) Stream.empty
       else as.toStream.map(a => as.filterNot(_ == a))
-    
+
     Shrink {
       case sel @ SelectStmt(d, projs, rel, filter, groupBy, orderBy, limit, offset) =>
         val sProjs = shortened(projs).map(ps => SelectStmt(d, ps, rel, filter, groupBy, orderBy, limit, offset))
@@ -1782,7 +1795,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
                   'tmp0, read("foo"),
                   LogicalPlan.Let(
                     'tmp1, makeObj("bar" -> ObjectProject(Free('tmp0), Constant(Data.Str("bar")))),
-                    LogicalPlan.Let('tmp2, 
+                    LogicalPlan.Let('tmp2,
                       set.OrderBy(
                         Free('tmp1),
                         MakeArrayN(
@@ -1801,20 +1814,20 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         $read(Collection("foo")),
         $project(Reshape.Doc(ListMap(
           BsonField.Name("lEft") -> \/- (Reshape.Doc(ListMap(
-            BsonField.Name("bar") -> -\/ (DocField(BsonField.Name("bar")))))), 
+            BsonField.Name("bar") -> -\/ (DocField(BsonField.Name("bar")))))),
           BsonField.Name("rIght") -> \/- (Reshape.Arr(ListMap(
             BsonField.Index(0) -> \/- (Reshape.Doc(ListMap(
               BsonField.Name("key") -> -\/ (DocField(
-                BsonField.Name("bar"))), 
-              BsonField.Name("order") -> -\/ (ExprOp.Literal(Bson.Text("ASC")))))))))))), 
-        $sort(NonEmptyList(BsonField.Name("rIght") \ BsonField.Index(0) \ BsonField.Name("key") -> Ascending)), 
+                BsonField.Name("bar"))),
+              BsonField.Name("order") -> -\/ (ExprOp.Literal(Bson.Text("ASC")))))))))))),
+        $sort(NonEmptyList(BsonField.Name("rIght") \ BsonField.Index(0) \ BsonField.Name("key") -> Ascending)),
         $project(Reshape.Doc(ListMap(BsonField.Name("bar") -> -\/(DocField(BsonField.Name("lEft") \ BsonField.Name("bar")))))))
 
       plan(lp) must beWorkflow(exp)
     }
 
     "plan OrderBy with expression" in {
-      val lp = LogicalPlan.Let('tmp0, 
+      val lp = LogicalPlan.Let('tmp0,
                   read("foo"),
                   set.OrderBy(
                     Free('tmp0),
@@ -1834,7 +1847,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
                   $project(Reshape.Doc(ListMap(
                     BsonField.Name("__sd_tmp_1") ->  \/- (Reshape.Arr(ListMap(
                       BsonField.Index(0) -> -\/ (ExprOp.Divide(
-                                                          DocField(BsonField.Name("bar")), 
+                                                          DocField(BsonField.Name("bar")),
                                                           Literal(Bson.Dec(10.0)))))))))),
                   $sort(NonEmptyList(BsonField.Name("__sd_tmp_1") \ BsonField.Index(0) -> Ascending))
                   // We'll want another Project here to remove the temporary field
@@ -1876,7 +1889,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }.pendingUntilFixed
 
     "plan OrderBy with expression (and extra project)" in {
-      val lp = LogicalPlan.Let('tmp0, 
+      val lp = LogicalPlan.Let('tmp0,
                   read("foo"),
                   LogicalPlan.Let('tmp9,
                     makeObj(
@@ -1898,8 +1911,8 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
 
       val exp = chain(
         $read(Collection("foo")),
-        $project(Reshape.Doc(ListMap(BsonField.Name("lEft") -> \/-(Reshape.Doc(ListMap(BsonField.Name("bar") -> -\/(DocField(BsonField.Name("bar")))))), BsonField.Name("rIght") -> \/-(Reshape.Arr(ListMap(BsonField.Index(0) -> \/-(Reshape.Doc(ListMap(BsonField.Name("key") -> -\/(ExprOp.Divide(DocField(BsonField.Name("bar")), ExprOp.Literal(Bson.Dec(10.0)))), BsonField.Name("order") -> -\/(ExprOp.Literal(Bson.Text("ASC")))))))))))), 
-        $sort(NonEmptyList(BsonField.Name("rIght") \ BsonField.Index(0) \ BsonField.Name("key") -> Ascending)), 
+        $project(Reshape.Doc(ListMap(BsonField.Name("lEft") -> \/-(Reshape.Doc(ListMap(BsonField.Name("bar") -> -\/(DocField(BsonField.Name("bar")))))), BsonField.Name("rIght") -> \/-(Reshape.Arr(ListMap(BsonField.Index(0) -> \/-(Reshape.Doc(ListMap(BsonField.Name("key") -> -\/(ExprOp.Divide(DocField(BsonField.Name("bar")), ExprOp.Literal(Bson.Dec(10.0)))), BsonField.Name("order") -> -\/(ExprOp.Literal(Bson.Text("ASC")))))))))))),
+        $sort(NonEmptyList(BsonField.Name("rIght") \ BsonField.Index(0) \ BsonField.Name("key") -> Ascending)),
         $project(Reshape.Doc(ListMap(BsonField.Name("bar") -> -\/(DocField(BsonField.Name("lEft") \ BsonField.Name("bar")))))))
 
       plan(lp) must beWorkflow(exp)


### PR DESCRIPTION
Fixes the particular query reported in #603, but not many other equally simple queries.