### PR TITLE
Fix AST rendering (many cases) and parsing (a few) (fixes #430)

### DIFF
--- a/core/src/test/scala/slamdata/engine/sql/SqlQueries.scala
+++ b/core/src/test/scala/slamdata/engine/sql/SqlQueries.scala
@@ -171,7 +171,7 @@ from
     select
       n1.n_name as supp_nation,
       n2.n_name as cust_nation,
-      extract(year from l_shipdate) as l_year,
+      date_part('year', l_shipdate) as l_year,
       l_extendedprice * (1 - l_discount) as volume
     from
       supplier,
@@ -212,7 +212,7 @@ select
 from
   (
     select
-      extract(year from o_orderdate) as o_year,
+      date_part('year', o_orderdate) as o_year,
       l_extendedprice * (1 - l_discount) as volume,
       n2.n_name as nation
     from
@@ -251,7 +251,7 @@ from
   (
     select
       n_name as nation,
-      extract(year from o_orderdate) as o_year,
+      date_part('year', o_orderdate) as o_year,
       l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
     from
       part,


### PR DESCRIPTION
Parsing fixes:

1. Accept parens around joins.
2. Allow arbitrary expressions inside `[]` and `{}`.
3. Parse numeric literals with exponents.
4. Rip out half-implemented
EXTRACT syntax.

Rendering:

1. Always surround joins with parens.
2. Escape single quotes in string
constants.
3. Quote identifiers as needed and escape double quotes in them.

This means `day` and `hour`, etc. are no longer keywords, at least until we
decide to support the awful EXTRACT syntax (see #210).

There were some parsing tests that included EXTRACT, which I just modified to
use `date_part`. As long as we have an equivalent that works, I didn't see any
point in preserving a test for the syntax we've never supported in the
compiler.