### PR TITLE
Some small things I noticed working on other issues.

### DIFF
--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -317,7 +317,7 @@ object WorkflowBuilder {
             CollectionBuilderF(
               chain(wf,
                 $simpleMap(JsMacro(x =>
-                  JsCore.Arr(jsExprs.map(_(x)).toList).fix))),
+                  JsCore.Arr(jsExprs.map(_(base.toJs(x))).toList).fix))),
               DocVar.ROOT(),
               None)))
         }

--- a/it/src/test/resources/tests/concatFieldAndConstant.test
+++ b/it/src/test/resources/tests/concatFieldAndConstant.test
@@ -1,0 +1,16 @@
+{
+    "name": "concat field with constant array",
+    "data": "zips.data",
+    "query": "select array_concat(make_array(pop), array_concat(make_array(1), make_array(2))) from zips",
+    "predicate": "containsAtLeast",
+    "expected": [{ "0": [15338.0, 1.0, 2.0] },
+                 { "0": [36963.0, 1.0, 2.0] },
+                 { "0": [ 4546.0, 1.0, 2.0] },
+                 { "0": [10579.0, 1.0, 2.0] },
+                 { "0": [ 1240.0, 1.0, 2.0] },
+                 { "0": [ 3706.0, 1.0, 2.0] },
+                 { "0": [ 1688.0, 1.0, 2.0] },
+                 { "0": [  177.0, 1.0, 2.0] },
+                 { "0": [23396.0, 1.0, 2.0] },
+                 { "0": [31495.0, 1.0, 2.0] }]
+}

--- a/it/src/test/resources/tests/flattenArray.test
+++ b/it/src/test/resources/tests/flattenArray.test
@@ -1,7 +1,7 @@
 {
     "name": "flatten array",
     "data": "zips.data",
-    "query": "SELECT loc[*] AS loc FROM \"/zips\" LIMIT 1",
+    "query": "SELECT loc[*] AS loc FROM zips LIMIT 1",
     "predicate": "containsExactly",
     "expected": [{ "loc" : -72.622739}]
 }

--- a/scripts/importTestData
+++ b/scripts/importTestData
@@ -23,5 +23,5 @@ TEST_DIR="$dir/../it/src/test/resources/tests"
 for f in $(find $TEST_DIR -name '*.data'); do
   coll=`expr "$f" : '.*/\(.*\)\.data'`
   echo "Loading $coll from $f..."
-  mongoimport ${import_opts[@]} --collection $coll --file $f
+  mongoimport ${import_opts[@]} --collection $coll --file $f || true
 done


### PR DESCRIPTION
* ArrayBuilders weren’t rewriting refs correctly when converting to
  Workflow, fixed that and added a test to cover it;
* fixed a test that used the wrong copy of a collection; and
* have `importTestData` try remaining collections if one fails.