### PR TITLE
Fix projecting an index on a field in a group.

### DIFF
--- a/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -720,7 +720,7 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
           }
         case `ArrayProject` =>
           Arity2(HasWorkflow, HasInt64).flatMap {
-            case (p, index) => lift(projectIndex(p, index.toInt))
+            case (p, index) => projectIndex(p, index.toInt)
           }
         case `FlattenObject` => Arity1(HasWorkflow).map(flattenObject)
         case `FlattenArray` => Arity1(HasWorkflow).map(flattenArray)

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -528,13 +528,13 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
       }
 
       def expr1(f: ExprOp => ExprOp): Output =
-        Arity1(HasWorkflow).flatMap(wb => lift(WorkflowBuilder.expr1(wb)(f)))
+        Arity1(HasWorkflow).map(WorkflowBuilder.expr1(_)(f))
 
       def groupExpr1(f: ExprOp => ExprOp.GroupOp): Output =
         Arity1(HasWorkflow).map(reduce(_)(f))
 
       def mapExpr(p: WorkflowBuilder)(f: ExprOp => ExprOp): Output =
-        lift(WorkflowBuilder.expr1(p)(f))
+        emit(WorkflowBuilder.expr1(p)(f))
 
       def expr2(f: (ExprOp, ExprOp) => ExprOp): Output =
         Arity2(HasWorkflow, HasWorkflow).flatMap {
@@ -596,8 +596,9 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
         case `Gt`         => expr2(ExprOp.Gt.apply _)
         case `Gte`        => expr2(ExprOp.Gte.apply _)
 
-        case `IsNull`     => Arity1(HasWorkflow).flatMap(wf =>
-          lift(WorkflowBuilder.expr1(wf)(ExprOp.Eq(_, ExprOp.Literal(Bson.Null)))))
+        case `IsNull`     =>
+          Arity1(HasWorkflow).flatMap(
+            mapExpr(_)(ExprOp.Eq(_, ExprOp.Literal(Bson.Null))))
 
         case `Coalesce`   => expr2(ExprOp.IfNull.apply _)
 
@@ -620,7 +621,7 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
 
         case `ArrayLength` =>
           Arity2(HasWorkflow, HasInt64).flatMap {
-            case (p, 1)   => lift(WorkflowBuilder.expr1(p)(ExprOp.Size(_)))
+            case (p, 1)   => mapExpr(p)(ExprOp.Size(_))
             case (_, dim) => fail(FuncApply(func, "lower array dimension", dim.toString))
           }
 

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -520,27 +520,27 @@ object WorkflowBuilder {
       WorkflowBuilder =
     ShapePreservingBuilder(src, those, PartialFunction(fields => $match(sel(fields))))
 
-  def expr1(wb: WorkflowBuilder)(f: ExprOp => ExprOp):
-      Error \/ WorkflowBuilder =
+  def expr1(wb: WorkflowBuilder)(f: ExprOp => ExprOp): WorkflowBuilder =
     wb.unFix match {
       case ShapePreservingBuilderF(src, inputs, op) =>
-        expr1(src)(f).map(ShapePreservingBuilder(_, inputs, op))
+        ShapePreservingBuilder(expr1(src)(f), inputs, op)
       case GroupBuilderF(wb0, key, Expr(-\/(DocVar.ROOT(None))), id) =>
-        expr1(wb0)(f).map(GroupBuilder(_, key, Expr(-\/(DocVar.ROOT())), id))
+        GroupBuilder(expr1(wb0)(f), key, Expr(-\/(DocVar.ROOT())), id)
       case GroupBuilderF(wb0, key, Expr(-\/(expr)), id) =>
-        \/-(GroupBuilder(wb0, key, Expr(-\/(f(expr))), id))
-      case ExprBuilderF(wb0, -\/ (expr1)) =>
-        \/-(ExprBuilder(wb0, -\/(f(expr1))))
+        GroupBuilder(wb0, key, Expr(-\/(f(expr))), id)
+      case ExprBuilderF(wb0, -\/ (expr1)) => ExprBuilder(wb0, -\/(f(expr1)))
       case ExprBuilderF(wb0,  \/-(js1)) =>
-        toJs(f(DocVar.ROOT())).map(js => ExprBuilder(wb0, \/-(js1 >>> js)))
-      case _ => \/-(ExprBuilder(wb, -\/(f(DocVar.ROOT()))))
+        toJs(f(DocVar.ROOT())).fold(
+          κ(ExprBuilder(wb, -\/(f(DocVar.ROOT())))),
+          js => ExprBuilder(wb0, \/-(js1 >>> js)))
+      case _ => ExprBuilder(wb, -\/(f(DocVar.ROOT())))
     }
 
   def expr2(wb1: WorkflowBuilder, wb2: WorkflowBuilder)(f: (ExprOp, ExprOp) => ExprOp):
       M[WorkflowBuilder] =
     (wb1.unFix, wb2.unFix) match {
-      case (_, ValueBuilderF(bson)) => lift(expr1(wb1)(f(_, Literal(bson))))
-      case (ValueBuilderF(bson), _) => lift(expr1(wb2)(f(Literal(bson), _)))
+      case (_, ValueBuilderF(bson)) => emit(expr1(wb1)(f(_, Literal(bson))))
+      case (ValueBuilderF(bson), _) => emit(expr1(wb2)(f(Literal(bson), _)))
       case _ =>
         merge(wb1, wb2).map { case (lbase, rbase, src) =>
           src.unFix match {
@@ -590,6 +590,8 @@ object WorkflowBuilder {
         lift(toJs(expr1).map(js1 => ExprBuilder(wb1, \/-(js1 >>> js))))
       case ExprBuilderF(wb1,  \/-(js1)) =>
         emit(ExprBuilder(wb1, \/-(js1 >>> js)))
+      case GroupBuilderF(wb0, key, Expr(-\/(DocVar.ROOT(None))), id) =>
+        jsExpr1(wb0, js).map(GroupBuilder(_, key, Expr(-\/(DocVar.ROOT())), id))
       case GroupBuilderF(wb1, key, Expr(-\/(expr)), id) =>
         for {
           x   <- lift(toJs(expr))
@@ -865,8 +867,8 @@ object WorkflowBuilder {
   def flattenObject(wb: WorkflowBuilder): WorkflowBuilder = wb.unFix match {
     case ShapePreservingBuilderF(src, inputs, op) =>
       ShapePreservingBuilder(flattenObject(src), inputs, op)
-    case GroupBuilderF(src, keys, contents, id) =>
-      GroupBuilder(flattenObject(src), keys, contents, id)
+    case GroupBuilderF(src, keys, Expr(-\/(DocVar.ROOT(None))), id) =>
+      GroupBuilder(flattenObject(src), keys, Expr(-\/(DocVar.ROOT())), id)
     case _ => FlatteningBuilder(wb, Object, DocVar.ROOT())
   }
 
@@ -910,6 +912,9 @@ object WorkflowBuilder {
             "projectField",
             "document does not contain a field ‘" + name + "’.")))(
           expr => \/-(ExprBuilder(wb, expr)))
+      case ExprBuilderF(wb0,  \/-(js1)) =>
+        \/-(ExprBuilder(wb0,
+          \/-(JsMacro(base => DocField(BsonField.Name(name)).toJs(js1(base))))))
       case ExprBuilderF(wb, -\/(DocField(field))) =>
         \/-(ExprBuilder(wb, -\/(DocField(field \ BsonField.Name(name)))))
       case _ => \/-(ExprBuilder(wb, -\/(DocField(BsonField.Name(name)))))
@@ -917,6 +922,10 @@ object WorkflowBuilder {
 
   def projectIndex(wb: WorkflowBuilder, index: Int): Error \/ WorkflowBuilder =
     wb.unFix match {
+      case ShapePreservingBuilderF(src, inputs, op) =>
+        projectIndex(src, index).map(ShapePreservingBuilder(_, inputs, op))
+      case GroupBuilderF(wb0, key, Expr(-\/(DocVar.ROOT(None))), id) =>
+        projectIndex(wb0, index).map(GroupBuilder(_, key, Expr(-\/(DocVar.ROOT())), id))
       case ValueBuilderF(Bson.Arr(elems)) =>
         if (index < elems.length) // UGH!
           \/-(ValueBuilder(elems(index)))

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -310,13 +310,9 @@ class WorkflowBuilderSpec
 
     "group constant in proj" in {
       val read = WorkflowBuilder.read(Collection("zips"))
-      val op = (for {
-        one     <- lift(expr1(read)(κ(Literal(Bson.Int32(1)))))
-        grouped =  groupBy(one, List(one))
-        total   =  reduce(grouped)(Sum(_))
-        obj     =  makeObject(total, "total")
-        rez     <- build(obj)
-      } yield rez).evalZero
+      val one  = expr1(read)(κ(Literal(Bson.Int32(1))))
+      val obj  = makeObject(reduce(groupBy(one, List(one)))(Sum(_)), "total")
+      val op   = build(obj).evalZero
   
       op must beRightDisjOrDiff(
         chain($read(Collection("zips")),
@@ -329,11 +325,10 @@ class WorkflowBuilderSpec
   
     "group in two projs" in {
       val read = WorkflowBuilder.read(Collection("zips"))
+      val cp   = makeObject(
+        reduce(expr1(read)(κ(Literal(Bson.Int32(1)))))(Sum(_)),
+        "count")
       val op = (for {
-        one      <- lift(expr1(read)(κ(Literal(Bson.Int32(1)))))
-        count    =  reduce(one)(Sum(_))
-        cp       =  makeObject(count, "count")
-
         pop      <- lift(projectField(read, "pop"))
         total    =  reduce(pop)(Sum(_))
         tp       =  makeObject(total, "total")

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -57,7 +57,7 @@ class WorkflowBuilderSpec
       val op = (for {
         city   <- lift(projectField(read, "city"))
         array  <- arrayConcat(makeArray(city), pureArr)
-        state2 <- lift(projectIndex(array, 2))
+        state2 <- projectIndex(array, 2)
       } yield state2).evalZero
 
       op must_== expr1(read)(κ(Literal(Bson.Int32(1))))
@@ -69,7 +69,7 @@ class WorkflowBuilderSpec
         city   <- lift(projectField(read, "city"))
         state  <- lift(projectField(read, "state"))
         array  <- arrayConcat(makeArray(city), makeArray(state))
-        state2 <- lift(projectIndex(array, 1))
+        state2 <- projectIndex(array, 1)
       } yield state2).evalZero
 
       op must_== (projectField(read, "state"))
@@ -81,7 +81,7 @@ class WorkflowBuilderSpec
         city   <- lift(projectField(read, "city"))
         state  <- lift(projectField(read, "state"))
         array  <- arrayConcat(makeArray(city), makeArray(state))
-        state2 <- lift(projectIndex(array, 2))
+        state2 <- projectIndex(array, 2)
       } yield state2).evalZero
 
       op must beLeftDisj(WorkflowBuilderError.InvalidOperation(
@@ -98,7 +98,7 @@ class WorkflowBuilderSpec
 
     "project index from value" in {
       val value = pure(Bson.Arr(List(Bson.Int32(1), Bson.Int32(2))))
-      projectIndex(value, 1) must
+      projectIndex(value, 1).evalZero must
         beRightDisjOrDiff(pure(Bson.Int32(2)))
     }
 
@@ -139,8 +139,8 @@ class WorkflowBuilderSpec
 
       val read = WorkflowBuilder.read(Collection("zips"))
       val op = (for {
-        l    <- lift(projectField(read, "loc").flatMap(projectIndex(_, 1)))
-        r    <- lift(projectField(read, "enemies").flatMap(projectIndex(_, 0)))
+        l    <- lift(projectField(read, "loc")).flatMap(projectIndex(_, 1))
+        r    <- lift(projectField(read, "enemies")).flatMap(projectIndex(_, 0))
         lobj =  makeObject(l, "long")
         robj =  makeObject(r, "public enemy #1")
         merged <- objectConcat(lobj, robj)

--- a/it/src/test/resources/tests/flattenGroupedObject.test
+++ b/it/src/test/resources/tests/flattenGroupedObject.test
@@ -1,0 +1,17 @@
+{
+    "name": "flatten a grouped object with filter",
+    "data": "slamengine_commits.data",
+    "query": "select distinct commit{*}, count(*) from slamengine_commits where commit{*} like 'http%' group by committer.login",
+    "predicate": "containsAtLeast",
+    "expected": [
+        { "commit": "https://api.github.com/repos/slamdata/slamengine/git/commits/859f02befb7774aae6f7526a5a7d0a083697e4ea", "1": 9 },
+        { "commit": "https://api.github.com/repos/slamdata/slamengine/git/commits/5b54522e340244d618645ace4bd0cbb7edf8bd5b", "1": 6 },
+        { "commit": "https://api.github.com/repos/slamdata/slamengine/git/commits/472dd80e8bdffae0c1bded28a91139941433550d", "1": 6 },
+        { "commit": "https://api.github.com/repos/slamdata/slamengine/git/commits/f1b375cf28abebb32f296119dbb347e5121c3a7a", "1": 9 },
+        { "commit": "https://api.github.com/repos/slamdata/slamengine/git/commits/3e955a22e1f94205c4dfba6aa78a1c94257bb972", "1": 9 },
+        { "commit": "https://api.github.com/repos/slamdata/slamengine/git/commits/696c6ff2556bb1ea6a6de86a03736058e8f6c52a", "1": 9 },
+        { "commit": "https://api.github.com/repos/slamdata/slamengine/git/commits/b812837ee2f72be3aaee582b42e3ad901d1f7371", "1": 9 },
+        { "commit": "https://api.github.com/repos/slamdata/slamengine/git/commits/d58e3105e317ccec3c138be709af0a45ef79c66e", "1": 9 },
+        { "commit": "https://api.github.com/repos/slamdata/slamengine/git/commits/3bacb29203d499edc69f7ff2b1f5ea681411eb75", "1": 15 },
+        { "commit": "https://api.github.com/repos/slamdata/slamengine/git/commits/b29d8f254e5df2c4d1792f077625924cd1fde2db", "1": 15 }]
+}

--- a/it/src/test/resources/tests/projectIndexFromGroup.test
+++ b/it/src/test/resources/tests/projectIndexFromGroup.test
@@ -1,0 +1,16 @@
+{
+    "name": "project index from group",
+    "query": "select distinct parents[0].sha, count(parents[0].sha) as count from slamengine_commits group by parents[0].sha",
+    "predicate": "containsAtLeast",
+    "expected": [
+        { "sha": "b812837ee2f72be3aaee582b42e3ad901d1f7371", "count": 1 },
+        { "sha": "9897104b5a22571a5940f4ba2ba89addaef81ed0", "count": 1 },
+        { "sha": "3d44ce48fc0670aaf39ba1acd0e1c161f14cc2d6", "count": 1 },
+        { "sha": "82e67fef1aae1d283bff90d1d27efd4266d26d49", "count": 2 },
+        { "sha": "56d1caf5d082d1a6840090986e277d36d03f1859", "count": 4 },
+        { "sha": "b29d8f254e5df2c4d1792f077625924cd1fde2db", "count": 1 },
+        { "sha": "166f7337c8fd5db13941abf482de05accb8e9380", "count": 1 },
+        { "sha": "92245a05c6b851a97883d9276889b4f6f09fff9d", "count": 1 },
+        { "sha": "a31c0a8f2d0f771cf2aecb67c9822f930c260c29", "count": 2 },
+        { "sha": "696c6ff2556bb1ea6a6de86a03736058e8f6c52a", "count": 1 }]
+}

--- a/it/src/test/resources/tests/projectIndexFromGroupWithFilter.test
+++ b/it/src/test/resources/tests/projectIndexFromGroupWithFilter.test
@@ -1,0 +1,9 @@
+{
+    "name": "project index from group with filter",
+    "query": "select distinct parents[0].sha, count(parents[0].sha) as count from slamengine_commits where parents[0].sha like '5%' group by parents[0].sha",
+    "predicate": "containsExactly",
+    "expected": [
+        { "sha": "53d2e5684d9403194dff1cc63423c2590038d1c0", "count": 1 },
+        { "sha": "56d1caf5d082d1a6840090986e277d36d03f1859", "count": 4 },
+        { "sha": "5b54522e340244d618645ace4bd0cbb7edf8bd5b", "count": 1 }]
+}


### PR DESCRIPTION
Fixes #620.

`projectIndex` was not passing operations through GroupBuilder or
ShapePreservingBuilder, creating broken physical plans for the former
and overly-complicated ones for the latter.

Also

* make `expr1` total by allowing `ExprBuilder(ExprBuilder(…))` in the
  case of an expr that has no JS representation on top of a JS expr,
* use `mapExpr` more consistently in the planner, rather than calling
  expr1 directly,
* add a `projectField` case for JS expr that avoids stacked
  ExprBuilders (this showed up after fixing the `projectIndex` case for
  SPBs), and
* tighten up the GroupBuilder pass-though on flattenObject, since
  previously it could ruin plans.

Finally, add an integration test for the GroupBuilder fix, since the
results were previously incorrect, but only a planner test for the
ShapePreservingBuilder fix, since the results were already correct, but
the plan was just too complicated.