### PR TITLE
Switching from Attr/CoAttr to Cofree/Free.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,13 +16,16 @@ lazy val standardSettings = Defaults.defaultSettings ++ Seq(
         >= 7,
       "Java 7 or above required")
   },
+  autoCompilerPlugins := true,
   exportJars := true,
   resolvers ++= Seq(
     Resolver.sonatypeRepo("releases"),
     Resolver.sonatypeRepo("snapshots"),
     "JBoss repository" at "https://repository.jboss.org/nexus/content/repositories/",
-    "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases"
+    "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases",
+    "bintray/non" at "http://dl.bintray.com/non/maven"
   ),
+  addCompilerPlugin("org.spire-math" % "kind-projector_2.11" % "0.5.2"),
   scalacOptions ++= Seq(
     "-Xfatal-warnings",
     "-deprecation",
@@ -51,6 +54,7 @@ lazy val standardSettings = Defaults.defaultSettings ++ Seq(
     "org.scalaz"        %% "scalaz-scalacheck-binding" % scalazVersion     % "compile, test",
     "com.github.julien-truffaut" %% "monocle-law"      % monocleVersion    % "compile, test",
     "org.specs2"        %% "specs2-core"       % "2.3.13-scalaz-7.1.0-RC1" % "test",
+    "org.typelevel"     %% "scalaz-specs2"             % "0.3.0"           % "test",
     "net.databinder.dispatch" %% "dispatch-core"       % "0.11.1"          % "test"
   ),
   licenses += ("GNU Affero GPL V3", url("http://www.gnu.org/licenses/agpl-3.0.html")))

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,8 @@ lazy val standardSettings = Defaults.defaultSettings ++ Seq(
     "Scalaz Bintray Repo" at "http://dl.bintray.com/scalaz/releases",
     "bintray/non" at "http://dl.bintray.com/non/maven"
   ),
-  addCompilerPlugin("org.spire-math" % "kind-projector_2.11" % "0.5.2"),
+  // TODO: use this to replace type lambdas once non/kind-projector#7 is fixed.
+  // addCompilerPlugin("org.spire-math" % "kind-projector_2.11" % "0.5.2"),
   scalacOptions ++= Seq(
     "-Xfatal-warnings",
     "-deprecation",

--- a/core/src/main/scala/slamdata/engine/fp/package.scala
+++ b/core/src/main/scala/slamdata/engine/fp/package.scala
@@ -8,12 +8,6 @@ import Liskov._
 import scalaz.concurrent.{Task}
 
 sealed trait LowerPriorityTreeInstances {
-  implicit val IntRenderTree =
-    new RenderTree[Int] {
-      override def render(t: Int) =
-        Terminal("", t.shows :: Nil)
-    }
-
   implicit def Tuple2RenderTree[A, B](implicit RA: RenderTree[A], RB: RenderTree[B]) =
     new RenderTree[(A, B)] {
       override def render(t: (A, B)) =
@@ -252,8 +246,8 @@ package object fp extends TreeInstances with ListMapInstances with ToTaskOps wit
     new Show[FF[A]] { override def show(fa: FF[A]) = FS.show(fa) }
 
   implicit def ShowFNT[F[_]](implicit SF: ShowF[F]):
-      Show ~> λ[α => Show[F[α]]] =
-    new (Show ~> λ[α => Show[F[α]]]) {
+      Show ~> ({type λ[α] = Show[F[α]]})#λ =
+    new (Show ~> ({type λ[α] = Show[F[α]]})#λ) {
       def apply[α](st: Show[α]): Show[F[α]] = ShowShowF(st, SF)
     }
 
@@ -266,8 +260,8 @@ package object fp extends TreeInstances with ListMapInstances with ToTaskOps wit
     new Equal[FF[A]] { def equal(fa1: FF[A], fa2: FF[A]) = FE.equal(fa1, fa2) }
 
   implicit def EqualFNT[F[_]](implicit EF: EqualF[F]):
-      Equal ~> λ[α => Equal[F[α]]] =
-    new (Equal ~> λ[α => Equal[F[α]]]) {
+      Equal ~> ({type λ[α] = Equal[F[α]]})#λ =
+    new (Equal ~> ({type λ[α] = Equal[F[α]]})#λ) {
       def apply[α](eq: Equal[α]): Equal[F[α]] = EqualEqualF(eq, EF)
     }
 

--- a/core/src/main/scala/slamdata/engine/functions.scala
+++ b/core/src/main/scala/slamdata/engine/functions.scala
@@ -54,9 +54,7 @@ trait VirtualFunc {
 
   def Attr: VirtualFuncAttrExtractor
   trait VirtualFuncAttrExtractor {
-    import slamdata.engine.analysis.fixplate.{Attr => FAttr}
-
-    def unapply[A](t: FAttr[LogicalPlan, A]): Option[List[FAttr[LogicalPlan, A]]]
+    def unapply[A](t: Cofree[LogicalPlan, A]): Option[List[Cofree[LogicalPlan, A]]]
   }
 }
 

--- a/core/src/main/scala/slamdata/engine/mra.scala
+++ b/core/src/main/scala/slamdata/engine/mra.scala
@@ -222,7 +222,7 @@ object MRA {
   def DimsPhase[A]: PhaseE[LogicalPlan, PlannerError, A, Dims] = lpBoundPhaseE {
     type Output = Dims
 
-    liftPhaseE(Phase { (attr: Attr[LogicalPlan,A]) =>
+    liftPhaseE(Phase { (attr: Cofree[LogicalPlan,A]) =>
       synthPara2(forget(attr)) { (node: LogicalPlan[(Term[LogicalPlan], Output)]) =>
         node.fold[Output](
           read      = Dims.set(_),

--- a/core/src/main/scala/slamdata/engine/optimizer.scala
+++ b/core/src/main/scala/slamdata/engine/optimizer.scala
@@ -16,7 +16,7 @@ object Optimizer {
           free      = symbol => if (symbol == target) 1 else 0,
           let       = (_, form, in) => form + in
         )
-      }).unFix.attr
+      }).head
     }
 
     def inline(start: Term[LogicalPlan], target: Symbol, repl: Term[LogicalPlan]): Term[LogicalPlan] = {

--- a/core/src/main/scala/slamdata/engine/std/structural.scala
+++ b/core/src/main/scala/slamdata/engine/std/structural.scala
@@ -97,13 +97,11 @@ trait StructuralLib extends Library {
     def unapply(t: Term[LogicalPlan]): Option[List[(Term[LogicalPlan], Term[LogicalPlan])]] =
       for {
         pairs <- Attr.unapply(attrK(t, ()))
-      } yield pairs.map { case (key, expr) => (forget(key), forget(expr)) }
+      } yield pairs.map(_.bimap(forget(_), forget(_)))
 
     object Attr {
-      import slamdata.engine.analysis.fixplate.{Attr => FAttr}
-
       // Note: signature does not match VirtualFuncAttrExtractor
-      def unapply[A](t: FAttr[LogicalPlan, A]): Option[List[(FAttr[LogicalPlan, A], FAttr[LogicalPlan, A])]] = t.unFix.unAnn match {
+      def unapply[A](t: Cofree[LogicalPlan, A]): Option[List[(Cofree[LogicalPlan, A], Cofree[LogicalPlan, A])]] = t.tail match {
         case MakeObject(name :: expr :: Nil) =>
           Some((name, expr) :: Nil)
 
@@ -125,9 +123,7 @@ trait StructuralLib extends Library {
       }
 
     def Attr = new VirtualFuncAttrExtractor {
-      import slamdata.engine.analysis.fixplate.{Attr => FAttr}
-
-      def unapply[A](t: FAttr[LogicalPlan, A]): Option[List[FAttr[LogicalPlan, A]]] = t.unFix.unAnn match {
+      def unapply[A](t: Cofree[LogicalPlan, A]): Option[List[Cofree[LogicalPlan, A]]] = t.tail match {
         case MakeArray(x :: Nil) =>
           Some(x :: Nil)
 

--- a/core/src/test/scala/slamdata/engine/analysis/fixplate.scala
+++ b/core/src/test/scala/slamdata/engine/analysis/fixplate.scala
@@ -8,11 +8,12 @@ import slamdata.engine.{RenderTree, Terminal, NonTerminal}
 import scalaz._
 import Scalaz._
 
-import org.specs2.mutable._
 import org.specs2.ScalaCheck
+import org.specs2.mutable._
+import org.specs2.scalaz._
 import org.scalacheck._
 
-class FixplateSpecs extends Specification with ScalaCheck {
+class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
   sealed trait Exp[+A]
   case class Num(value: Int) extends Exp[Nothing]
   case class Mul[A](left: A, right: A) extends Exp[A]
@@ -39,19 +40,24 @@ class FixplateSpecs extends Specification with ScalaCheck {
     }
   }
 
-  implicit val ExpRenderTree: RenderTree[Exp[_]] = new RenderTree[Exp[_]] {
-    def render(v: Exp[_]) = v match {
-      case Num(value)       => Terminal(value.toString, List("Num"))
-      case Mul(_, _)        => Terminal("", List("Mul"))
-      case Var(sym)         => Terminal(sym.toString, List("Var"))
-      case Lambda(param, _) => Terminal(param.toString, List("Lambda"))
-      case Apply(_, _)      => Terminal("", List("Apply"))
-      case Let(name, _, _)  => Terminal(name.toString, List("Let"))
+  implicit val ExpRenderTree: RenderTree[Exp[_]] =
+    new RenderTree[Exp[_]] {
+      def render(v: Exp[_]) = v match {
+        case Num(value)       => Terminal(value.toString, List("Num"))
+        case Mul(_, _)        => Terminal("", List("Mul"))
+        case Var(sym)         => Terminal(sym.toString, List("Var"))
+        case Lambda(param, _) => Terminal(param.toString, List("Lambda"))
+        case Apply(_, _)      => Terminal("", List("Apply"))
+        case Let(name, _, _)  => Terminal(name.toString, List("Let"))
+      }
     }
+
+  implicit val ExpShow: ShowF[Exp] = new ShowF[Exp] {
+    def show[A](ex: Exp[A])(implicit SA: Show[A]) = RenderTree.show[Exp[_]](ex)
   }
 
-  // NB: an unusual definition of equality, in that only the first 3 characters of
-  // variable names are significant
+  // NB: an unusual definition of equality, in that only the first 3 characters
+  //     of variable names are significant
   implicit val EqualExp: EqualF[Exp] = new EqualF[Exp] {
     def equal[A](e1: Exp[A], e2: Exp[A])(implicit eq: Equal[A]) = (e1, e2) match {
       case (Num(v1), Num(v2))                 => v1 == v2
@@ -64,25 +70,25 @@ class FixplateSpecs extends Specification with ScalaCheck {
     }
   }
 
-  type AttrExp[A] = Attr[Exp, A] // Attributed expression
+  type CofreeExp[A] = Cofree[Exp, A] // Attributed expression
 
-  implicit val ExpBinder: Binder[Exp, ({type f[A] = Map[Symbol, Attr[Exp, A]]})#f] = {
-    type MapSymbol[A] = Map[Symbol, AttrExp[A]]
+  implicit val ExpBinder: Binder[Exp, ({type f[A] = Map[Symbol, Cofree[Exp, A]]})#f] = {
+    type MapSymbol[A] = Map[Symbol, CofreeExp[A]]
 
     new Binder[Exp, MapSymbol] {
-      val bindings = new NaturalTransformation[AttrExp, MapSymbol] {
-        def apply[A](attrexpa: Attr[Exp, A]): MapSymbol[A] = {
-          attrexpa.unFix.unAnn match {
+      val bindings = new NaturalTransformation[CofreeExp, MapSymbol] {
+        def apply[A](attrexpa: Cofree[Exp, A]): MapSymbol[A] = {
+          attrexpa.tail match {
             case Let(name, value, _) => Map(name -> value)
             case _ => Map()
           }
         }
       }
-      val subst = new NaturalTransformation[`AttrF * G`, Subst] {
-        def apply[A](fa: `AttrF * G`[A]): Subst[A] = {
+      val subst = new NaturalTransformation[`CofreeF * G`, Subst] {
+        def apply[A](fa: `CofreeF * G`[A]): Subst[A] = {
           val (attr, map) = fa
 
-          attr.unFix.unAnn match {
+          attr.tail match {
             case Var(symbol) => map.get(symbol).map(exp => (exp, new Forall[Unsubst] { def apply[A] = { (a: A) => attrK(vari(symbol), a) } }))
             case _ => None
           }
@@ -105,9 +111,9 @@ class FixplateSpecs extends Specification with ScalaCheck {
   }
 
   def bindExp[A, B](phase: Phase[Exp, A, B]): Phase[Exp, A, B] = {
-    type MapSymbol[A] = Map[Symbol, Attr[Exp, A]]
+    type MapSymbol[A] = Map[Symbol, Cofree[Exp, A]]
 
-    implicit val sg = Semigroup.lastSemigroup[Attr[Exp, A]]
+    implicit val sg = Semigroup.lastSemigroup[Cofree[Exp, A]]
 
     bound[Id.Id, Exp, MapSymbol, A, B](phase)
   }
@@ -502,18 +508,9 @@ class FixplateSpecs extends Specification with ScalaCheck {
   }
 
   "Attr" should {
-    "unapply" should {
-      "match annotated leaf" in {
-        attrK(num(0), 0) match {
-          case Attr(0, Num(0)) => success
-          case _ => failure
-        }
-      }
-    }
-
     "attrSelf" should {
       "annotate all" ! Prop.forAll(expGen) { exp =>
-        attrSelf(exp).universe must_== exp.universe.map(attrSelf(_))
+        universe(attrSelf(exp)) must equal(exp.universe.map(attrSelf(_)))
       }
     }
 
@@ -525,11 +522,11 @@ class FixplateSpecs extends Specification with ScalaCheck {
 
     "foldMap" should {
       "zeros" ! Prop.forAll(expGen) { exp =>
-        Foldable[AttrExp].foldMap(attrK(exp, 0))(_ :: Nil) must_== exp.universe.map(κ(0))
+        Foldable[CofreeExp].foldMap(attrK(exp, 0))(_ :: Nil) must_== exp.universe.map(κ(0))
       }
 
       "selves" ! Prop.forAll(expGen) { exp =>
-        Foldable[AttrExp].foldMap(attrSelf(exp))(_ :: Nil) must_== exp.universe
+        Foldable[CofreeExp].foldMap(attrSelf(exp))(_ :: Nil) must_== exp.universe
       }
     }
 
@@ -551,18 +548,8 @@ class FixplateSpecs extends Specification with ScalaCheck {
 
     "zip" should {
       "tuplify simple constants" ! Prop.forAll(expGen) { exp =>
-        AttrZip[Exp].zip(attrK(exp, 0), attrK(exp, 1)) must_==
-          attrK(exp, (0, 1))
-      }
-    }
-
-    "duplicate" should {
-      "annotate root with root" ! Prop.forAll(expGen) { exp =>
-        attr(duplicate(attrK(exp, 0))) must_== attrK(exp, 0)
-      }
-
-      "annotate every node with self" ! Prop.forAll(expGen) { exp =>
-        duplicate(attrK(exp, 0)).universe.map(attr(_)) must_== attrK(exp, 0).universe
+        unsafeZip2(attrK(exp, 0), attrK(exp, 1)) must
+          equal(attrK(exp, (0, 1)))
       }
     }
 
@@ -573,7 +560,7 @@ class FixplateSpecs extends Specification with ScalaCheck {
       "produce correct annotations for 5 * 2" in {
         val rez = (ExamplePhase1[Unit])(attrUnit(Example1))
 
-        rez.unFix.attr must beSome(10)
+        rez.head must beSome(10)
       }
     }
 
@@ -581,21 +568,21 @@ class FixplateSpecs extends Specification with ScalaCheck {
       "produce incorrect annotations when not used in let expression" in {
         val rez = (ExamplePhase1[Unit])(attrUnit(Example2))
 
-        rez.unFix.attr must beNone
+        rez.head must beNone
       }
 
       "produce correct annotations when used in let expression" in {
         val rez = bindExp(ExamplePhase1[Unit])(attrUnit(Example2))
 
-        // println(Show[Attr[Exp, Option[Int]]].show(rez))
+        // println(Show[Cofree[Exp, Option[Int]]].show(rez))
 
-        rez.unFix.attr must beSome(10)
+        rez.head must beSome(10)
       }
     }
   }
 
   def expGen: Gen[Term[Exp]] = Gen.oneOf(
-    Gen.choose(0, 10).flatMap(x => num(x)),
+    Gen.choose(0, 10).flatMap(num),
     for {
       x <- Gen.choose(0, 10)
       y <- Gen.choose(0, 10)


### PR DESCRIPTION
* Simplify some of the fixplate morphisms and
* use kind-projector to make type lambdas somewhat closer to readable.

A couple things I’m not happy with:
* `IntRenderTree` – I wanted to make a lower-priority ShowRenderTree
  that would give us a RenderTree instance for anything that had a Show
  instance, but I kept getting diverging implicits, so I punted and
  created the one case we needed.
* `EqualFNT` (and `ShowFNT`) – this converts `EqualF` instances into
  `NaturalTransformation`s (which we need to make `Cofree`’s `Equal`
  instance work). This is much like our `EqualEqualF`, except that it
  doesn’t deal with subtypes. I was hoping to get rid of `EqualF` and
  use NTs directly, but getting something like `FF[A] <: F[A]` into the
  NT stymies me.