### PR TITLE
handle splicing in objectConcat (fixes #497)

### DIFF
--- a/core/src/main/scala/slamdata/engine/physical/mongodb/exprop.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/exprop.scala
@@ -148,6 +148,8 @@ object ExprOp {
       case Multiply(l, r)        => binop(JsCore.Mult, l, r)
       case Neq(l, r)             => binop(JsCore.Neq, l, r)
       case Not(a)                => unop(JsCore.Not, a)
+
+      case Concat(l, r, Nil)     => binop(JsCore.Add, l, r)
       case Substr(f, start, len) =>
         (toJs(f) |@| toJs(start) |@| toJs(len))((f, s, l) =>
           JsMacro(x =>

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/optimize/optimize.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/optimize/optimize.scala
@@ -26,7 +26,7 @@ package object optimize {
         //        JS function, we need to assume they all are, until we hit the
         //        next $Group or $Project.
         case $Map(_, _, _)             => None
-        case $SimpleMap(_, _)          => None
+        case $SimpleMap(_, _, _)       => None
         case $FlatMap(_, _, _)         => None
         case $Reduce(_, _, _)          => None
         case $Project(_, _, IncludeId) => Some(refs(op).toSet + IdVar)

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -59,6 +59,16 @@ object WorkflowBuilder {
     inputs: List[A],
     op: PartialFunction[List[BsonField], WorkflowOp])
       extends WorkflowBuilderF[A]
+  {
+    import ShapePreservingBuilder._
+
+    override def equals(that: Any) = that match {
+      case that @ ShapePreservingBuilderF(src1, inputs1, op1) =>
+        src == src1 && inputs == inputs1 && dummyOp(this) == dummyOp(that)
+      case _ => false
+    }
+    override def hashCode = List(src, inputs, dummyOp(this)).hashCode
+  }
   object ShapePreservingBuilder {
     def apply(
       src: WorkflowBuilder,
@@ -66,7 +76,7 @@ object WorkflowBuilder {
       op: PartialFunction[List[BsonField], WorkflowOp]) =
       Term[WorkflowBuilderF](new ShapePreservingBuilderF(src, inputs, op))
 
-    def dummyOp(builder: ShapePreservingBuilderF[WorkflowBuilder]) =
+    def dummyOp[A](builder: ShapePreservingBuilderF[A]) =
       builder.op(
         builder.inputs.zipWithIndex.map {
           case (_, index) => BsonField.Name("_" + index)
@@ -292,7 +302,7 @@ object WorkflowBuilder {
             chain(graph,
               rewriteExprPrefix(expr, base).fold(
                 op => $project(Reshape(ListMap(name -> -\/(op)))),
-                js => $simpleMap(JsMacro(x => JsCore.Obj(ListMap(name.asText -> js(x))).fix)))),
+                js => $simpleMap(JsMacro(x => JsCore.Obj(ListMap(name.asText -> js(x))).fix), Nil))),
             DocField(name),
             None)
       }
@@ -307,7 +317,7 @@ object WorkflowBuilder {
                   jsExprs => $simpleMap(JsMacro(x =>
                     Term(JsCore.Obj(jsExprs.map {
                       case (name, expr) => name.asText -> expr(x)
-                    })))))),
+                    }))), Nil))),
               DocVar.ROOT(),
               Some(shape.toList.map(_._1.asText)))))
         }
@@ -317,7 +327,7 @@ object WorkflowBuilder {
             CollectionBuilderF(
               chain(wf,
                 $simpleMap(JsMacro(x =>
-                  JsCore.Arr(jsExprs.map(_(base.toJs(x))).toList).fix))),
+                  JsCore.Arr(jsExprs.map(_(base.toJs(x))).toList).fix), Nil)),
               DocVar.ROOT(),
               None)))
         }
@@ -416,36 +426,26 @@ object WorkflowBuilder {
             import JsCore._
             CollectionBuilderF(
               chain(graph,
-                $simpleFlatMap(Predef.identity, JsMacro((base \\ field).toJs(_)))),
+                $simpleMap(JsMacro(Predef.identity), List(JsMacro((base \\ field).toJs(_))))),
               base,
               struct)
         }
       case SpliceBuilderF(src, structure) =>
         workflow(src).flatMap { case (wf, base) =>
-          emitSt(freshId("arg")).flatMap { name =>
-            lift(structure.map {
+          lift(
+            structure.map {
               case Expr(unknown) =>
-                exprToJs(rewriteExprPrefix(unknown, base)).map(x =>
-                  List($Reduce.copyAllFields(x(JsCore.Ident(name).fix))))
+                exprToJs(rewriteExprPrefix(unknown, base))
               case Doc(known) =>
                 rewriteDocPrefix(known, base).toList.map { case (k, v) =>
-                  exprToJs(v).map(js =>
-                    $Reduce.copyOneField(
-                      JsMacro(JsCore.Select(_, k.asText).fix),
-                      js(JsCore.Ident(name).fix)))
-                }.sequenceU
-            }.sequenceU.map(lists =>
+                  exprToJs(v).map(k.asText -> _)
+                }.sequenceU.map(ms => JsMacro(x => JsCore.Obj(ms.map { case (k, v) => k -> v(x) }.toListMap).fix))
+            }.sequenceU.map(srcs =>
               CollectionBuilderF(
                 chain(wf,
-                  $map($Map.mapMap(name,
-                    Js.Call(
-                      Js.AnonFunDecl(List("rez"),
-                        lists.foldMap().map(_(JsCore.Ident("rez").fix)) :+ Js.Return(Js.Ident("rez"))),
-                      List(Js.AnonObjDecl(Nil)))),
-                    ListMap())),
+                  $simpleMap(JsMacro(x => JsCore.Splice(srcs.map(_(x))).fix), Nil)),
                 DocVar.ROOT(),
                 None)))
-          }
         }
     }
 
@@ -541,6 +541,13 @@ object WorkflowBuilder {
     (wb1.unFix, wb2.unFix) match {
       case (_, ValueBuilderF(bson)) => emit(expr1(wb1)(f(_, Literal(bson))))
       case (ValueBuilderF(bson), _) => emit(expr1(wb2)(f(Literal(bson), _)))
+      case (ExprBuilderF(src1, -\/(exprOp1)), ExprBuilderF(src2, -\/(exprOp2)))
+        if src1 == src2 => emit(ExprBuilder(src1, -\/(f(exprOp1, exprOp2))))
+      case (
+        ShapePreservingBuilderF(Term(ExprBuilderF(src1, -\/(exprOp1))), inputs1, op1),
+        ShapePreservingBuilderF(Term(ExprBuilderF(src2, -\/(exprOp2))), inputs2, op2))
+        if src1 == src2 && inputs1 == inputs2 && op1 == op2 =>
+        emit(ShapePreservingBuilder(ExprBuilder(src1, -\/(f(exprOp1, exprOp2))), inputs1, op1))
       case _ =>
         merge(wb1, wb2).map { case (lbase, rbase, src) =>
           src.unFix match {
@@ -842,6 +849,22 @@ object WorkflowBuilder {
               Expr(rewriteExprPrefix(expr1, left)),
               Expr(rewriteExprPrefix(expr2, right)))(List(_, _)))
           }
+
+        case (SpliceBuilderF(src1, structure1), DocBuilderF(src2, shape2)) =>
+          merge(src1, src2).map { case (left, right, list) =>
+            SpliceBuilder(list, combine(
+              structure1,
+              List(Doc(rewriteDocPrefix(shape2, right))))(_ ++ _))
+          }
+        case (DocBuilderF(_, _), SpliceBuilderF(_, _)) => delegate
+
+        case (SpliceBuilderF(src1, structure1), CollectionBuilderF(_, _, _)) =>
+          merge(src1, wb2).map { case (left, right, list) =>
+            SpliceBuilder(list, combine(
+              structure1,
+              List(Expr(-\/(right))))(_ ++ _))
+          }
+        case (CollectionBuilderF(_, _, _), SpliceBuilderF(_, _)) => delegate
 
         case (DocBuilderF(src, shape), _) =>
           merge(src, wb2).map { case (left, right, list) =>

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowop.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowop.scala
@@ -104,9 +104,8 @@ object Workflow {
       case x @ $Pure(_)             => G.point(x)
       case x @ $Read(_)             => G.point(x)
       case $Map(src, fn, scope)     => G.apply(f(src))($Map(_, fn, scope))
-      case $SimpleMap(src, expr)    => G.apply(f(src))($SimpleMap(_, expr))
       case $FlatMap(src, fn, scope) => G.apply(f(src))($FlatMap(_, fn, scope))
-      case $SimpleFlatMap(src, fn, expr) => G.apply(f(src))($SimpleFlatMap(_, fn, expr))
+      case $SimpleMap(src, expr, flatten) => G.apply(f(src))($SimpleMap(_, expr, flatten))
       case $Reduce(src, fn, scope)  => G.apply(f(src))($Reduce(_, fn, scope))
       case $FoldLeft(head, tail)    =>
         G.apply2(
@@ -192,11 +191,6 @@ object Workflow {
             s => chain(src0, $flatMap($FlatMap.mapCompose(fn, fn0), s)))
         case _                   => op
       }
-      case sm @ $SimpleMap(src, _) => src.unFix match {
-        case sm0 @ $SimpleMap(_, _)         => Term(sm.compose(sm0))
-        case fm @ $SimpleFlatMap(_, _, _) => Term(sm.liftCompose(fm))
-        case _                             => op
-      }
       case $FlatMap(src, fn, scope) => src.unFix match {
         case $Map(src0, fn0, scope0)     =>
           Reshape.mergeMaps(scope0, scope).fold(
@@ -208,10 +202,9 @@ object Workflow {
             $flatMap($FlatMap.kleisliCompose(fn, fn0), _)(src0))
         case _                   => op
       }
-      case fm @ $SimpleFlatMap(src, _, _) => src.unFix match {
-        case sm @ $SimpleMap(_, _)         => Term(fm.mapCompose(sm))
-        case fm0 @ $SimpleFlatMap(_, _, _) => Term(fm.kleisliCompose(fm0))
-        case _                             => op
+      case fm @ $SimpleMap(src, _, _) => src.unFix match {
+        case fm0 @ $SimpleMap(_, _, _) => Term(fm.kleisliCompose(fm0))
+        case _                         => op
       }
       case $FoldLeft(head, tail) => head.unFix match {
         case $FoldLeft(head0, tail0) =>
@@ -360,7 +353,7 @@ object Workflow {
                 $unwind(right0.field)))
           }
 
-        case ($SimpleMap(lsrc, lexpr), $SimpleMap(rsrc, rexpr)) =>
+        case ($SimpleMap(lsrc, lexpr, Nil), $SimpleMap(rsrc, rexpr, Nil)) =>
           for {
             lName <- freshName
             rName <- freshName
@@ -373,9 +366,10 @@ object Workflow {
                 $simpleMap(JsMacro(value =>
                   JsCore.Obj(ListMap(
                     lName.asText -> lexpr(lb.toJs(value)),
-                    rName.asText -> rexpr(rb.toJs(value)))).fix))))
+                    rName.asText -> rexpr(rb.toJs(value)))).fix),
+                  Nil)))
 
-        case ($SimpleMap(lsrc, lexpr), _) =>
+        case ($SimpleMap(lsrc, lexpr, lflatten), _) =>
           for {
             lName <- freshName
             rName <- freshName
@@ -385,29 +379,13 @@ object Workflow {
           } yield
             ((ExprOp.DocField(lName), ExprOp.DocField(rName)) ->
               chain(src,
-                $simpleMap(JsMacro(value =>
-                  JsCore.Obj(ListMap(
-                    lName.asText -> lexpr(lb.toJs(value)),
-                    rName.asText -> rb.toJs(value))).fix))))
-        case (_, $SimpleMap(_, _)) => delegate
-
-        case ($SimpleFlatMap(lsrc, lf, lexpr), _) =>
-          for {
-            lName <- freshName
-            rName <- freshName
-
-            t <- merge(lsrc, right)
-            ((lb, rb), src) = t
-          } yield
-            ((ExprOp.DocField(lName), ExprOp.DocField(rName)) ->
-              chain(src,
-                $simpleFlatMap(expr =>
+                $simpleMap(
                   JsMacro(value =>
                     JsCore.Obj(ListMap(
-                      lName.asText -> lf(expr)(lb.toJs(value)),
+                      lName.asText -> lexpr(lb.toJs(value)),
                       rName.asText -> rb.toJs(value))).fix),
-                  JsMacro(value => lexpr(lb.toJs(value))))))
-        case (_, $SimpleFlatMap(_, _, _)) => delegate
+                  lflatten.map(m => JsMacro(value => m(lb.toJs(value)))))))
+        case (_, $SimpleMap(_, _, _)) => delegate
 
         case (l @ $Project(lsrc, _, lx), r @ $Project(rsrc, _, rx)) =>
           merge(lsrc, rsrc).flatMap { case ((lb, rb), src) =>
@@ -728,7 +706,7 @@ object Workflow {
   def simpleShape(op: Workflow): Option[List[BsonField.Leaf]] = op.unFix match {
     case $Pure(Bson.Doc(value))             => Some(value.keys.toList.map(BsonField.Name))
     case $Project(_, Reshape(value), _) => Some(value.keys.toList)
-    case $SimpleMap(_, js) =>
+    case $SimpleMap(_, js, _) =>
       js(JsCore.Ident("_").fix).unFix match {
         case JsCore.Obj(value) => Some(value.keys.toList.map(BsonField.Name))
         case _ => None
@@ -795,14 +773,13 @@ object Workflow {
   //     affect the final shape unnecessarily.
   private def finalize0(op: Workflow): Workflow = op.unFix match {
     case mr: MapReduceF[_] => mr.src.unFix match {
-      case $Project(src, shape, _) =>
+      case $Project(src, shape, _)  =>
         shape.toJs.fold(
           _ => op.descend(finalize(_)),
-          x => finalize(mr.reparentW($simpleMap(x)(src))))
-      case uw @ $Unwind(_, _) => finalize(mr.reparentW(Term(uw.flatmapop)))
-      case sm @ $SimpleMap(_, _) => finalize(mr.reparentW(Term(sm.raw)))
-      case fm @ $SimpleFlatMap(_, _, _) => finalize(mr.reparentW(Term(fm.raw)))
-      case _ => op.descend(finalize(_))
+          x => finalize(mr.reparentW($simpleMap(x, Nil)(src))))
+      case uw @ $Unwind(_, _)       => finalize(mr.reparentW(Term(uw.flatmapop)))
+      case sm @ $SimpleMap(_, _, _) => finalize(mr.reparentW(Term(sm.raw)))
+      case _                        => op.descend(finalize(_))
     }
     case op @ $FoldLeft(head, tail) =>
       $foldLeft(
@@ -833,8 +810,7 @@ object Workflow {
     }
 
     def promoteKnownShape(wf: Workflow): Workflow = wf.unFix match {
-      case $SimpleMap(_, e)         => fixShape(e(JsCore.Ident("_").fix))
-      case $SimpleFlatMap(_, f, e)  => fixShape(f(e)(JsCore.Ident("_").fix))
+      case $SimpleMap(_, e, _)      => fixShape(e(JsCore.Ident("_").fix))
       case sp: ShapePreservingF[_]  => promoteKnownShape(sp.src)
       case _                        => finalized
     }
@@ -1004,7 +980,7 @@ object Workflow {
 
   case class $Unwind[A](src: A, field: ExprOp.DocVar)
       extends PipelineF[A]("$unwind") {
-    lazy val flatmapop = $SimpleFlatMap(src, identity, JsMacro(field.toJs(_)))
+    lazy val flatmapop = $SimpleMap(src, JsMacro(identity), List(JsMacro(field.toJs(_))))
     def reparent[B](newSrc: B) = copy(src = newSrc)
     def rhs = field.bson
   }
@@ -1177,26 +1153,53 @@ object Workflow {
 
   // FIXME: this one should become $Map, with the other one being replaced by
   // a new op that combines a map and reduce operation?
-  case class $SimpleMap[A](src: A, expr: JsMacro) extends MapReduceF[A] {
-    def fn: Js.AnonFunDecl = {
+  case class $SimpleMap[A](src: A, expr: JsMacro, flatten: List[JsMacro]) extends MapReduceF[A] {
+    private def fn: Js.AnonFunDecl = {
       import JsCore._
 
-      Js.AnonFunDecl(List("key", "value"), List(
-        Js.Return(Arr(List(
-          Ident("key").fix,
-          expr(Ident("value").fix))).fix.toJs)))
+      def body(fs: List[(Term[JsCore], JsMacro)]) =
+        Js.AnonFunDecl(List("key", "value"),
+          List(
+            Js.VarDef(List("rez" -> Js.AnonElem(Nil))),
+            fs.foldLeft[Js.Stmt](Js.Block(
+                List(
+                  Js.VarDef(List("each" -> Js.Call(Js.Ident("clone"), List(Js.Ident("value")))))) ++
+                fs.map { case (n, x) =>
+                  safeAssign(x(Ident("each").fix), Access(x(Ident("value").fix), n).fix) } ++
+                List(Call(Select(Ident("rez").fix, "push").fix,
+                  List(
+                    Arr(List(
+                      Call(Ident("ObjectId").fix, Nil).fix,
+                       expr(Ident("each").fix))).fix)).fix.toJs))) { case (inner, (n, m)) =>
+                         Js.ForIn(n.toJs.asInstanceOf[Js.Ident], m(Ident("value").fix).toJs, inner)
+                       },
+            Js.Return(Js.Ident("rez"))))
+
+      flatten match {
+        case x :: Nil => body(List(Ident("elem").fix -> x))
+        case _        => body(flatten.zipWithIndex.map { case (x, i) => Ident("elem" + i).fix -> x })
+      }
     }
 
-    def compose(f0: $SimpleMap[A]) =
-      $SimpleMap(f0.src, JsMacro(base => this.expr(f0.expr(base))))
-
-    def liftCompose(f0: $SimpleFlatMap[A]) =
-      $SimpleFlatMap(
+    def kleisliCompose(f0: $SimpleMap[A]) =
+      $SimpleMap(
         f0.src,
-        e => JsMacro(base => this.expr(f0.f(e)(base))),
-        f0.expr)
+        f0.expr >>> this.expr,
+        f0.flatten ++ this.flatten.map(f0.expr >>> _))
 
-    def raw = $Map(src, fn, ListMap())
+    def raw = {
+      import JsCore._
+
+      if (flatten.isEmpty)
+        $Map(src,
+          Js.AnonFunDecl(List("key", "value"), List(
+            Js.Return(Arr(List(
+              Ident("key").fix,
+              expr(Ident("value").fix))).fix.toJs))),
+        ListMap.empty)
+      else
+        $FlatMap(src, fn, ListMap("clone" -> Bson.JavaScript($SimpleMap.jsClone)))
+    }
 
     def newMR(base: DocVar, src: WorkflowTask, sel: Option[Selector], sort: Option[NonEmptyList[(BsonField, SortType)]], count: Option[Long]) =
       raw.newMR(base, src, sel, sort, count)
@@ -1204,61 +1207,8 @@ object Workflow {
     def reparent[B](newSrc: B) = copy(src = newSrc)
   }
   object $SimpleMap {
-    def make(expr: JsMacro)(src: Workflow): Workflow =
-      coalesce(Term($SimpleMap(src, expr)))
-  }
-  val $simpleMap = $SimpleMap.make _
-
-
-  case class $SimpleFlatMap[A](src: A, f: JsMacro => JsMacro, expr: JsMacro) extends MapReduceF[A] {
-    def fn: Js.AnonFunDecl = {
-      import JsCore._
-      Js.AnonFunDecl(List("key", "value"),
-        List(
-          Js.VarDef(List("rez" -> Js.AnonElem(Nil))),
-          Js.ForIn(Js.Ident("elem"), expr(Ident("value").fix).toJs,
-            Js.Block(List(
-              Js.VarDef(List(
-                "each" -> Js.Call(Js.Ident("clone"), List(Js.Ident("value"))))),
-              safeAssign(expr(Ident("each").fix), Access(expr(Ident("value").fix), Ident("elem").fix).fix),
-              Call(Select(Ident("rez").fix, "push").fix,
-                List(
-                  Arr(List(
-                    Call(Ident("ObjectId").fix, Nil).fix,
-                    f(JsMacro(identity))(Ident("each").fix))).fix)).fix.toJs))),
-          Js.Return(Js.Ident("rez"))))
-    }
-
-    def kleisliCompose(f0: $SimpleFlatMap[A]) =
-      $SimpleFlatMap(
-        f0.src,
-        e => this.f(JsMacro(base => this.expr(f0.f(e)(base)))),
-        f0.expr)
-
-    def mapCompose(f0: $SimpleMap[A]) =
-      $SimpleFlatMap(f0.src, e => this.f(JsMacro(base => f0.expr(e(base)))), JsMacro(base => this.expr(f0.expr(base))))
-
-    def raw =
-      $FlatMap(src, fn, ListMap(
-        "clone" -> Bson.JavaScript($SimpleFlatMap.jsClone)))
-
-    def newMR(base: DocVar, src: WorkflowTask, sel: Option[Selector], sort: Option[NonEmptyList[(BsonField, SortType)]], count: Option[Long]) =
-      raw.newMR(base, src, sel, sort, count)
-
-    def reparent[B](newSrc: B) = copy(src = newSrc)
-
-    // Need to handle equality for the mapping function
-    override def equals(that: Any) = that match {
-      case $SimpleFlatMap(src0, f0, expr0) =>
-        src == src0 &&
-          expr == expr0 &&
-          f(JsMacro(identity)) == f0(JsMacro(identity))
-      case _ => false
-    }
-  }
-  object $SimpleFlatMap {
-    def make(f: JsMacro => JsMacro, expr: JsMacro)(src: Workflow): Workflow =
-      coalesce(Term($SimpleFlatMap(src, f, expr)))
+    def make(expr: JsMacro, flatten: List[JsMacro])(src: Workflow): Workflow =
+      coalesce(Term($SimpleMap(src, expr, flatten)))
 
     val jsClone =
       Js.AnonFunDecl(List("src"), List(
@@ -1276,7 +1226,7 @@ object Workflow {
               Js.Access(Js.Ident("src"), Js.Ident("i")))))),
         Js.Return(Js.Ident("dest"))))
   }
-  val $simpleFlatMap = $SimpleFlatMap.make _
+  val $simpleMap = $SimpleMap.make _
 
   /**
     Takes a function of two parameters. The first is the current key (which
@@ -1371,25 +1321,12 @@ object Workflow {
       Js.AnonFunDecl(List("key", "values"), List(
         Js.Return(Access(Ident("values").fix, Literal(Js.Num(0, false)).fix).fix.toJs)))
 
-    def copyOneField(key: JsMacro, expr: Term[JsCore]):
-        Term[JsCore] => Js.Expr =
-      base => safeAssign(key(base), expr)
-
-    def copyAllFields(expr: Term[JsCore]): Term[JsCore] => Js.Stmt = base =>
-      Js.ForIn(Js.Ident("attr"), expr.toJs,
-        Js.If(
-          Call(Select(expr, "hasOwnProperty").fix, List(Ident("attr").fix)).fix.toJs,
-          copyOneField(
-            JsMacro(Access(_, Ident("attr").fix).fix),
-            Access(expr, Ident("attr").fix).fix)(base),
-          None))
-
     val reduceFoldLeft =
       Js.AnonFunDecl(List("key", "values"), List(
         Js.VarDef(List("rez" -> Js.AnonObjDecl(Nil))),
         Js.Call(Select(Ident("values").fix, "forEach").fix.toJs,
           List(Js.AnonFunDecl(List("value"),
-            List(copyAllFields(Ident("value").fix)(Ident("rez").fix))))),
+            List(copyAllFields(Ident("value").fix, Ident("rez").fix))))),
         Js.Return(Js.Ident("rez"))))
   }
   val $reduce = $Reduce.make _
@@ -1470,13 +1407,15 @@ object Workflow {
             Terminal((scope ∘ (_.toJs.render(2))).toString, nodeType("$Map") :+ "Scope") ::
             Nil,
           nodeType("$Map"))
-        case $SimpleMap(_, expr) => NonTerminal("", RJM.render(expr) :: Nil, nodeType("$SimpleMap"))
         case $FlatMap(_, fn, scope) => NonTerminal("",
           RJ.render(fn) ::
             Terminal((scope ∘ (_.toJs.render(2))).toString, nodeType("$Map") :+ "Scope") ::
             Nil,
           nodeType("$FlatMap"))
-        case $SimpleFlatMap(_, fn, expr) => NonTerminal("", RJM.render(fn(JsMacro(identity))) :: RJM.render(expr) :: Nil, nodeType("$SimpleFlatMap"))
+        case $SimpleMap(_, expr, flatten) => NonTerminal("",
+            RJM.render(expr).copy(nodeType = nodeType("$SimpleMap") :+ "Expr") ::
+              flatten.map(RJM.render(_).copy(nodeType = nodeType("$SimpleMap") :+ "Flatten")),
+            nodeType("$SimpleFlatMap"))
         case $Reduce(_, fn, scope) => NonTerminal("",
           RJ.render(fn) ::
             Terminal((scope ∘ (_.toJs.render(2))).toString, nodeType("$Map") :+ "Scope") ::

--- a/core/src/test/scala/slamdata/engine/javascript/jscore.scala
+++ b/core/src/test/scala/slamdata/engine/javascript/jscore.scala
@@ -112,6 +112,22 @@ class JsCoreSpecs extends Specification with TreeMatchers {
       val expr = Call(Select(Ident("value").fix, "getUTCSeconds").fix, List()).fix
       expr.toJs.render(0) must_== "((value != null) && (value.getUTCSeconds != null)) ? value.getUTCSeconds() : undefined"
     }
+    
+    "splice obj constructor" in {
+      val expr = Splice(List(Obj(ListMap("foo" -> Select(Ident("bar").fix, "baz").fix)).fix)).fix
+      expr.toJs.render(0) must_==
+        "(function (__rez) { __rez.foo = (bar != null) ? bar.baz : undefined; return __rez })(\n  {  })"
+    }
+
+    "splice other expression" in {
+      val expr = Splice(List(Ident("foo").fix)).fix
+      expr.toJs.render(0) must_==
+        """(function (__rez) {
+          |  for (var __attr in (foo)) if (foo.hasOwnProperty(__attr)) __rez[__attr] = foo[__attr];
+          |  return __rez
+          |})(
+          |  {  })""".stripMargin
+    }
   }
 
   ">>>" should {

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -216,7 +216,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         $simpleMap(JsMacro(value => Obj(ListMap(
           "loc" -> Select(value, "loc").fix,
           "__tmp0" ->
-            Access(Select(value, "loc").fix, JsCore.Literal(Js.Num(0, false)).fix).fix)).fix)),
+            Access(Select(value, "loc").fix, JsCore.Literal(Js.Num(0, false)).fix).fix)).fix), Nil),
         $match(Selector.Doc(BsonField.Name("__tmp0") -> Selector.Lt(Bson.Int64(-73)))),
         // FIXME: This match _could_ be implemented as below (without the
         //        $simpleMap) if it weren’t for Mongo’s broken index
@@ -235,7 +235,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         $read(Collection("zips")),
         $simpleMap(JsMacro(value => Obj(ListMap(
           "0" -> Access(Select(value, "loc").fix,
-            JsCore.Literal(Js.Num(0, false)).fix).fix)).fix))))
+            JsCore.Literal(Js.Num(0, false)).fix).fix)).fix), Nil)))
     }
 
     "plan array length" in {
@@ -327,7 +327,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         // FIXME: Inline this $simpleMap with the $match (#454)
         $simpleMap(JsMacro(x => Obj(ListMap(
           "__tmp0" -> Select(Select(x, "city").fix, "length").fix,
-          "__tmp1" -> x)).fix)),
+          "__tmp1" -> x)).fix), Nil),
         $match(Selector.Doc(
           BsonField.Name("__tmp0") -> Selector.Lt(Bson.Int64(4)))),
         $project(Reshape(ListMap(
@@ -343,7 +343,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         $simpleMap(JsMacro(value => Obj(ListMap(
           "__tmp4" -> Select(Select(value, "city").fix, "length").fix,
           "__tmp5" -> value,
-          "__tmp6" -> Select(value, "pop").fix)).fix)),
+          "__tmp6" -> Select(value, "pop").fix)).fix), Nil),
         $match(Selector.And(
           Selector.Doc(BsonField.Name("__tmp4") -> Selector.Lt(Bson.Int64(4))),
           Selector.Doc(BsonField.Name("__tmp6") -> Selector.Lt(Bson.Int64(20000))))),
@@ -433,7 +433,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           "__tmp6" -> Call(
             Select(New("RegExp", List(Select(x, "pattern").fix)).fix, "test").fix,
             List(Select(x, "target").fix)).fix
-        )).fix)),
+        )).fix), Nil),
         $match(
           Selector.Or(
             Selector.Doc(
@@ -482,7 +482,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
                 Access(
                   Select(x, "parents").fix,
                   JsCore.Literal(Js.Num(0, false)).fix).fix,
-                "sha").fix)).fix)),
+                "sha").fix)).fix), Nil),
           $project(Reshape(ListMap(
             BsonField.Name("__tmp0") ->
               -\/(DocField(BsonField.Name("__tmp2"))))),
@@ -549,20 +549,20 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         $read(Collection("zips")),
         $project(
           Reshape(ListMap(
-            BsonField.Name("__tmp4") ->
+            BsonField.Name("__tmp2") ->
                 -\/(ExprOp.Neq(
                   DocField(BsonField.Name("city")),
                   DocField(BsonField.Name("state")))),
-            BsonField.Name("__tmp5") -> -\/(DocVar.ROOT()),
-            BsonField.Name("__tmp6") -> -\/(DocField(BsonField.Name("pop"))))),
+            BsonField.Name("__tmp3") -> -\/(DocVar.ROOT()),
+            BsonField.Name("__tmp4") -> -\/(DocField(BsonField.Name("pop"))))),
           IgnoreId),
         $match(Selector.And(
           Selector.Doc(
-            BsonField.Name("__tmp4") -> Selector.Eq(Bson.Bool(true))),
+            BsonField.Name("__tmp2") -> Selector.Eq(Bson.Bool(true))),
           Selector.Doc(
-            BsonField.Name("__tmp6") -> Selector.Lt(Bson.Int64(10000))))),
+            BsonField.Name("__tmp4") -> Selector.Lt(Bson.Int64(10000))))),
         $project(Reshape(ListMap(
-          BsonField.Name("value") -> -\/(DocField(BsonField.Name("__tmp5"))))),
+          BsonField.Name("value") -> -\/(DocField(BsonField.Name("__tmp3"))))),
           ExcludeId)))
     }
 
@@ -623,45 +623,57 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
       plan("select *, pop from zips") must
         beWorkflow(chain(
           $read(Collection("zips")),
-          $map($Map.mapMap("__arg0",
-            Js.Call(Js.AnonFunDecl(List("rez"),
-              List(
-                Js.ForIn(Js.Ident("attr"), Ident("__arg0").fix.toJs,
-                  Js.If(
-                    Call(Select(Ident("__arg0").fix, "hasOwnProperty").fix,
-                      List(Ident("attr").fix)).fix.toJs,
-                    safeAssign(Access(Ident("rez").fix, Ident("attr").fix).fix,
-                      Access(Ident("__arg0").fix, Ident("attr").fix).fix),
-                    None)),
-                safeAssign(Select(Ident("rez").fix, "pop").fix,
-                  Select(Ident("__arg0").fix, "pop").fix),
-                Js.Return(Js.Ident("rez")))),
-              List(Js.AnonObjDecl(Nil)))),
-            ListMap())))
+          $simpleMap(JsMacro(x =>
+            Splice(List(
+              x,
+              Obj(ListMap(
+                "pop" -> Select(x, "pop").fix)).fix)).fix), Nil)))
+    }
+
+    "plan select with wildcard and two fields" in {
+      plan("select *, city as city2, pop as pop2 from zips") must
+        beWorkflow(chain(
+          $read(Collection("zips")),
+          $simpleMap(JsMacro(x =>
+            Splice(List(
+              x,
+              Obj(ListMap(
+                "city2" -> Select(x, "city").fix)).fix,
+              Obj(ListMap(
+                "pop2"  -> Select(x, "pop").fix)).fix)).fix), Nil)))
+    }
+
+    "plan select with multiple wildcards and fields" in {
+      plan("select state as state2, *, city as city2, *, pop as pop2 from zips where pop < 1000") must
+        beWorkflow(chain(
+          $read(Collection("zips")),
+          $match(Selector.Doc(
+            BsonField.Name("pop") -> Selector.Lt(Bson.Int64(1000)))),
+          $simpleMap(JsMacro(x => Obj(ListMap(
+            "__tmp0" -> Splice(List(
+              Obj(ListMap(
+                "state2" -> Select(x, "state").fix)).fix,
+              x,
+              Obj(ListMap(
+                "city2" -> Select(x, "city").fix)).fix,
+              x,
+              Obj(ListMap(
+                "pop2"  -> Select(x, "pop").fix)).fix)).fix,
+            "__tmp1" -> x)).fix), Nil),
+          $project(
+            Reshape(ListMap(
+              BsonField.Name("value") -> -\/(DocField(BsonField.Name("__tmp0"))))),
+            ExcludeId)))
     }
 
     "plan sort with wildcard and expression in key" in {
       plan("select * from zips order by pop/10 desc") must
         beWorkflow(chain(
           $read(Collection("zips")),
-          $map($Map.mapMap("__arg1",
-            Js.Call(Js.AnonFunDecl(List("rez"),
-              List(
-                Js.ForIn(Js.Ident("attr"), Ident("__arg1").fix.toJs,
-                  Js.If(
-                    Call(Select(Ident("__arg1").fix, "hasOwnProperty").fix,
-                      List(Ident("attr").fix)).fix.toJs,
-                    safeAssign(
-                      Access(Ident("rez").fix, Ident("attr").fix).fix,
-                      Access(Ident("__arg1").fix, Ident("attr").fix).fix),
-                    None)),
-                safeAssign(Select(Ident("rez").fix, "__sd__0").fix,
-                  BinOp(Div,
-                    Select(Ident("__arg1").fix, "pop").fix,
-                    JsCore.Literal(Js.Num(10, false)).fix).fix),
-                Js.Return(Js.Ident("rez")))),
-              List(Js.AnonObjDecl(Nil)))),
-            ListMap()),
+          $simpleMap(JsMacro(x => Splice(List(
+            x,
+            Obj(ListMap(
+              "__sd__0" -> BinOp(Div, Select(x, "pop").fix, JsCore.Literal(Js.Num(10, false)).fix).fix)).fix)).fix), Nil),
           $sort(NonEmptyList(BsonField.Name("__sd__0") -> Descending))))
     }
 
@@ -774,7 +786,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             $unwind(DocField(BsonField.Name("__tmp0"))),
             $simpleMap(JsMacro(x => Obj(ListMap(
               "cnt" -> Select(x, "cnt").fix,
-              "1" -> Select(Select(Select(x, "__tmp0").fix, "city").fix, "length").fix)).fix)))
+              "1" -> Select(Select(Select(x, "__tmp0").fix, "city").fix, "length").fix)).fix), Nil))
         }
     }
 
@@ -953,7 +965,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           $unwind(DocField(BsonField.Name("state"))),
           $simpleMap(JsMacro(x => Obj(ListMap(
             "state" -> Select(x, "state").fix,
-            "shortest" -> Select(Select(x, "__tmp0").fix, "length").fix)).fix))))
+            "shortest" -> Select(Select(x, "__tmp0").fix, "length").fix)).fix), Nil)))
     }
 
     "plan js expr grouped by js expr" in {
@@ -963,7 +975,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           $simpleMap(JsMacro(js =>
             Obj(ListMap(
               "__tmp0" -> Select(Select(js, "city").fix, "length").fix,
-              "__tmp1" -> js)).fix)),
+              "__tmp1" -> js)).fix), Nil),
           $group(
             Grouped(ListMap(
               BsonField.Name("len") -> Push(DocField(BsonField.Name("__tmp0"))),
@@ -979,7 +991,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           $simpleMap(JsMacro(x => Obj(ListMap(
             "0" -> BinOp(JsCore.Add,
               Select(Select(x, "city").fix, "length").fix,
-              JsCore.Literal(Js.Num(1, false)).fix).fix)).fix))))
+              JsCore.Literal(Js.Num(1, false)).fix).fix)).fix), Nil)))
     }
 
     "plan expressions with ~"in {
@@ -996,7 +1008,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               List(JsCore.Literal(Js.Str("baz")).fix)).fix,
             "3" -> Call(
               Select(New("RegExp", List(Select(x, "regex").fix)).fix, "test").fix,
-              List(Select(x, "target").fix)).fix)).fix))))
+              List(Select(x, "target").fix)).fix)).fix), Nil)))
     }
 
     "plan object flatten" in {
@@ -1004,7 +1016,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         beWorkflow {
           chain(
             $read(Collection("usa_factbook")),
-            $simpleFlatMap(Predef.identity, JsMacro(Select(_, "geo").fix)),
+            $simpleMap(JsMacro(Predef.identity), List(JsMacro(Select(_, "geo").fix))),
             $project(Reshape(ListMap(
               BsonField.Name("geo") -> -\/(DocField(BsonField.Name("geo"))))),
               IgnoreId))
@@ -1020,7 +1032,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               "city" -> JsCore.Select(value, "city").fix,
               "1" -> JsCore.Access(
                 JsCore.Select(value, "loc").fix,
-                JsCore.Literal(Js.Num(0, false)).fix).fix)).fix)))
+                JsCore.Literal(Js.Num(0, false)).fix).fix)).fix), Nil))
         }
     }
 
@@ -1339,7 +1351,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         beWorkflow(chain(
           $read(Collection("zips")),
           $simpleMap(JsMacro(x => Obj(ListMap(
-            "0" -> Select(Select(x, "city").fix, "length").fix)).fix))))
+            "0" -> Select(Select(x, "city").fix, "length").fix)).fix), Nil)))
     }
 
     "plan select length() and simple field" in {
@@ -1348,7 +1360,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         $read(Collection("zips")),
         $simpleMap(JsMacro(value => Obj(ListMap(
           "city" -> Select(value, "city").fix,
-          "1" -> Select(Select(value, "city").fix, "length").fix)).fix))))
+          "1" -> Select(Select(value, "city").fix, "length").fix)).fix), Nil)))
     }
 
     "plan combination of two distinct sets" in {
@@ -1376,23 +1388,23 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           $read(Collection("days")),
           $project(
             Reshape(ListMap(
-              BsonField.Name("__tmp4") ->
+              BsonField.Name("__tmp2") ->
                 -\/(ExprOp.Subtract(
                   DocField(BsonField.Name("date")),
                   ExprOp.Literal(Bson.Dec(12*60*60*1000)))),
-              BsonField.Name("__tmp5") -> -\/(DocVar.ROOT()))),
+              BsonField.Name("__tmp3") -> -\/(DocVar.ROOT()))),
             IgnoreId),
           $match(
             Selector.And(
               Selector.Doc(
-                BsonField.Name("__tmp5") \ BsonField.Name("date") ->
+                BsonField.Name("__tmp3") \ BsonField.Name("date") ->
                   Selector.Lt(Bson.Date(Instant.parse("2014-11-17T22:00:00Z")))),
               Selector.Doc(
-                BsonField.Name("__tmp4") ->
+                BsonField.Name("__tmp2") ->
                   Selector.Gt(Bson.Date(Instant.parse("2014-11-17T00:00:00Z")))))),
           $project(Reshape(ListMap(
             BsonField.Name("value") ->
-              -\/(DocField(BsonField.Name("__tmp5"))))),
+              -\/(DocField(BsonField.Name("__tmp3"))))),
             ExcludeId)))
     }
 
@@ -1435,12 +1447,14 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           $read(Collection("days")),
           $match(Selector.Doc(
             BsonField.Name("_id") -> Selector.Eq(Bson.ObjectId("0123456789abcdef01234567").toOption.get))),
-          $simpleMap(JsMacro(x => Obj(ListMap(
-            "__tmp0" -> Obj(ListMap(
-              "0" -> BinOp(JsCore.Lt,
-                Select(Select(x, "city").fix, "length").fix,
-                New("ObjectId", List(JsCore.Literal(Js.Str("0123456789abcdef01234567")).fix)).fix).fix)).fix,
-            "__tmp1" -> x)).fix)),
+          $simpleMap(
+            JsMacro(x => Obj(ListMap(
+              "__tmp0" -> Obj(ListMap(
+                "0" -> BinOp(JsCore.Lt,
+                  Select(Select(x, "city").fix, "length").fix,
+                  New("ObjectId", List(JsCore.Literal(Js.Str("0123456789abcdef01234567")).fix)).fix).fix)).fix,
+              "__tmp1" -> x)).fix),
+            Nil),
           $project(Reshape(ListMap(
             BsonField.Name("0") ->
               -\/(DocField(BsonField.Name("__tmp0") \ BsonField.Name("0"))))),
@@ -1569,31 +1583,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               IgnoreId),
             $unwind(DocField(BsonField.Name("left"))),
             $unwind(DocField(BsonField.Name("right"))),
-            $map(
-              Js.AnonFunDecl(List("key", "__arg1"), List(
-                Js.Return(Js.AnonElem(List(Js.Ident("key"), Js.Call(
-                  Js.AnonFunDecl(List("rez"), List(
-                    Js.ForIn(Js.Ident("attr"),
-                      Select(Ident("__arg1").fix, "left").fix.toJs,
-                      Js.If(
-                        Call(Select(Select(Ident("__arg1").fix, "left").fix,
-                          "hasOwnProperty").fix, List(Ident("attr").fix)).fix.toJs,
-                        safeAssign(
-                          Access(Ident("rez").fix, Ident("attr").fix).fix,
-                          Access(Select(Ident("__arg1").fix, "left").fix, Ident("attr").fix).fix),
-                        None)),
-                    Js.ForIn(Js.Ident("attr"),
-                      Select(Ident("__arg1").fix, "right").fix.toJs,
-                      Js.If(
-                        Call(Select(Select(Ident("__arg1").fix, "right").fix,
-                          "hasOwnProperty").fix, List(Ident("attr").fix)).fix.toJs,
-                        safeAssign(
-                          Access(Ident("rez").fix, Ident("attr").fix).fix,
-                          Access(Select(Ident("__arg1").fix, "right").fix, Ident("attr").fix).fix),
-                        None)),
-                    Js.Return(Js.Ident("rez")))),
-                  List(Js.AnonObjDecl(List())))))))),
-              ListMap()))))
+            $simpleMap(JsMacro(x => Splice(List(Select(x, "left").fix, Select(x, "right").fix)).fix), Nil))))
     }
 
     "plan simple left equi-join" in {
@@ -1706,7 +1696,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     def noConsecutiveProjectOps(wf: Workflow) =
       countOps(wf, { case $Project(Term($Project(_, _, _)), _, _) => true }) aka "the occurrences of consecutive $project ops:" must_== 0
     def noConsecutiveSimpleMapOps(wf: Workflow) =
-      countOps(wf, { case $SimpleMap(Term($SimpleMap(_, _)), _) => true }) aka "the occurrences of consecutive $simpleMap ops:" must_== 0
+      countOps(wf, { case $SimpleMap(Term($SimpleMap(_, _, _)), _, _) => true }) aka "the occurrences of consecutive $simpleMap ops:" must_== 0
     def maxGroupOps(wf: Workflow, max: Int) =
       countOps(wf, { case $Group(_, _, _) => true }) aka "the number of $group ops:" must beLessThanOrEqualTo(max)
     def maxUnwindOps(wf: Workflow, max: Int) =
@@ -1761,7 +1751,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
   def fieldNames(wf: Workflow): Option[List[String]] =
     Workflow.simpleShape(wf).map(_.map(_.asText))
 
-  import sql.{Binop => _, Ident => _,  _}
+  import sql.{Binop => _, Ident => _, Splice => _, _}
 
   val notDistinct = Gen.const(SelectAll)
   val distinct = Gen.const(SelectDistinct)
@@ -1803,7 +1793,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     InvokeFunction("min", List(x)),
     InvokeFunction("max", List(x)),
     InvokeFunction("sum", List(x)),
-    InvokeFunction("count", List(Splice(None)))))
+    InvokeFunction("count", List(sql.Splice(None)))))
   def genOuterInt = Gen.oneOf(
     Gen.const(IntLiteral(0)),
     genReduceInt,

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/workflowop.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/workflowop.scala
@@ -451,9 +451,9 @@ class WorkflowSpec extends Specification with TreeMatchers {
       import JsCore._
 
       val left = chain(readFoo,
-        $simpleMap(JsMacro(value => Select(value, "a").fix)))
+        $simpleMap(JsMacro(value => Select(value, "a").fix), Nil))
       val right = chain(readFoo,
-        $simpleMap(JsMacro(value => Select(value, "b").fix)))
+        $simpleMap(JsMacro(value => Select(value, "b").fix), Nil))
 
       val ((lb, rb), op) = merge(left, right).evalZero
 
@@ -462,9 +462,11 @@ class WorkflowSpec extends Specification with TreeMatchers {
 
       op must beTree(chain(
         readFoo,
-        $simpleMap(JsMacro(value => Obj(ListMap(
-          "__tmp0" -> Select(value, "a").fix,
-          "__tmp1" -> Select(value, "b").fix)).fix))))
+        $simpleMap(
+          JsMacro(value => Obj(ListMap(
+            "__tmp0" -> Select(value, "a").fix,
+            "__tmp1" -> Select(value, "b").fix)).fix),
+          Nil)))
     }
 
     "merge simpleMap sequence and project" in {
@@ -475,7 +477,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
           Reshape(ListMap(
             BsonField.Name("value") -> -\/(ExprOp.DocField(BsonField.Name("a"))))),
             IgnoreId),
-        $simpleMap(JsMacro(Select(_, "length").fix)),
+        $simpleMap(JsMacro(Select(_, "length").fix), Nil),
         $project(
           Reshape(ListMap(
             BsonField.Name("1") -> -\/(ExprOp.DocField(BsonField.Name("value"))))),
@@ -496,9 +498,11 @@ class WorkflowSpec extends Specification with TreeMatchers {
               BsonField.Name("value") -> -\/(ExprOp.DocField(BsonField.Name("a")))))),
             BsonField.Name("__tmp3") -> -\/(ExprOp.DocVar.ROOT()))),
           IncludeId),
-        $simpleMap(JsMacro(value => Obj(ListMap(
-          "__tmp0" -> Select(Select(value, "__tmp2").fix, "length").fix,
-          "__tmp1" -> Select(value, "__tmp3").fix)).fix)),
+        $simpleMap(
+          JsMacro(value => Obj(ListMap(
+            "__tmp0" -> Select(Select(value, "__tmp2").fix, "length").fix,
+            "__tmp1" -> Select(value, "__tmp3").fix)).fix),
+          Nil),
         $project(
           Reshape(ListMap(
             BsonField.Name("1") -> -\/(ExprOp.DocField(BsonField.Name("__tmp0") \ BsonField.Name("value"))),
@@ -514,7 +518,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
           Reshape(ListMap(
             BsonField.Name("value") -> -\/(ExprOp.DocField(BsonField.Name("a"))))),
             IgnoreId),
-        $simpleMap(JsMacro(Select(_, "length").fix)),
+        $simpleMap(JsMacro(Select(_, "length").fix), Nil),
         $project(
           Reshape(ListMap(
             BsonField.Name("1") -> -\/(ExprOp.DocField(BsonField.Name("value"))))),
@@ -531,9 +535,11 @@ class WorkflowSpec extends Specification with TreeMatchers {
               BsonField.Name("value") -> -\/(ExprOp.DocField(BsonField.Name("a")))))),
             BsonField.Name("__tmp3") -> -\/(ExprOp.DocVar.ROOT()))),
           IncludeId),
-        $simpleMap(JsMacro(value => Obj(ListMap(
-          "__tmp0" -> Select(Select(value, "__tmp2").fix, "length").fix,
-          "__tmp1" -> Select(value, "__tmp3").fix)).fix)),
+        $simpleMap(
+          JsMacro(value => Obj(ListMap(
+            "__tmp0" -> Select(Select(value, "__tmp2").fix, "length").fix,
+            "__tmp1" -> Select(value, "__tmp3").fix)).fix),
+          Nil),
         $project(
           Reshape(ListMap(
             BsonField.Name("__tmp4") -> \/-(Reshape(ListMap(
@@ -660,7 +666,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
                       Call(Ident("ObjectId").fix, Nil).fix,
                       Ident("each").fix)).fix)).fix.toJs))),
             Js.Return(Js.Ident("rez"))))),
-          ListMap("clone" -> Bson.JavaScript($SimpleFlatMap.jsClone))))
+          ListMap("clone" -> Bson.JavaScript($SimpleMap.jsClone))))
       Workflow.finalize(given) must beTree(expected)
     }
 
@@ -714,7 +720,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
                       Call(Ident("ObjectId").fix, Nil).fix,
                       Ident("each").fix)).fix)).fix.toJs))),
             Js.Return(Js.Ident("rez"))))),
-          ListMap("clone" -> Bson.JavaScript($SimpleFlatMap.jsClone))))
+          ListMap("clone" -> Bson.JavaScript($SimpleMap.jsClone))))
       Workflow.finalize(given) must beTree(expected)
     }
 
@@ -741,7 +747,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
                       Call(Ident("ObjectId").fix, Nil).fix,
                       Ident("each").fix)).fix)).fix.toJs))),
             Js.Return(Js.Ident("rez")))),
-          ListMap("clone" -> Bson.JavaScript($SimpleFlatMap.jsClone))),
+          ListMap("clone" -> Bson.JavaScript($SimpleMap.jsClone))),
         $reduce($Reduce.reduceNOP, ListMap()))
       Workflow.finalize(given) must beTree(expected)
     }
@@ -779,14 +785,18 @@ class WorkflowSpec extends Specification with TreeMatchers {
     "avoid dangling map with known shape" in {
       Workflow.finalize(chain(
         $read(Collection("zips")),
-        $simpleMap(JsMacro(base => JsCore.Obj(ListMap(
-          "first" -> JsCore.Select(base, "pop").fix,
-          "second" -> JsCore.Select(base, "city").fix)).fix)))) must
+        $simpleMap(
+          JsMacro(base => JsCore.Obj(ListMap(
+            "first" -> JsCore.Select(base, "pop").fix,
+            "second" -> JsCore.Select(base, "city").fix)).fix),
+          Nil))) must
       beTree(chain(
         $read(Collection("zips")),
-        $simpleMap(JsMacro(base => JsCore.Obj(ListMap(
-          "first" -> JsCore.Select(base, "pop").fix,
-          "second" -> JsCore.Select(base, "city").fix)).fix)),
+        $simpleMap(
+          JsMacro(base => JsCore.Obj(ListMap(
+            "first" -> JsCore.Select(base, "pop").fix,
+            "second" -> JsCore.Select(base, "city").fix)).fix),
+          Nil),
         $project(Reshape(ListMap(
           BsonField.Name("first") -> -\/(ExprOp.Include),
           BsonField.Name("second") -> -\/(ExprOp.Include))),
@@ -796,21 +806,68 @@ class WorkflowSpec extends Specification with TreeMatchers {
     "avoid dangling flatMap with known shape" in {
       Workflow.finalize(chain(
         $read(Collection("zips")),
-        $simpleFlatMap(
-          mac => JsMacro(base => JsCore.Obj(ListMap(
+        $simpleMap(
+          JsMacro(base => JsCore.Obj(ListMap(
             "first"  -> JsCore.Select(base, "loc").fix,
-            "second" -> mac(base))).fix),
-          JsMacro(base => JsCore.Select(base, "city").fix)))) must
+            "second" -> base)).fix),
+          List(JsMacro(base => JsCore.Select(base, "city").fix))))) must
       beTree(chain(
         $read(Collection("zips")),
-        $simpleFlatMap(
-          mac => JsMacro(base => JsCore.Obj(ListMap(
+        $simpleMap(
+          JsMacro(base => JsCore.Obj(ListMap(
             "first"  -> JsCore.Select(base, "loc").fix,
-            "second" -> mac(base))).fix),
-          JsMacro(base => JsCore.Select(base, "city").fix)),
+            "second" -> base)).fix),
+          List(JsMacro(base => JsCore.Select(base, "city").fix))),
         $project(Reshape(ListMap(
           BsonField.Name("first") -> -\/(ExprOp.Include),
           BsonField.Name("second") -> -\/(ExprOp.Include))),
+          IgnoreId)))
+    }
+
+    "fold unwind into SimpleMap" in {
+      import JsCore._
+
+      Workflow.finalize(chain(
+        $read(Collection("zips")),
+        $unwind(ExprOp.DocField(BsonField.Name("loc"))),
+        $simpleMap(JsMacro(x =>
+          Obj(ListMap(
+            "0" -> Select(x, "loc").fix)).fix), Nil))) must
+      beTree(chain(
+        $read(Collection("zips")),
+        $simpleMap(
+          JsMacro(x => Obj(ListMap("0" -> Select(x, "loc").fix)).fix),
+          List(JsMacro(Select(_, "loc").fix))),
+        $project(
+          Reshape(ListMap(
+            BsonField.Name("0") -> -\/(ExprOp.Include))),
+          IgnoreId)))
+    }
+
+    "fold multiple unwinds into SimpleMap" in {
+      import JsCore._
+
+      Workflow.finalize(chain(
+        $read(Collection("foo")),
+        $unwind(ExprOp.DocField(BsonField.Name("bar"))),
+        $unwind(ExprOp.DocField(BsonField.Name("baz"))),
+        $simpleMap(JsMacro(x =>
+          Obj(ListMap(
+            "0" -> Select(x, "bar").fix,
+            "1" -> Select(x, "baz").fix)).fix), Nil))) must
+      beTree(chain(
+        $read(Collection("foo")),
+        $simpleMap(
+          JsMacro(x => Obj(ListMap(
+            "0" -> Select(x, "bar").fix,
+            "1" -> Select(x, "baz").fix)).fix),
+          List(
+            JsMacro(Select(_, "bar").fix),
+            JsMacro(Select(_, "baz").fix))),
+        $project(
+          Reshape(ListMap(
+            BsonField.Name("0") -> -\/(ExprOp.Include),
+            BsonField.Name("1") -> -\/(ExprOp.Include))),
           IgnoreId)))
     }
   }
@@ -964,6 +1021,101 @@ class WorkflowSpec extends Specification with TreeMatchers {
             limit = Some(100),
             finalizer = Some($Map.finalizerFn($Map.mapMap("value",
               Js.Ident("value")))))))
+    }
+    
+    "fold unwind into SimpleMap" in {
+      import JsCore._
+
+      task(chain(
+        $read(Collection("zips")),
+        $unwind(ExprOp.DocField(BsonField.Name("loc"))),
+        $simpleMap(JsMacro(x =>
+          Obj(ListMap(
+            "0" -> Select(x, "loc").fix)).fix), Nil))) must
+      beTree[WorkflowTask](
+        PipelineTask(
+          MapReduceTask(
+            ReadTask(Collection("zips")),
+            MapReduce(
+              Js.AnonFunDecl(Nil, List(
+                Js.Call(
+                  Js.Select(
+                    Js.Call(
+                      Js.AnonFunDecl(List("key", "value"), List(
+                        Js.VarDef(List("rez" -> Js.AnonElem(Nil))),
+                        Js.ForIn(Js.Ident("elem"), JsCore.Select(Ident("value").fix, "loc").fix.toJs,
+                          Js.Block(List(
+                            Js.VarDef(List("each" -> Js.Call(Js.Ident("clone"), List(Js.Ident("value"))))),
+                            JsCore.safeAssign(Select(Ident("each").fix, "loc").fix, Access(Select(Ident("value").fix, "loc").fix, Ident("elem").fix).fix),
+                            JsCore.Call(JsCore.Select(Ident("rez").fix, "push").fix, List(
+                              Arr(List(
+                                Call(Ident("ObjectId").fix, List[Term[JsCore]]()).fix,
+                                Obj(ListMap("0" -> Select(Ident("each").fix, "loc").fix)).fix)).fix)).fix.toJs))),
+                        Js.Return(Js.Ident("rez")))),
+                      List(Js.Select(Js.This, IdLabel), Js.This)),
+                    "map"),
+                  List(
+                    Js.AnonFunDecl(List("__rez"), List(
+                      Js.Call(Js.Select(Js.Ident("emit"), "apply"), List(Js.Null, Js.Ident("__rez"))))))))),
+              $Reduce.reduceNOP,
+              scope = ListMap(
+                "clone" -> Bson.JavaScript($SimpleMap.jsClone)))),
+          List(
+            $Project((),
+              Reshape(ListMap(
+                BsonField.Name("0") -> -\/(ExprOp.DocField(BsonField.Name("value") \ BsonField.Name("0"))))),
+              IgnoreId))))
+    }
+
+    "fold multiple unwinds into SimpleMap" in {
+      import JsCore._
+
+      task(chain(
+        $read(Collection("foo")),
+        $unwind(ExprOp.DocField(BsonField.Name("bar"))),
+        $unwind(ExprOp.DocField(BsonField.Name("baz"))),
+        $simpleMap(JsMacro(x =>
+          Obj(ListMap(
+            "0" -> Select(x, "bar").fix,
+            "1" -> Select(x, "baz").fix)).fix), Nil))) must
+      beTree[WorkflowTask](
+        PipelineTask(
+          MapReduceTask(
+            ReadTask(Collection("foo")),
+            MapReduce(
+              Js.AnonFunDecl(Nil, List(
+                Js.Call(
+                  Js.Select(
+                    Js.Call(
+                      Js.AnonFunDecl(List("key", "value"), List(
+                        Js.VarDef(List("rez" -> Js.AnonElem(Nil))),
+                        Js.ForIn(Js.Ident("elem1"), JsCore.Select(Ident("value").fix, "baz").fix.toJs,
+                          Js.ForIn(Js.Ident("elem0"), JsCore.Select(Ident("value").fix, "bar").fix.toJs,
+                            Js.Block(List(
+                              Js.VarDef(List("each" -> Js.Call(Js.Ident("clone"), List(Js.Ident("value"))))),
+                              JsCore.safeAssign(Select(Ident("each").fix, "bar").fix, Access(Select(Ident("value").fix, "bar").fix, Ident("elem0").fix).fix),
+                              JsCore.safeAssign(Select(Ident("each").fix, "baz").fix, Access(Select(Ident("value").fix, "baz").fix, Ident("elem1").fix).fix),
+                              JsCore.Call(JsCore.Select(Ident("rez").fix, "push").fix, List(
+                                Arr(List(
+                                  Call(Ident("ObjectId").fix, List[Term[JsCore]]()).fix,
+                                  Obj(ListMap(
+                                    "0" -> Select(Ident("each").fix, "bar").fix,
+                                    "1" -> Select(Ident("each").fix, "baz").fix)).fix)).fix)).fix.toJs)))),
+                        Js.Return(Js.Ident("rez")))),
+                      List(Js.Select(Js.This, IdLabel), Js.This)),
+                    "map"),
+                  List(
+                    Js.AnonFunDecl(List("__rez"), List(
+                      Js.Call(Js.Select(Js.Ident("emit"), "apply"), List(Js.Null, Js.Ident("__rez"))))))))),
+              $Reduce.reduceNOP,
+              scope = ListMap(
+                "clone" -> Bson.JavaScript($SimpleMap.jsClone)))),
+          List(
+            $Project((),
+              Reshape(ListMap(
+                BsonField.Name("0") -> -\/(ExprOp.DocField(BsonField.Name("value") \ BsonField.Name("0"))),
+                BsonField.Name("1") -> -\/(ExprOp.DocField(BsonField.Name("value") \ BsonField.Name("1"))))),
+              IgnoreId))))
     }
   }
 

--- a/it/src/test/resources/tests/wildcardWithExtraProjections.test
+++ b/it/src/test/resources/tests/wildcardWithExtraProjections.test
@@ -1,0 +1,18 @@
+{
+  "name": "wildcard with additional projections (and filtering)",
+  "data": "zips.data",
+  "query": "select *, concat(city, concat(', ', state)), city = 'BOULDER' from zips where city like 'BOULDER%'",
+  "predicate": "containsExactly",
+  "expected": [
+    { "value": {  "_id": "80301", "city": "BOULDER",          "loc": [ -105.21426, 40.049733 ],  "pop": 18174.0, "state": "CO", "1": "BOULDER, CO",          "2": true  } },
+    { "value": {  "_id": "80302", "city": "BOULDER",          "loc": [ -105.285131, 40.017235 ], "pop": 29384.0, "state": "CO", "1": "BOULDER, CO",          "2": true  } },
+    { "value": {  "_id": "80303", "city": "BOULDER",          "loc": [ -105.239178, 39.991381 ], "pop": 39860.0, "state": "CO", "1": "BOULDER, CO",          "2": true  } },
+    { "value": {  "_id": "80304", "city": "BOULDER",          "loc": [ -105.277073, 40.037482 ], "pop": 21550.0, "state": "CO", "1": "BOULDER, CO",          "2": true  } },
+    { "value": {  "_id": "59632", "city": "BOULDER",          "loc": [ -112.113757, 46.230647 ], "pop": 1737.0,  "state": "MT", "1": "BOULDER, MT",          "2": true  } },
+    { "value": {  "_id": "84716", "city": "BOULDER",          "loc": [ -111.426646, 37.916606 ], "pop": 131.0,   "state": "UT", "1": "BOULDER, UT",          "2": true  } },
+    { "value": {  "_id": "82923", "city": "BOULDER",          "loc": [ -109.540105, 42.688146 ], "pop": 112.0,   "state": "WY", "1": "BOULDER, WY",          "2": true  } },
+    { "value": {  "_id": "89005", "city": "BOULDER CITY",     "loc": [ -114.834413, 35.972711 ], "pop": 12920.0, "state": "NV", "1": "BOULDER CITY, NV",     "2": false } },
+    { "value": {  "_id": "95006", "city": "BOULDER CREEK",    "loc": [ -122.133053, 37.149934 ], "pop": 9434.0,  "state": "CA", "1": "BOULDER CREEK, CA",    "2": false } },
+    { "value": {  "_id": "54512", "city": "BOULDER JUNCTION", "loc": [ -89.632454, 46.111183 ],  "pop": 563.0,   "state": "WI", "1": "BOULDER JUNCTION, WI", "2": false } }
+  ]
+}


### PR DESCRIPTION
Added a primitive `Splice` expression to JsCore, which encapsulates the
JavaScript machinery as a pure computation. This allows splicing to be
handled by SimpleMap. Also implemented the missing cases in objectConcat
for SpliceBuilders.

That resulted in Simple(Flat)Maps showing up in more places, including after
the unwinds introduced by joins, exposing the fact that successive
SimpleFlatMap ops were not composed in a sensible way. The simplest fix was
extending SimpleFlatMap to handle a list of flattened values. Since
a SimpleFlatMap with an empty list of flattened fields is equivalent to
SimpleMap, just went for it and collapsed the two ops into one, with a
potentially empty list of fields to be flattened.

The new SimpleMap is not as clean and, well, simple, as the old SimpleMap,
but it's more general than the old SimpleFlatMap, so on net it's an improvement.
We could get even more generality by making the "flattening" operation
an arbitrary expression, but it would be tricky to get equally clean, efficient JS.

Slightly improved handling of SimpleMap in the RenderTree instance, making it
more obvious what's what.

Now collapsing ExprBuilders in expr2, so the shape is more
consistent when it arrives in objectConcat. You can still get stacked
ExprBuilders in some cases, however, such as when a JS expression is built on
an ExprOp.