### PR TITLE
translate unrepresentable Bson/Data to new NA value (fixes #627)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val standardSettings = Defaults.defaultSettings ++ Seq(
   ),
   libraryDependencies ++= Seq(
     "org.scalaz"        %% "scalaz-core"               % scalazVersion     % "compile, test",
-    "org.scalaz"        %% "scalaz-concurrent"         % scalazVersion     % "compile, test",  
+    "org.scalaz"        %% "scalaz-concurrent"         % scalazVersion     % "compile, test",
     "org.scalaz.stream" %% "scalaz-stream"             % "0.5a"            % "compile, test",
     "org.spire-math"    %% "spire"                     % "0.8.2"           % "compile, test",
     "com.github.julien-truffaut" %% "monocle-core"     % monocleVersion    % "compile, test",
@@ -50,8 +50,7 @@ lazy val standardSettings = Defaults.defaultSettings ++ Seq(
     "org.jboss.aesh"    %  "aesh"                      % "0.55"            % "compile, test",
     "org.scalaz"        %% "scalaz-scalacheck-binding" % scalazVersion     % "compile, test",
     "com.github.julien-truffaut" %% "monocle-law"      % monocleVersion    % "compile, test",
-    "org.scalacheck"    %% "scalacheck"                % "1.10.1"          % "test",
-    "org.specs2"        %% "specs2"                    % "2.4.15"          % "test",
+    "org.specs2"        %% "specs2-core"       % "2.3.13-scalaz-7.1.0-RC1" % "test",
     "net.databinder.dispatch" %% "dispatch-core"       % "0.11.1"          % "test"
   ),
   licenses += ("GNU Affero GPL V3", url("http://www.gnu.org/licenses/agpl-3.0.html")))

--- a/core/src/main/scala/slamdata/engine/data.scala
+++ b/core/src/main/scala/slamdata/engine/data.scala
@@ -132,6 +132,12 @@ object Data {
     def toJs = JsCore.New("ObjectId", List(JsCore.Literal(Js.Str(value)).fix)).fix
   }
 
+  /**
+   An object to represent any value that might come from a backend, but that
+   we either don't know about or can't represent in this ADT. We represent it
+   with JS's `undefined`, just because no other value will ever be translated
+   that way.
+   */
   case object NA extends Data {
     def dataType = Type.Bottom
     def toJs = JsCore.Ident(Js.Undefined.ident).fix

--- a/core/src/main/scala/slamdata/engine/data.scala
+++ b/core/src/main/scala/slamdata/engine/data.scala
@@ -131,4 +131,9 @@ object Data {
     def dataType = Type.Id
     def toJs = JsCore.New("ObjectId", List(JsCore.Literal(Js.Str(value)).fix)).fix
   }
+
+  case object NA extends Data {
+    def dataType = Type.Bottom
+    def toJs = JsCore.Ident(Js.Undefined.ident).fix
+  }
 }

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/bson.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/bson.scala
@@ -52,10 +52,10 @@ object Bson {
 
       // NB: the remaining types are not easily translated back to Bson,
       // and we don't expect them to appear anyway.
-      // JavaScript/JavaScriptScope: would require parsing a string to our Js type
+      // - JavaScript/JavaScriptScope: would require parsing a string to our Js type.
+      // - Any other value that might be produced by MongoDB which is unknown to us.
 
-      // FIXME: use Error \/ Bson (see #627)
-      case _ => Text("unrecognized BSON value: " + v + " (" + v.getClass.getName + ")")
+      case _ => NA
     }
 
     loop(obj)
@@ -172,6 +172,16 @@ object Bson {
   case object MaxKey extends Bson {
     def repr = new types.MaxKey
     def toJs = Js.Ident("MaxKey")
+  }
+  /**
+   An object to represent any value that might be produced by MongoDB, but that
+   we either don't know about or can't represent in this ADT. We choose a
+   JavaScript value to represent it, so it is (semi) isomorphic with respect to
+   translation to/from the native types.
+   */
+  case object NA extends Bson {
+    def repr = JavaScript(Js.Undefined).repr
+    def toJs = Js.Undefined
   }
 }
 

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/bson.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/bson.scala
@@ -4,6 +4,7 @@ import slamdata.engine.fp._
 import slamdata.engine.javascript._
 
 import org.threeten.bp.{Instant, ZoneOffset}
+import org.threeten.bp.temporal.{ChronoUnit}
 
 import com.mongodb._
 import org.bson.types
@@ -160,10 +161,15 @@ object Bson {
     def repr = value: java.lang.Long
     def toJs = Js.Call(Js.Ident("NumberLong"), List(Js.Num(value, false)))
   }
-  case class Timestamp(instant: Instant, ordinal: Int) extends Bson {
-    def repr = new types.BSONTimestamp((instant.toEpochMilli / 1000).toInt, ordinal)
+  case class Timestamp private (epochSecond: Int, ordinal: Int) extends Bson {
+    def repr = new types.BSONTimestamp(epochSecond, ordinal)
     def toJs = Js.Call(Js.Ident("Timestamp"),
-      List(Js.Num(instant.getEpochSecond, false), Js.Num(ordinal, false)))
+      List(Js.Num(epochSecond, false), Js.Num(ordinal, false)))
+    override def toString = "Timestamp(" + Instant.ofEpochSecond(epochSecond) + ", " + ordinal + ")"
+  }
+  object Timestamp {
+    def apply(instant: Instant, ordinal: Int): Timestamp =
+      Timestamp((instant.toEpochMilli/1000).toInt, ordinal)
   }
   case object MinKey extends Bson {
     def repr = new types.MinKey

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/bsoncodec.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/bsoncodec.scala
@@ -11,9 +11,6 @@ object BsonCodec {
   case class InvalidObjectIdError(data: Data.Id) extends Error {
     def message = "Not a valid MongoDB ObjectId: " + data.value
   }
-  case class BsonConversionError(bson: Bson) extends Error {
-    def message = "BSON has no corresponding Data representation: " + bson
-  }
 
   def fromData(data: Data): InvalidObjectIdError \/ Bson = {
     data match {
@@ -46,32 +43,38 @@ object BsonCodec {
       case Data.Time(value) => {
         def pad2(x: Int) = if (x < 10) "0" + x else x.toString
         def pad3(x: Int) = if (x < 10) "00" + x else if (x < 100) "0" + x else x.toString
-        \/ right (Bson.Text(pad2(value.getHour()) + ":" + pad2(value.getMinute()) + ":" + pad2(value.getSecond()) + "." + pad3(value.getNano()/1000000)))
+        \/ right (Bson.Text(
+          pad2(value.getHour()) + ":" +
+          pad2(value.getMinute()) + ":" +
+          pad2(value.getSecond()) + "." +
+          pad3(value.getNano()/1000000)))
       }
       case Data.Interval(value) => \/ right (Bson.Dec(value.getSeconds*1000 + value.getNano*1e-6))
 
       case Data.Binary(value) => \/ right (Bson.Binary(value.toArray[Byte]))
 
       case id @ Data.Id(value) => Bson.ObjectId(value) \/> InvalidObjectIdError(id)
+
+      case Data.NA => \/ right (Bson.NA)
     }
   }
 
-  def toData(bson: Bson): BsonConversionError \/ Data = bson match {
-    case Bson.Null              => \/-(Data.Null)
-    case Bson.Text(str)         => \/-(Data.Str(str))
-    case Bson.Bool(true)        => \/-(Data.True)
-    case Bson.Bool(false)       => \/-(Data.False)
-    case Bson.Dec(value)        => \/-(Data.Dec(value))
-    case Bson.Int32(value)      => \/-(Data.Int(value))
-    case Bson.Int64(value)      => \/-(Data.Int(value))
-    case Bson.Doc(value)        => value.toList.map { case (k, v) => toData(v).map(k -> _) }.sequenceU.map(_.toListMap).map(Data.Obj.apply)
-    case Bson.Arr(value)        => value.map(toData).sequenceU.map(Data.Arr.apply)
-    case Bson.Date(value)       => \/-(Data.Timestamp(value))
-    case Bson.Binary(value)     => \/-(Data.Binary(value))
-    case oid @ Bson.ObjectId(_) => \/-(Data.Id(oid.str))
+  def toData(bson: Bson): Data = bson match {
+    case Bson.Null              => Data.Null
+    case Bson.Text(str)         => Data.Str(str)
+    case Bson.Bool(true)        => Data.True
+    case Bson.Bool(false)       => Data.False
+    case Bson.Dec(value)        => Data.Dec(value)
+    case Bson.Int32(value)      => Data.Int(value)
+    case Bson.Int64(value)      => Data.Int(value)
+    case Bson.Doc(value)        => Data.Obj(value ∘ toData)
+    case Bson.Arr(value)        => Data.Arr(value.map(toData))
+    case Bson.Date(value)       => Data.Timestamp(value)
+    case Bson.Binary(value)     => Data.Binary(value)
+    case oid @ Bson.ObjectId(_) => Data.Id(oid.str)
 
     // NB: several types have no corresponding Data representation, including
-    // MinKey, MaxKey, Regex, Timestamp, JavaScript, and JavaScriptScope
-    case _ => -\/(BsonConversionError(bson))
+    // MinKey, MaxKey, Regex, Symbol, Timestamp, JavaScript, and JavaScriptScope
+    case _                     => Data.NA
   }
 }

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/filesystem.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/filesystem.scala
@@ -34,7 +34,7 @@ sealed trait MongoDbFileSystem extends FileSystem {
             if (cursor.hasNext) {
               val obj = cursor.next
               obj.removeField("_id")
-              BsonCodec.toData(Bson.fromRepr(obj)) valueOr (err => Data.Str(err.message))
+              BsonCodec.toData(Bson.fromRepr(obj))
             }
             else throw Cause.End.asThrowable
           }

--- a/core/src/test/scala/slamdata/engine/codec.scala
+++ b/core/src/test/scala/slamdata/engine/codec.scala
@@ -58,6 +58,7 @@ class DataCodecSpecs extends Specification with ScalaCheck with DisjunctionMatch
       "encode set"       in { DataCodec.render(Data.Set(List(Data.Int(0), Data.Int(1), Data.Int(2)))) must beRightDisj("""{ "$set": [ 0, 1, 2 ] }""") }
       "encode binary"    in { DataCodec.render(Data.Binary(Array[Byte](76, 77, 78, 79))) must beRightDisj("""{ "$binary": "TE1OTw==" }""") }
       "encode objectId"  in { DataCodec.render(Data.Id("abc")) must beRightDisj("""{ "$oid": "abc" }""") }
+      "encode NA"        in { DataCodec.render(Data.NA) must beRightDisj("""{ "$na": null }""") }
     }
 
     "round-trip" ! prop { (data: Data) =>
@@ -102,6 +103,7 @@ class DataCodecSpecs extends Specification with ScalaCheck with DisjunctionMatch
       case Data.Set(_)    => false
       case Data.Binary(_) => false
       case Data.Id(_)     => false
+      case Data.NA        => false
       case _              => true
     }
 
@@ -131,6 +133,7 @@ class DataCodecSpecs extends Specification with ScalaCheck with DisjunctionMatch
       "encode set"       in { DataCodec.render(Data.Set(List(Data.Int(0), Data.Int(1), Data.Int(2)))) must beRightDisj("[ 0, 1, 2 ]") }
       "encode binary"    in { DataCodec.render(Data.Binary(Array[Byte](76, 77, 78, 79))) must beRightDisj("\"TE1OTw==\"") }
       "encode objectId"  in { DataCodec.render(Data.Id("abc")) must beRightDisj("\"abc\"") }
+      "encode NA"        in { DataCodec.render(Data.NA) must beRightDisj("\"NA\"") }
     }
 
     "round-trip" ! prop { (data: Data) =>
@@ -206,6 +209,7 @@ class DataCodecSpecs extends Specification with ScalaCheck with DisjunctionMatch
       Data.Time(LocalTime.now),
       Data.Binary(Array[Byte](0, 1, 2, 3)),
       Data.Id("012345678901234567890123"),  // NB: a (nominally) valid MongoDB id, because we use this generator to test BSON conversion, too
+      Data.NA,
 
       // Tricky cases:
       LargeInt,

--- a/core/src/test/scala/slamdata/engine/compiler.scala
+++ b/core/src/test/scala/slamdata/engine/compiler.scala
@@ -9,7 +9,6 @@ import org.specs2.mutable._
 import org.specs2.matcher.{Matcher, Expectable}
 import slamdata.specs2._
 
-@org.junit.runner.RunWith(classOf[org.specs2.runner.JUnitRunner])
 class CompilerSpec extends Specification with CompilerHelpers with PendingWithAccurateCoverage with DisjunctionMatchers {
   import StdLib._
   import agg._

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/bson.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/bson.scala
@@ -94,7 +94,7 @@ object BsonGen {
     listOf(arbitrary[Byte]).map(bytes => Binary(bytes.toArray)),
     listOfN(12, arbitrary[Byte]).map(bytes => ObjectId(bytes.toArray)),
     const(Date(Instant.now)),
-    // const(Timestamp(Instant.now, 0)),  // FIXME: round to nearest second?
+    const(Timestamp(Instant.now, 0)),
     const(Regex("a.*")),
     const(JavaScript(Js.Null)),
     const(JavaScriptScope(Js.Null, Doc(ListMap.empty))),

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/bson.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/bson.scala
@@ -1,0 +1,114 @@
+package slamdata.engine.physical.mongodb
+
+import org.specs2.mutable._
+import org.specs2.ScalaCheck
+import scala.collection.immutable.ListMap
+
+import scalaz._
+import Scalaz._
+
+import org.threeten.bp._
+
+import slamdata.engine._
+import slamdata.engine.fp._
+import slamdata.engine.javascript._
+
+class BsonSpecs extends Specification with ScalaCheck {
+  import Bson._
+
+  "fromRepr" should {
+    "handle partially invalid object" in {
+      val native = Doc(ListMap(
+        "a" -> Int32(0),
+        "b" -> JavaScript(Js.Null))).repr
+
+      fromRepr(native) must_==
+        Doc(ListMap(
+          "a" -> Int32(0),
+          "b" -> NA))
+    }
+
+    "preserve NA" in {
+      val b = Doc(ListMap("a" -> NA))
+
+      fromRepr(b.repr) must_== b
+    }
+
+    "handle completely unexpected object" in {
+      // Simulating a type MongoDB uses that we know nothing about:
+      class Foo
+
+      val native = new com.mongodb.BasicDBObject()
+      native.put("a", new Foo())
+
+      Bson.fromRepr(native) must_== Doc(ListMap("a" -> NA))
+    }
+
+    import BsonGen._
+
+    "be (fully) isomorphic for representable types" ! org.scalacheck.Arbitrary(simpleGen) { (bson: Bson) =>
+      val representable = bson match {
+        case JavaScript(_)         => false
+        case JavaScriptScope(_, _) => false
+        case `NA`                  => false
+        case _ => true
+      }
+
+      val wrapped = Doc(ListMap("value" -> bson))
+
+      if (representable)
+        fromRepr(wrapped.repr) must_== wrapped
+      else
+        fromRepr(wrapped.repr) must_== Doc(ListMap("value" -> NA))
+    }
+
+    "be 'semi' isomorphic for all types" ! prop { (bson: Bson) =>
+      val wrapped = Doc(ListMap("value" -> bson)).repr
+
+      // (fromRepr >=> repr >=> fromRepr) == fromRepr
+      fromRepr(fromRepr(wrapped).repr.asInstanceOf[com.mongodb.DBObject]) must_== fromRepr(wrapped)
+    }
+  }
+}
+
+object BsonGen {
+  import org.scalacheck._
+  import Gen._
+  import Arbitrary._
+
+  import Bson._
+
+  implicit val arbBson: Arbitrary[Bson] = Arbitrary(Gen.oneOf(
+    simpleGen,
+    resize(5, objGen),
+    resize(5, arrGen)))
+
+  val simpleGen = oneOf(
+    const(Null),
+    const(Bool(true)),
+    const(Bool(false)),
+    resize(20, arbitrary[String]).map(Text.apply),
+    arbitrary[Int].map(Int32.apply),
+    arbitrary[Long].map(Int64.apply),
+    arbitrary[Double].map(Dec.apply),
+    listOf(arbitrary[Byte]).map(bytes => Binary(bytes.toArray)),
+    listOfN(12, arbitrary[Byte]).map(bytes => ObjectId(bytes.toArray)),
+    const(Date(Instant.now)),
+    // const(Timestamp(Instant.now, 0)),  // FIXME: round to nearest second?
+    const(Regex("a.*")),
+    const(JavaScript(Js.Null)),
+    const(JavaScriptScope(Js.Null, Doc(ListMap.empty))),
+    resize(5, arbitrary[String]).map(Symbol.apply),
+    const(MinKey),
+    const(MaxKey),
+    const(NA))
+
+  val objGen = for {
+    pairs <- listOf(for {
+      n <- resize(5, alphaStr)
+      v <- simpleGen
+    } yield n -> v)
+  } yield Doc(pairs.toListMap)
+
+  val arrGen = listOf(simpleGen).map(Arr.apply)
+}

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/bsoncodec.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/bsoncodec.scala
@@ -2,21 +2,73 @@ package slamdata.engine.physical.mongodb
 
 import org.specs2.mutable._
 import org.specs2.ScalaCheck
+
 import scala.collection.immutable.ListMap
+
+import scalaz._
+import Scalaz._
 
 import slamdata.engine._
 import slamdata.engine.fp._
 
 class BsonCodecSpecs extends Specification with ScalaCheck with DisjunctionMatchers {
+  import BsonCodec._
+
+  import DataGen._
+  import BsonGen._
+
+  implicit val ShowData = new Show[Data] {
+    override def show(v: Data) = Cord(v.toString)
+  }
+  implicit val ShowBson = new Show[Bson] {
+    override def show(v: Bson) = Cord(v.toString)
+  }
+
   "fromData" should {
     "fail with bad Id" in {
-      BsonCodec.fromData(Data.Id("invalid")) must beAnyLeftDisj
+      fromData(Data.Id("invalid")) must beAnyLeftDisj
+    }
+
+    "be isomorphic for preserved values" ! prop { (data: Data) =>
+      // (fromData >=> toData) == identity, except for values that are known not to be preserved
+
+      import Data._
+
+      val preserved = data match {
+        case Int(x)      => x.isValidLong
+        case Interval(_) => false
+        case Date(_)     => false
+        case Time(_)     => false
+        case Set(_)      => false
+        case _ => true
+      }
+
+      preserved ==> {
+        fromData(data).map(toData) must beRightDisj(data)
+      }
+    }
+
+    "be 'semi'-isomorphic for all Bson values" ! prop { (bson: Bson) =>
+      // (toData >=> fromData >=> toData) == toData
+
+      val data = toData(bson)
+      fromData(data).map(toData _) must beRightDisj(data)
     }
   }
 
   "toData" should {
-    "fail with MinKey" in {
-      BsonCodec.toData(Bson.MinKey) must beAnyLeftDisj
+    "convert MinKey to NA" in {
+      toData(Bson.MinKey) must_== Data.NA
+    }
+
+    "be 'semi'-isomorphic for all Data values" ! prop { (data: Data) =>
+      // (fromData >=> toData >=> fromData) == fromData
+      // Which is to say, every Bson value that results from conversion
+      // can be converted to Data and back to Bson, recovering the same
+      // Bson value.
+      fromData(data).fold(
+        err => sys.error(err.toString),
+        bson => fromData(toData(bson)) must beRightDisj(bson))
     }
   }
 

--- a/core/src/test/scala/slamdata/engine/semantics.scala
+++ b/core/src/test/scala/slamdata/engine/semantics.scala
@@ -9,7 +9,6 @@ import org.specs2.mutable._
 import org.specs2.matcher.{Matcher, Expectable}
 import slamdata.specs2._
 
-@org.junit.runner.RunWith(classOf[org.specs2.runner.JUnitRunner])
 class SemanticsSpec extends Specification with PendingWithAccurateCoverage {
 
   "TransformSelect" should {

--- a/core/src/test/scala/slamdata/engine/types.scala
+++ b/core/src/test/scala/slamdata/engine/types.scala
@@ -7,7 +7,6 @@ import scalaz.Validation.{success, failure}
 import scalaz.Monad
 import slamdata.specs2._
 
-@org.junit.runner.RunWith(classOf[org.specs2.runner.JUnitRunner])
 class TypesSpec extends Specification with ScalaCheck with PendingWithAccurateCoverage {
   import Type._
   import SemanticError._


### PR DESCRIPTION
This seemed the simplest, most practical approach. It protects slamdata from any unexpected values we might find in MongoDB, while not propagating complex error handling (i.e. functorization). I'm happy with this approach, at least for now, because although it might be nice to record the error that occurred and where, realistically I don't think we would do anything with that detail at this point.

There's a new value in each of Bson and Data which stands in for any unrepresentable value coming from the backend. Because the value can appear anywhere, it allows the rest of the structure of any result to be preserved even when some fields contain values we can't use.

Wrote a scalacheck generator for Bson values, and a number of tests of the reversibility of translation. This also turned up a problem with the semantics of Bson.Timestamp, which is fixed here.

Questions:

I don't like the name `NA`, but couldn't think of anything better that's reasonably succinct. Maybe `NotRepresentable`, `Unknown` or `Invalid`?

I had to choose a representation for each NA value when translating to Bson and JavaScript, although we should never actually generate these values. It seemed sensible to choose something that would translate back to NA, so I just used `Bson.Javascript(Js.Undefined)`, because all BSON JavaScript values become NA when translated back to Bson. It's less clear that this makes any sense for `Data.NA`, but I used it anyway for consistency.

