### PR TITLE
A number of small unrelated changes.

### DIFF
--- a/core/src/main/scala/slamdata/engine/data.scala
+++ b/core/src/main/scala/slamdata/engine/data.scala
@@ -1,22 +1,28 @@
 package slamdata.engine
 
+import scala.collection.immutable.ListMap
+
 import org.threeten.bp.{Instant, LocalDate, LocalTime, Duration}
+
+import slamdata.engine.analysis.fixplate._
+import slamdata.engine.fp._
+import slamdata.engine.javascript.Js
+import slamdata.engine.javascript.JsCore
 
 sealed trait Data {
   def dataType: Type
+  def toJs: Term[JsCore]
 }
 
 object Data {
   case object Null extends Data {
     def dataType = Type.Null
-    
-    override def toString = "Data.Null"
+    def toJs = JsCore.Literal(Js.Null).fix
   }
   
   case class Str(value: String) extends Data {
     def dataType = Type.Str
-    
-    override def toString = s"""Data.Str("$value")"""
+    def toJs = JsCore.Literal(Js.Str(value)).fix
   }
 
   sealed trait Bool extends Data {
@@ -30,10 +36,11 @@ object Data {
     }
   }
   case object True extends Bool {
-    override def toString = "Data.True"
+    def toJs = JsCore.Literal(Js.Bool(true)).fix
   }
   case object False extends Bool {
     override def toString = "Data.False"
+    def toJs = JsCore.Literal(Js.Bool(false)).fix
   }
 
   sealed trait Number extends Data
@@ -46,50 +53,59 @@ object Data {
   }
   case class Dec(value: BigDecimal) extends Number {
     def dataType = Type.Dec
-    
-    override def toString = s"Data.Dec($value)"
+    def toJs = JsCore.Literal(Js.Num(value.doubleValue, true)).fix
   }
   case class Int(value: BigInt) extends Number {
     def dataType = Type.Int
-    
-    override def toString = s"Data.Int($value)"
+    def toJs = JsCore.Literal(Js.Num(value.doubleValue, false)).fix
   }
 
   case class Obj(value: Map[String, Data]) extends Data {
     def dataType = (value.map {
       case (name, data) => Type.NamedField(name, data.dataType)
     }).foldLeft[Type](Type.Top)(_ & _)
+    def toJs =
+      JsCore.Obj(value.toList.map { case (k, v) => k -> v.toJs }.toListMap).fix
   }
 
   case class Arr(value: List[Data]) extends Data {
     def dataType = (value.zipWithIndex.map {
       case (data, index) => Type.IndexedElem(index, data.dataType)
     }).foldLeft[Type](Type.Top)(_ & _)
+    def toJs = JsCore.Arr(value.map(_.toJs)).fix
   }
 
   case class Set(value: List[Data]) extends Data {
     def dataType = (value.headOption.map { head => 
       value.drop(1).map(_.dataType).foldLeft(head.dataType)(Type.lub _)
     }).getOrElse(Type.Bottom) // TODO: ???
+    def toJs = JsCore.Arr(value.map(_.toJs)).fix
   }
 
   case class Timestamp(value: Instant) extends Data {
     def dataType = Type.Timestamp
+    def toJs = JsCore.New("Date", List(JsCore.Literal(Js.Str(value.toString)).fix)).fix
   }
 
   case class Date(value: LocalDate) extends Data {
     def dataType = Type.Date
+    def toJs = JsCore.New("Date", List(JsCore.Literal(Js.Str(value.toString)).fix)).fix
   }
 
   case class Time(value: LocalTime) extends Data {
     def dataType = Type.Time
+    def toJs = JsCore.Literal(Js.Str(value.toString)).fix
   }
 
   case class Interval(value: Duration) extends Data {
     def dataType = Type.Interval
+    def toJs = JsCore.Literal(Js.Num(value.getSeconds, true)).fix
   }
   
   case class Binary(value: Array[Byte]) extends Data {
     def dataType = Type.Binary
+    def toJs =
+      JsCore.Arr(value.toList.map(x =>
+        JsCore.Literal(Js.Num(x.doubleValue, false)).fix)).fix
   }
 }

--- a/core/src/main/scala/slamdata/engine/data.scala
+++ b/core/src/main/scala/slamdata/engine/data.scala
@@ -99,7 +99,7 @@ object Data {
 
   case class Interval(value: Duration) extends Data {
     def dataType = Type.Interval
-    def toJs = JsCore.Literal(Js.Num(value.getSeconds, true)).fix
+    def toJs = JsCore.Literal(Js.Num(value.getSeconds*1000 + value.getNano*1e-6, true)).fix
   }
   
   case class Binary(value: Array[Byte]) extends Data {

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -17,12 +17,6 @@ import monocle.syntax._
 
 sealed trait WorkflowBuilderError extends Error
 object WorkflowBuilderError {
-  case object CannotObjectConcatExpr extends WorkflowBuilderError {
-    def message = "Cannot object concat an expression"
-  }
-  case object InvalidSortBy extends WorkflowBuilderError {
-    def message = "The sort by set has an invalid structure"
-  }
   case class InvalidOperation(operation: String, msg: String)
       extends WorkflowBuilderError {
     def message = "Can not perform `" + operation + "`, because " + msg
@@ -45,10 +39,10 @@ object WorkflowBuilder {
   type Expr = ExprOp \/ JsMacro
   private def exprToJs(expr: Expr) = expr.fold(ExprOp.toJs(_), \/-(_))
   implicit def ExprRenderTree = new RenderTree[Expr] {
-      override def render(x: Expr) =
-        x.fold(
-          op => Terminal(op.toString, List("ExprBuilder", "ExprOp")),
-          js => Terminal(js(JsCore.Ident("_").fix).toJs.render(0), List("ExprBuilder", "Js")))
+    override def render(x: Expr) =
+      x.fold(
+        op => Terminal(op.toString, List("ExprOp")),
+        js => Terminal(js(JsCore.Ident("_").fix).toJs.render(0), List("Js")))
     }
 
   case class CollectionBuilderF(
@@ -194,15 +188,6 @@ object WorkflowBuilder {
       _.rewriteRefs(prefixBase(base)),
       js => base.toJs >>> js)
 
-  def chainBuilder(wb: WorkflowBuilder, base: DocVar, struct: SchemaChange)(f: WorkflowOp) =
-    toCollectionBuilder(wb).map {
-      case CollectionBuilderF(g, b, _) =>
-        CollectionBuilder(
-          Term[WorkflowF](Workflow.rewriteRefs(f(g).unFix, prefixBase(b))),
-          base,
-          struct)
-    }
-
   type EitherE[X] = Error \/ X
   type M[X] = StateT[EitherE, NameGen, X]
   type MId[X] = State[NameGen, X]
@@ -342,7 +327,8 @@ object WorkflowBuilder {
       case ArrayBuilderF(src, shape) =>
         workflow(src).flatMap { case (wf, base) =>
           commonMap(shape.zipWithIndex.map {
-            case (expr, index) => BsonField.Index(index) -> expr
+            case (expr, index) =>
+              BsonField.Index(index) -> rewriteExprPrefix(expr, base)
           }.toListMap)(ExprOp.toJs).fold(
             fail(_),
             s => emitSt(
@@ -718,18 +704,6 @@ object WorkflowBuilder {
   // TODO: handle concating value, expr, or collection with group (#439)
   def objectConcat(wb1: WorkflowBuilder, wb2: WorkflowBuilder):
       M[WorkflowBuilder] = {
-    // TODO: change this to take Maps and only fail if overlapping keys have
-    //       conflicting values
-    def unlessConflicts[A, B](a: Set[A], b: Set[A])(f: => M[B]): M[B] = {
-      val keys = a intersect b
-      if (keys.isEmpty)
-        f
-      else
-        fail(WorkflowBuilderError.InvalidOperation(
-          "objectConcat",
-          "conflicting keys: " + keys))
-    }
-
     def impl(wb1: WorkflowBuilder, wb2: WorkflowBuilder, combine: Combine): M[WorkflowBuilder] = {
       def delegate = impl(wb2, wb1, combine.flip)
 
@@ -757,21 +731,17 @@ object WorkflowBuilder {
           emit(ValueBuilder(Bson.Doc(combine(map1, map2)(_ ++ _))))
 
         case (ValueBuilderF(Bson.Doc(map1)), DocBuilderF(s2, shape2)) =>
-          unlessConflicts(map1.keySet.map(BsonField.Name(_)), shape2.keySet) {
-            emit(DocBuilder(s2,
-              combine(
-                map1.map { case (k, v) => BsonField.Name(k) -> -\/(Literal(v)) },
-                shape2)(_ ++ _)))
-          }
+          emit(DocBuilder(s2,
+            combine(
+              map1.map { case (k, v) => BsonField.Name(k) -> -\/(Literal(v)) },
+              shape2)(_ ++ _)))
         case (DocBuilderF(_, _), ValueBuilderF(Bson.Doc(_))) => delegate
 
         case (ValueBuilderF(Bson.Doc(map1)), GroupBuilderF(s1, k1, Doc(c2), id2)) =>
-          unlessConflicts(map1.keySet.map(BsonField.Name(_)), c2.keySet) {
-            val content = combine(
-              map1.map { case (k, v) => BsonField.Name(k) -> -\/(Literal(v)) },
-              c2)(_ ++ _)
-            emit(GroupBuilder(s1, k1, Doc(content), id2))
-          }
+          val content = combine(
+            map1.map { case (k, v) => BsonField.Name(k) -> -\/(Literal(v)) },
+            c2)(_ ++ _)
+          emit(GroupBuilder(s1, k1, Doc(content), id2))
         case (GroupBuilderF(_, _, Doc(_), _), ValueBuilderF(_)) => delegate
 
         case (
@@ -805,13 +775,11 @@ object WorkflowBuilder {
           DocBuilderF(Term(GroupBuilderF(s1, keys, c1, id1)), shape1),
           DocBuilderF(Term(GroupBuilderF(s2, _,    c2, id2)), shape2))
             if id1 == id2 =>
-          unlessConflicts(shape1.keySet, shape2.keySet) {
-            mergeGroups(s1, s2, c1, c2, keys, id1).flatMap {
-              case ((glbase, grbase), g) =>
-                emit(DocBuilder(g, combine(
-                  shape1 ∘ (rewriteExprPrefix(_, glbase)),
-                  shape2 ∘ (rewriteExprPrefix(_, grbase)))(_ ++ _)))
-            }
+          mergeGroups(s1, s2, c1, c2, keys, id1).flatMap {
+            case ((glbase, grbase), g) =>
+              emit(DocBuilder(g, combine(
+                shape1 ∘ (rewriteExprPrefix(_, glbase)),
+                shape2 ∘ (rewriteExprPrefix(_, grbase)))(_ ++ _)))
           }
 
         case (
@@ -839,12 +807,10 @@ object WorkflowBuilder {
           delegate
         
         case (DocBuilderF(s1, shape1), DocBuilderF(s2, shape2)) =>
-          unlessConflicts(shape1.keySet, shape2.keySet) {
-            merge(s1, s2).map { case (lbase, rbase, src) =>
-              DocBuilder(src, combine(
-                rewriteDocPrefix(shape1, lbase),
-                rewriteDocPrefix(shape2, rbase))(_ ++ _))
-            }
+          merge(s1, s2).map { case (lbase, rbase, src) =>
+            DocBuilder(src, combine(
+              rewriteDocPrefix(shape1, lbase),
+              rewriteDocPrefix(shape2, rbase))(_ ++ _))
           }
 
         case (DocBuilderF(src1, shape), ExprBuilderF(src2, expr)) =>
@@ -898,7 +864,7 @@ object WorkflowBuilder {
 
         case (ValueBuilderF(Bson.Arr(seq)), ArrayBuilderF(src, shape)) =>
           emit(ArrayBuilder(src,
-            combine(shape, seq.map(x => -\/(Literal(x))))(_ ++ _)))
+            combine(seq.map(x => -\/(Literal(x))), shape)(_ ++ _)))
         case (ArrayBuilderF(_, _), ValueBuilderF(Bson.Arr(_))) => delegate
 
         case (ArrayBuilderF(src1, shape1), ArrayBuilderF(src2, shape2)) =>
@@ -974,31 +940,38 @@ object WorkflowBuilder {
       case _ => \/-(ExprBuilder(wb, -\/(DocField(BsonField.Name(name)))))
     }
 
-  def projectIndex(wb: WorkflowBuilder, index: Int): M[WorkflowBuilder] =
+  def projectIndex(wb: WorkflowBuilder, index: Int): Error \/ WorkflowBuilder =
     wb.unFix match {
       case ValueBuilderF(Bson.Arr(elems)) =>
         if (index < elems.length) // UGH!
-          emit(ValueBuilder(elems(index)))
+          \/-(ValueBuilder(elems(index)))
         else
-          fail(WorkflowBuilderError.InvalidOperation(
+          -\/(WorkflowBuilderError.InvalidOperation(
             "projectIndex",
             "value does not contain index ‘" + index + "’."))
+      case ArrayBuilderF(wb0, elems) =>
+        if (index < elems.length) // UGH!
+          \/-(ExprBuilder(wb0, elems(index)))
+        else
+          -\/(WorkflowBuilderError.InvalidOperation(
+            "projectIndex",
+            "array does not contain index ‘" + index + "’."))
       case ValueBuilderF(_) =>
-        fail(WorkflowBuilderError.InvalidOperation(
+        -\/(WorkflowBuilderError.InvalidOperation(
           "projectIndex",
           "value is not an array."))
       case DocBuilderF(_, _) =>
-        fail(WorkflowBuilderError.InvalidOperation(
+        -\/(WorkflowBuilderError.InvalidOperation(
           "projectIndex",
           "value is not an array."))
       case ExprBuilderF(wb0, expr) =>
-        lift(exprToJs(expr).map(js =>
+        exprToJs(expr).map(js =>
           ExprBuilder(wb0,
             \/-(JsMacro(base =>
               JsCore.Access(js(base),
-                JsCore.Literal(Js.Num(index, false)).fix).fix)))))
+                JsCore.Literal(Js.Num(index, false)).fix).fix))))
       case _ =>
-        emit(ExprBuilder(wb,
+        \/-(ExprBuilder(wb,
           \/-(JsMacro(base =>
             JsCore.Access(base,
               JsCore.Literal(Js.Num(index, false)).fix).fix))))
@@ -1157,17 +1130,6 @@ object WorkflowBuilder {
   def distinctBy(src: WorkflowBuilder, keys: List[WorkflowBuilder]):
       M[WorkflowBuilder] = {
     def sortKeys(op: WorkflowBuilder): M[List[(BsonField, SortType)]] = {
-      object HavingRoot {
-        def unapply(shape: Reshape): Option[BsonField] = shape match {
-          case Reshape.Doc(map) => map.collect {
-            case (name, -\/(op)) if op == DocVar.ROOT() => name
-          }.headOption
-          case Reshape.Arr(map) => map.collect {
-            case (index, -\/(op)) if op == DocVar.ROOT() => index
-          }.headOption
-        }
-      }
-
       def isOrdered(op: Workflow): Boolean = op.unFix match {
         case $Sort(_, _)                            => true
         case $Group(_, _, _)                        => false
@@ -1184,17 +1146,14 @@ object WorkflowBuilder {
       def findSortKeys(wf: Workflow): Error \/ List[(BsonField, SortType)] =
         wf.unFix match {
           case $Sort(_, keys) => \/-(keys.list)
-          case $Project(Term($Sort(_, keys)), HavingRoot(root), _) =>
-            \/-(keys.list.map {
-              case (field, sortType) => (root \ field) -> sortType
-            })
-          case $Project(Term($Sort(_, keys)), Reshape.Doc(shape), _) =>
+          case $Project(Term($Sort(_, keys)), shape, _) =>
             keys.list.map {
               case (field, sortType) =>
-                shape.find {
-                  case (_, -\/(DocField(v))) => v == field
-                  case _                     => false
-                }.map(_._1 -> sortType)
+                Reshape.getAll(shape).collectFirst {
+                  case (k, dv @ DocVar.ROOT(prefix))
+                      if DocVar.ROOT(field).startsWith(dv) =>
+                    k \\ field.flatten.drop(prefix.fold(0)(_.flatten.length))
+                }.map(_ -> sortType)
             }.sequence.fold[Error \/ List[(BsonField, SortType)]](-\/(WorkflowBuilderError.UnsupportedDistinct("cannot distinct with missing keys: " + wf)))(\/-(_))
           case sp: ShapePreservingF[_] => findSortKeys(sp.src)
           case _ =>

--- a/core/src/main/scala/slamdata/engine/types.scala
+++ b/core/src/main/scala/slamdata/engine/types.scala
@@ -231,48 +231,50 @@ case object Type extends TypeInstances {
     case _                        => Top
   }
 
-  def typecheck(expected: Type, actual: Type): ValidationNel[TypeError, Unit] = (expected, actual) match {
-    case (expected, actual) if (expected == actual) => succeed(Unit)
+  def typecheck(superType: Type, subType: Type):
+      ValidationNel[TypeError, Unit] =
+    (superType, subType) match {
+      case (superType, subType) if (superType == subType) => succeed(Unit)
 
-    case (Top, _)    => succeed(Unit)
-    case (_, Bottom) => succeed(Unit)
+      case (Top, _)    => succeed(Unit)
+      case (_, Bottom) => succeed(Unit)
 
-    case (expected, Const(actual)) => typecheck(expected, actual.dataType)
+      case (superType, Const(subType)) => typecheck(superType, subType.dataType)
 
-    case (expected : Product, actual : Product) => typecheckPP(expected.flatten, actual.flatten)
+      case (superType : Product, subType : Product) => typecheckPP(superType.flatten, subType.flatten)
 
-    case (expected : Product, actual : Coproduct) => typecheckPC(expected.flatten, actual.flatten)
+      case (superType : Product, subType : Coproduct) => typecheckPC(superType.flatten, subType.flatten)
 
-    case (expected : Coproduct, actual : Product) => typecheckCP(expected.flatten, actual.flatten)
+      case (superType : Coproduct, subType : Product) => typecheckCP(superType.flatten, subType.flatten)
 
-    case (expected : Coproduct, actual : Coproduct) => typecheckCC(expected.flatten, actual.flatten)
+      case (superType : Coproduct, subType : Coproduct) => typecheckCC(superType.flatten, subType.flatten)
 
-    case (AnonField(expected), AnonField(actual)) => typecheck(expected, actual)
+      case (AnonField(superType), AnonField(subType)) => typecheck(superType, subType)
 
-    case (AnonField(expected), NamedField(name, actual)) => typecheck(expected, actual)
-    case (NamedField(name, expected), AnonField(actual)) => typecheck(expected, actual)
+      case (AnonField(superType), NamedField(name, subType)) => typecheck(superType, subType)
+      case (NamedField(name, superType), AnonField(subType)) => typecheck(superType, subType)
 
-    case (NamedField(name1, expected), NamedField(name2, actual)) if (name1 == name2) => typecheck(expected, actual)
+      case (NamedField(name1, superType), NamedField(name2, subType)) if (name1 == name2) => typecheck(superType, subType)
 
-    case (AnonElem(expected), AnonElem(actual)) => typecheck(expected, actual)
+      case (AnonElem(superType), AnonElem(subType)) => typecheck(superType, subType)
 
-    case (AnonElem(expected), IndexedElem(idx, actual)) => typecheck(expected, actual)
-    case (IndexedElem(idx, expected), AnonElem(actual)) => typecheck(expected, actual)
+      case (AnonElem(superType), IndexedElem(idx, subType)) => typecheck(superType, subType)
+      case (IndexedElem(idx, superType), AnonElem(subType)) => typecheck(superType, subType)
 
-    case (IndexedElem(idx1, expected), IndexedElem(idx2, actual)) if (idx1 == idx2) => typecheck(expected, actual)
+      case (IndexedElem(idx1, superType), IndexedElem(idx2, subType)) if (idx1 == idx2) => typecheck(superType, subType)
 
-    case (Set(expected), Set(actual)) => typecheck(expected, actual)
+      case (Set(superType), Set(subType)) => typecheck(superType, subType)
 
-    case (expected, actual @ Coproduct(_, _)) => typecheckPC(expected :: Nil, actual.flatten)
+      case (superType, subType @ Coproduct(_, _)) => typecheckPC(superType :: Nil, subType.flatten)
 
-    case (expected @ Coproduct(_, _), actual) => typecheckCP(expected.flatten, actual :: Nil)
+      case (superType @ Coproduct(_, _), subType) => typecheckCP(superType.flatten, subType :: Nil)
 
-    case (expected, actual @ Product(_, _)) => typecheckPP(expected :: Nil, actual.flatten)
+      case (superType, subType @ Product(_, _)) => typecheckPP(superType :: Nil, subType.flatten)
 
-    case (expected @ Product(_, _), actual) => typecheckPP(expected.flatten, actual :: Nil)
+      case (superType @ Product(_, _), subType) => typecheckPP(superType.flatten, subType :: Nil)
 
-    case _ => fail(expected, actual)
-  }
+      case _ => fail(superType, subType)
+    }
 
   def children(v: Type): List[Type] = v match {
     case Top => Nil


### PR DESCRIPTION
The intent here was to improve coverage a bit, but I found various
things along the way that maybe didn’t help with that goal. I’ll list
the changes in the order of the GitHub diff to make it easier to review
them.

* Move `Planner.convertConstant` to `Data.toJs` and implement all
  cases (no more errors);
* remove State from `projectIndex` result;
* eliminate some unused error types;
* remove now-dead `chainBuilder`;
* fix array expr rewriting when converting to `CollectionBuilder`;
* don’t error when concatted objects have conflicting keys;
* fix reversed concatting of arrays;
* add statically-known case (and tests for it) to `projectIndex`;
* eliminate `HavingRoot` and generalizes the `$sort; $project` case in
  `distinctBy`’s `findSortKeys`;
* rename the parameters to typecheck;
* modify some join tests to exercise different join types; and
* add a pending test for issue #610.