### PR TITLE
array splicing, and `||` and `[]` syntax for arrays and strings (fixes #600)

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -12,7 +12,7 @@ import ScoverageSbtPlugin._
 
 ScoverageKeys.coverageExcludedPackages := "slamdata.engine.repl;.*RenderTree"
 
-ScoverageKeys.coverageMinimum := 72
+ScoverageKeys.coverageMinimum := 75
 
 ScoverageKeys.coverageFailOnMinimum := true
 

--- a/core/src/main/scala/slamdata/engine/data.scala
+++ b/core/src/main/scala/slamdata/engine/data.scala
@@ -74,9 +74,13 @@ object Data {
   }
 
   case class Arr(value: List[Data]) extends Data {
-    def dataType = (value.zipWithIndex.map {
-      case (data, index) => Type.IndexedElem(index, data.dataType)
-    }).foldLeft[Type](Type.Top)(_ & _)
+    def dataType =
+      // NB: an empty array constant should have an arrayLike type, but no element has any inhabited type
+      if (value.isEmpty) Type.AnonElem(Type.Bottom)
+      else
+        (value.zipWithIndex.map {
+          case (data, index) => Type.IndexedElem(index, data.dataType)
+        }).foldLeft[Type](Type.Top)(_ & _)
     def toJs = JsCore.Arr(value.map(_.toJs)).fix
   }
 

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowop.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowop.scala
@@ -1431,7 +1431,7 @@ object Workflow {
             RJM.render(expr).copy(nodeType = nodeType("$SimpleMap") :+ "Expr") ::
               (flatten.map(RJM.render(_).copy(nodeType = nodeType("$SimpleMap") :+ "Flatten")) :+
                 Terminal((scope ∘ (_.toJs.render(2))).toString, nodeType("$SimpleMap") :+ "Scope")),
-            nodeType("$SimpleFlatMap"))
+            nodeType("$SimpleMap"))
         case $Reduce(_, fn, scope) => NonTerminal("",
           RJ.render(fn) ::
             Terminal((scope ∘ (_.toJs.render(2))).toString, nodeType("$Map") :+ "Scope") ::

--- a/core/src/test/scala/slamdata/engine/javascript/jscore.scala
+++ b/core/src/test/scala/slamdata/engine/javascript/jscore.scala
@@ -114,19 +114,33 @@ class JsCoreSpecs extends Specification with TreeMatchers {
     }
 
     "splice obj constructor" in {
-      val expr = Splice(List(Obj(ListMap("foo" -> Select(Ident("bar").fix, "baz").fix)).fix)).fix
+      val expr = SpliceObjects(List(Obj(ListMap("foo" -> Select(Ident("bar").fix, "baz").fix)).fix)).fix
       expr.toJs.render(0) must_==
         "(function (__rez) { __rez.foo = (bar != null) ? bar.baz : undefined; return __rez })(\n  {  })"
     }
 
     "splice other expression" in {
-      val expr = Splice(List(Ident("foo").fix)).fix
+      val expr = SpliceObjects(List(Ident("foo").fix)).fix
       expr.toJs.render(0) must_==
         """(function (__rez) {
           |  for (var __attr in (foo)) if (foo.hasOwnProperty(__attr)) __rez[__attr] = foo[__attr];
           |  return __rez
           |})(
           |  {  })""".stripMargin
+    }
+
+    "splice arrays" in {
+      val expr = SpliceArrays(List(
+        Arr(List(
+          Select(Ident("foo").fix, "bar").fix)).fix,
+        Ident("foo").fix)).fix
+      expr.toJs.render(0) must_==
+      """(function (__rez) {
+        |  __rez.push((foo != null) ? foo.bar : undefined);
+        |  for (var __elem in (foo)) if (foo.hasOwnProperty(__elem)) __rez.push(foo[__elem]);
+        |  return __rez
+        |})(
+        |  [])""".stripMargin
     }
   }
 

--- a/core/src/test/scala/slamdata/engine/sql/SqlParserSpec.scala
+++ b/core/src/test/scala/slamdata/engine/sql/SqlParserSpec.scala
@@ -178,7 +178,7 @@ class SQLParserSpec extends Specification with ScalaCheck with DisjunctionMatche
 
     "parse nested joins with parens" in {
       val q = "select * from a cross join (b cross join c)"
-     parser.parse(q) must beRightDisj(
+      parser.parse(q) must beRightDisj(
         SelectStmt(
           SelectAll,
           List(Proj.Anon(Splice(None))),
@@ -188,6 +188,19 @@ class SQLParserSpec extends Specification with ScalaCheck with DisjunctionMatche
               CrossRelation(
                 TableRelationAST("b", None),
                 TableRelationAST("c", None)))),
+          None, None, None, None, None))
+    }
+
+    "parse array constructor and concat op" in {
+      parser.parse("select loc || [ pop ] from zips") must beRightDisj(
+        SelectStmt(SelectAll,
+          List(
+            Proj.Anon(
+              Binop(Ident("loc"),
+                ArrayLiteral(List(
+                  Ident("pop"))),
+                Concat))),
+          Some(TableRelationAST("zips", None)),
           None, None, None, None, None))
     }
 

--- a/core/src/test/scala/slamdata/engine/std/math.scala
+++ b/core/src/test/scala/slamdata/engine/std/math.scala
@@ -40,8 +40,18 @@ class MathSpec extends Specification with ScalaCheck with ValidationMatchers wit
       expr should beSuccess(Type.Dec)
     }
 
-    "type simple add with Numeric" in {
-      val expr = Divide(Type.Numeric, Const(Int(0)))
+    "type simple add with Int, Top" in {
+      val expr = Add(Type.Int, Type.Top)
+      expr should beSuccess(Type.Numeric)
+    }.pendingUntilFixed
+
+    "type simple add with int constant, Top" in {
+      val expr = Add(Type.Const(Int(0)), Type.Top)
+      expr should beSuccess(Type.Numeric)
+    }.pendingUntilFixed
+
+    "type simple add with zero" in {
+      val expr = Add(Type.Numeric, Const(Int(0)))
       expr should beSuccess(Type.Numeric)
     }
 

--- a/core/src/test/scala/slamdata/engine/std/structural.scala
+++ b/core/src/test/scala/slamdata/engine/std/structural.scala
@@ -1,0 +1,83 @@
+package slamdata.engine.std
+
+import org.specs2.mutable._
+import org.specs2.ScalaCheck
+
+import slamdata.engine._
+
+class StructuralSpecs extends Specification with ScalaCheck with ValidationMatchers {
+  import slamdata.engine.Type._
+
+  import StructuralLib._
+
+  import DataGen._
+  import TypeGen._
+
+  "ConcatOp" should {
+    // NB: the func's domain is the type assigned to any argument if nothing
+    // else is known about it.
+    val unknown = ConcatOp.domain.head
+
+    "type combination of arbitrary strs as str" ! (arbStrType, arbStrType) { (st1: Type, st2: Type) =>
+      ConcatOp(st1, st2).map(Str contains _) must beSuccess(true)
+      ConcatOp(st2, st1).map(Str contains _) must beSuccess(true)
+    }
+
+    "type arbitrary str || unknown as Str" ! arbStrType { (st: Type) =>
+      ConcatOp(st, unknown) must beSuccess(Str)
+      ConcatOp(unknown, st) must beSuccess(Str)
+    }
+
+    "fold constant Strings" ! prop { (s1: String, s2: String) =>
+      ConcatOp(Const(Data.Str(s1)), Const(Data.Str(s2))) must
+        beSuccess(Const(Data.Str(s1 + s2)))
+    }
+
+    "type combination of arbitrary arrays as array" ! (arbArrayType, arbArrayType) { (at1: Type, at2: Type) =>
+      ConcatOp(at1, at2).map(_.arrayLike) must beSuccess(true)
+      ConcatOp(at2, at1).map(_.arrayLike) must beSuccess(true)
+    }
+
+    "type arbitrary array || unknown as array" ! arbArrayType { (at: Type) =>
+      ConcatOp(at, unknown).map(_.arrayLike) must beSuccess(true)
+      ConcatOp(unknown, at).map(_.arrayLike) must beSuccess(true)
+    }
+
+    "fold constant arrays" ! prop { (ds1: List[Data], ds2: List[Data]) =>
+      ConcatOp(Const(Data.Arr(ds1)), Const(Data.Arr(ds2))) must
+        beSuccess(Const(Data.Arr(ds1 ++ ds2)))
+    }
+
+    "fail with mixed Str and array args" ! (arbStrType, arbArrayType) { (st: Type, at: Type) =>
+      ConcatOp(st, at) must beFailure
+      ConcatOp(at, st) must beFailure
+    }
+
+    "propagate unknown types" in {
+      ConcatOp(unknown, unknown) must beSuccess(unknown)
+    }
+
+    import org.scalacheck.Gen, Gen._
+    import org.scalacheck.Arbitrary, Arbitrary._
+    lazy val arbStrType = Arbitrary(Gen.oneOf(
+      const(Str),
+      arbitrary[String].map(s => Const(Data.Str(s)))))
+
+    lazy val arbArrayType = Arbitrary(Gen.oneOf(
+      simpleArrayGen,
+      for {
+        ts <- resize(5, nonEmptyListOf(simpleArrayGen))
+      } yield Product(ts)))
+    lazy val simpleArrayGen = Gen.oneOf(
+      for {
+        t <- arbitrary[Type]
+      } yield AnonElem(t),
+      for {
+        i <- posNum[Int]
+        t <- arbitrary[Type]
+      } yield IndexedElem(i, t),
+      for {
+        ds <- resize(5, arbitrary[List[Data]])
+      } yield Const(Data.Arr(ds)))
+  }
+}

--- a/core/src/test/scala/slamdata/engine/types.scala
+++ b/core/src/test/scala/slamdata/engine/types.scala
@@ -668,6 +668,10 @@ class TypesSpec extends Specification with ScalaCheck with PendingWithAccurateCo
       examples.filter(_.setLike) should_== List(exSet)
     }
 
+    "empty array constant is arrayLike" in {
+      Const(Data.Arr(List())).arrayLike must_== true
+    }
+
     "arrayType for simple type" in {
       Int.arrayType should beNone
     }

--- a/it/src/test/resources/tests/concatArray.test
+++ b/it/src/test/resources/tests/concatArray.test
@@ -1,7 +1,7 @@
 {
     "name": "concat known array structure",
     "data": "zips.data",
-    "query": "select array_concat(make_array(city), make_array(pop)) from zips",
+    "query": "select [ city, pop ] from zips",
     "predicate": "containsAtLeast",
     "expected": [{ "0": ["AGAWAM",      15338] },
                  { "0": ["CUSHMAN",     36963] },

--- a/it/src/test/resources/tests/concatArrayWithUnknown.test
+++ b/it/src/test/resources/tests/concatArrayWithUnknown.test
@@ -1,8 +1,7 @@
 {
     "name": "concat array with unknown structure",
-    "backends": { "mongodb": "pending" },
     "data": "zips.data",
-    "query": "select array_concat(loc, make_array(pop)) from zips",
+    "query": "select loc || [ pop ] from zips",
     "predicate": "containsAtLeast",
     "expected": [{ "0": [-72.622739, 42.070206, 15338] },
                  { "0": [-72.51565,  42.377017, 36963] },


### PR DESCRIPTION
Add `ArraySpliceBuilder` and cases in `arrayConcat` to handle it. Some
wrangling of types and names in WorkflowBuilder to make this work out. This
fixes a previously pending integration test.

Add `JsCore.SpliceArrays` (and `Splice` becomes `SpliceObjects`).

Add SQL syntax for array constants with `[ ]`, and a `||` operator that works
on both arrays and strings. The operator must be typed to either Str or an
array type during type-checking, so that the compiler can translate it to
either (string) Concat or ArrayConcat. Note: type-checking doesn't push the
inferred type up and down in some cases; see pending test referring to #637.

Other minor stuff:

Add a (pending) missing test and a fix a broken existing test for math.Add.

Fix the type of empty array constants to be recognizable as an array type
(was previously `Top`, now the slightly overwrought `AnonElem[Bottom]`). This
will do until we have a proper types for arrays and objects.

Fix the label for $simpleMap's in the RenderTree instance.

Increase the coverage minimum to 75%.