### PR TITLE
Parse SQL numeric literals as Long, not Int.

### DIFF
--- a/core/src/main/scala/slamdata/engine/sql/parser.scala
+++ b/core/src/main/scala/slamdata/engine/sql/parser.scala
@@ -248,7 +248,7 @@ class SQLParser extends StandardTokenParsers {
     }
 
   def literal: Parser[Expr] =
-    numericLit ^^ { case i => IntLiteral(i.toInt) } |
+    numericLit ^^ { case i => IntLiteral(i.toLong) } |
     floatLit ^^ { case f => FloatLiteral(f.toDouble) } |
     stringLit ^^ { case s => StringLiteral(s) } |
     keyword("null") ^^^ NullLiteral.apply |

--- a/core/src/test/scala/slamdata/engine/sql/SqlParserSpec.scala
+++ b/core/src/test/scala/slamdata/engine/sql/SqlParserSpec.scala
@@ -130,6 +130,17 @@ class SQLParserSpec extends Specification with ScalaCheck with DisjunctionMatche
       parser.parse("select * from foo where bar = 'that''s it!'").toOption should beSome
     }
 
+    "parse literal that’s too big for an Int" in {
+      parser.parse("select * from users where add_date > 1425460451000") should
+        beRightDisjOrDiff(
+          SelectStmt(
+            SelectAll,
+            List(Proj.Anon(Splice(None))),
+            Some(TableRelationAST("users",None)),
+            Some(Binop(Ident("add_date"),IntLiteral(1425460451000L), Gt)),
+            None,None,None,None))
+    }
+
     "parse quoted identifier" in {
       parser.parse("""select * from "tmp/foo" """).toOption should beSome
     }


### PR DESCRIPTION
Fixes #649.