### PR TITLE
A few steps toward using functors more directly.

### DIFF
--- a/core/src/main/scala/slamdata/engine/compiler.scala
+++ b/core/src/main/scala/slamdata/engine/compiler.scala
@@ -290,8 +290,8 @@ trait Compiler[F[_]] {
 
     def compileJoin(clause: Expr, lt: Term[LogicalPlan], rt: Term[LogicalPlan]):
         CompilerM[(Mapping, Term[LogicalPlan], Term[LogicalPlan])] = {
-      compile0(clause).flatMap(_ match {
-        case LogicalPlan.Invoke(f: Mapping, List(left, right)) =>
+      compile0(clause).flatMap(_.unFix match {
+        case LogicalPlan.InvokeF(f: Mapping, List(left, right)) =>
           if (Tag.unwrap(left.foldMap(x => Tags.Disjunction(x == lt))) && Tag.unwrap(right.foldMap(x => Tags.Disjunction(x == rt))))
             emit((f, left, right))
           else if (Tag.unwrap(left.foldMap(x => Tags.Disjunction(x == rt))) && Tag.unwrap(right.foldMap(x => Tags.Disjunction(x == lt))))

--- a/core/src/main/scala/slamdata/engine/functions.scala
+++ b/core/src/main/scala/slamdata/engine/functions.scala
@@ -15,14 +15,10 @@ sealed trait Func {
   def apply(args: Term[LogicalPlan]*): Term[LogicalPlan] = LogicalPlan.Invoke(this, args.toList)
 
   def unapply[A](node: LogicalPlan[A]): Option[List[A]] = {
-    node.fold(
-      read      = κ(None),
-      constant  = κ(None),
-      join      = κ(None),
-      invoke    = (f, a) => if (f == this) Some(a) else None,
-      free      = κ(None),
-      let       = κ(None)
-    )
+    node match {
+      case LogicalPlan.InvokeF(f, a) if f == this => Some(a)
+      case _                                      => None
+    }
   }
 
   def apply: Func.Typer

--- a/core/src/main/scala/slamdata/engine/logicalplan.scala
+++ b/core/src/main/scala/slamdata/engine/logicalplan.scala
@@ -9,65 +9,46 @@ import slamdata.engine.fs.Path
 import slamdata.engine.analysis._
 import fixplate._
 
-
-sealed trait LogicalPlan[+A] {
-  import LogicalPlan._
-
-  def fold[Z](
-      read:       Path  => Z,
-      constant:   Data  => Z,
-      join:       (A, A, JoinType, Mapping, A, A) => Z,
-      invoke:     (Func, List[A]) => Z,
-      free:       Symbol  => Z,
-      let:        (Symbol, A, A) => Z
-    ): Z = this match {
-    case Read0(x)              => read(x)
-    case Constant0(x)          => constant(x)
-    case Join0(left, right,
-              tpe, rel,
-              lproj, rproj)    => join(left, right, tpe, rel, lproj, rproj)
-    case Invoke0(func, values) => invoke(func, values)
-    case Free0(name)           => free(name)
-    case Let0(ident, form, in) => let(ident, form, in)
-  }
-}
-
+sealed trait LogicalPlan[+A]
 object LogicalPlan {
+  import slamdata.engine.std.StdLib._
+  import structural._
+
   implicit val LogicalPlanTraverse = new Traverse[LogicalPlan] {
     def traverseImpl[G[_], A, B](fa: LogicalPlan[A])(f: A => G[B])(implicit G: Applicative[G]): G[LogicalPlan[B]] = {
       fa match {
-        case x @ Read0(_) => G.point(x)
-        case x @ Constant0(_) => G.point(x)
-        case Join0(left, right, tpe, rel, lproj, rproj) =>
-          G.apply4(f(left), f(right), f(lproj), f(rproj))(Join0(_, _, tpe, rel, _, _))
-        case Invoke0(func, values) => G.map(Traverse[List].sequence(values.map(f)))(Invoke0(func, _))
-        case x @ Free0(_) => G.point(x)
-        case Let0(ident, form0, in0) =>
-          G.apply2(f(form0), f(in0))(Let0(ident, _, _))
+        case x @ ReadF(_) => G.point(x)
+        case x @ ConstantF(_) => G.point(x)
+        case JoinF(left, right, tpe, rel, lproj, rproj) =>
+          G.apply4(f(left), f(right), f(lproj), f(rproj))(JoinF(_, _, tpe, rel, _, _))
+        case InvokeF(func, values) => G.map(Traverse[List].sequence(values.map(f)))(InvokeF(func, _))
+        case x @ FreeF(_) => G.point(x)
+        case LetF(ident, form0, in0) =>
+          G.apply2(f(form0), f(in0))(LetF(ident, _, _))
       }
     }
 
     override def map[A, B](v: LogicalPlan[A])(f: A => B): LogicalPlan[B] = {
       v match {
-        case x @ Read0(_) => x
-        case x @ Constant0(_) => x
-        case Join0(left, right, tpe, rel, lproj, rproj) =>
-          Join0(f(left), f(right), tpe, rel, f(lproj), f(rproj))
-        case Invoke0(func, values) => Invoke0(func, values.map(f))
-        case x @ Free0(_) => x
-        case Let0(ident, form, in) => Let0(ident, f(form), f(in))
+        case x @ ReadF(_) => x
+        case x @ ConstantF(_) => x
+        case JoinF(left, right, tpe, rel, lproj, rproj) =>
+          JoinF(f(left), f(right), tpe, rel, f(lproj), f(rproj))
+        case InvokeF(func, values) => InvokeF(func, values.map(f))
+        case x @ FreeF(_) => x
+        case LetF(ident, form, in) => LetF(ident, f(form), f(in))
       }
     }
 
     override def foldMap[A, B](fa: LogicalPlan[A])(f: A => B)(implicit F: Monoid[B]): B = {
       fa match {
-        case x @ Read0(_) => F.zero
-        case x @ Constant0(_) => F.zero
-        case Join0(left, right, tpe, rel, lproj, rproj) =>
+        case x @ ReadF(_) => F.zero
+        case x @ ConstantF(_) => F.zero
+        case JoinF(left, right, tpe, rel, lproj, rproj) =>
           F.append(F.append(f(left), f(right)), F.append(f(lproj), f(rproj)))
-        case Invoke0(func, values) => Foldable[List].foldMap(values)(f)
-        case x @ Free0(_) => F.zero
-        case Let0(_, form, in) => {
+        case InvokeF(func, values) => Foldable[List].foldMap(values)(f)
+        case x @ FreeF(_) => F.zero
+        case LetF(_, form, in) => {
           F.append(f(form), f(in))
         }
       }
@@ -75,79 +56,57 @@ object LogicalPlan {
 
     override def foldRight[A, B](fa: LogicalPlan[A], z: => B)(f: (A, => B) => B): B = {
       fa match {
-        case x @ Read0(_) => z
-        case x @ Constant0(_) => z
-        case Join0(left, right, tpe, rel, lproj, rproj) =>
+        case x @ ReadF(_) => z
+        case x @ ConstantF(_) => z
+        case JoinF(left, right, tpe, rel, lproj, rproj) =>
           f(left, f(right, f(lproj, f(rproj, z))))
-        case Invoke0(func, values) => Foldable[List].foldRight(values, z)(f)
-        case x @ Free0(_) => z
-        case Let0(ident, form, in) => f(form, f(in, z))
+        case InvokeF(func, values) => Foldable[List].foldRight(values, z)(f)
+        case x @ FreeF(_) => z
+        case LetF(ident, form, in) => f(form, f(in, z))
       }
     }
   }
   implicit val RenderTreeLogicalPlan: RenderTree[LogicalPlan[_]] = new RenderTree[LogicalPlan[_]] {
     // Note: these are all terminals; the wrapping Term or Cofree will use these to build nodes with children.
     override def render(v: LogicalPlan[_]) = v match {
-      case Read0(name)                 => Terminal(name.pathname,             List("LogicalPlan", "Read"))
-      case Constant0(data)             => Terminal(data.toString,             List("LogicalPlan", "Constant"))
-      case Join0(_, _, tpe, rel, _, _) => Terminal(tpe.toString + ", " + rel, List("LogicalPlan", "Join"))
-      case Invoke0(func, _     )       => Terminal(func.name,                 List("LogicalPlan", "Invoke", func.mappingType.toString))
-      case Free0(name)                 => Terminal(name.toString,             List("LogicalPlan", "Free"))
-      case Let0(ident, _, _)           => Terminal(ident.toString,            List("LogicalPlan", "Let"))
+      case ReadF(name)                 => Terminal(name.pathname,             List("LogicalPlan", "Read"))
+      case ConstantF(data)             => Terminal(data.toString,             List("LogicalPlan", "Constant"))
+      case JoinF(_, _, tpe, rel, _, _) => Terminal(tpe.toString + ", " + rel, List("LogicalPlan", "Join"))
+      case InvokeF(func, _     )       => Terminal(func.name,                 List("LogicalPlan", "Invoke", func.mappingType.toString))
+      case FreeF(name)                 => Terminal(name.toString,             List("LogicalPlan", "Free"))
+      case LetF(ident, _, _)           => Terminal(ident.toString,            List("LogicalPlan", "Let"))
     }
   }
   implicit val EqualFLogicalPlan = new fp.EqualF[LogicalPlan] {
     def equal[A](v1: LogicalPlan[A], v2: LogicalPlan[A])(implicit A: Equal[A]): Boolean = (v1, v2) match {
-      case (Read0(n1), Read0(n2)) => n1 == n2
-      case (Constant0(d1), Constant0(d2)) => d1 == d2
-      case (Join0(l1, r1, tpe1, rel1, lproj1, rproj1),
-            Join0(l2, r2, tpe2, rel2, lproj2, rproj2)) =>
+      case (ReadF(n1), ReadF(n2)) => n1 == n2
+      case (ConstantF(d1), ConstantF(d2)) => d1 == d2
+      case (JoinF(l1, r1, tpe1, rel1, lproj1, rproj1),
+            JoinF(l2, r2, tpe2, rel2, lproj2, rproj2)) =>
         A.equal(l1, l2) && A.equal(r1, r2) && A.equal(lproj1, lproj2) && A.equal(rproj1, rproj2) && tpe1 == tpe2
-      case (Invoke0(f1, v1), Invoke0(f2, v2)) => Equal[List[A]].equal(v1, v2) && f1 == f2
-      case (Free0(n1), Free0(n2)) => n1 == n2
-      case (Let0(ident1, form1, in1), Let0(ident2, form2, in2)) =>
+      case (InvokeF(f1, v1), InvokeF(f2, v2)) => Equal[List[A]].equal(v1, v2) && f1 == f2
+      case (FreeF(n1), FreeF(n2)) => n1 == n2
+      case (LetF(ident1, form1, in1), LetF(ident2, form2, in2)) =>
         ident1 == ident2 && A.equal(form1, form2) && A.equal(in1, in2)
       case _ => false
     }
   }
 
-  private case class Read0(path: Path) extends LogicalPlan[Nothing] {
+  case class ReadF(path: Path) extends LogicalPlan[Nothing] {
     override def toString = s"""Read(Path("${path.simplePathname}"))"""
   }
   object Read {
     def apply(path: Path): Term[LogicalPlan] =
-      Term[LogicalPlan](new Read0(path))
-
-    def unapply(t: Term[LogicalPlan]): Option[Path] =
-      t.unFix match {
-        case Read0(path) => Some(path)
-        case _ => None
-      }
-
-    object Attr {
-      def unapply[A](a: Cofree[LogicalPlan, A]): Option[Path] = Read.unapply(forget(a))
-    }
+      Term[LogicalPlan](new ReadF(path))
   }
 
-  private case class Constant0(data: Data) extends LogicalPlan[Nothing] {
-    override def toString = s"Constant($data)"
-  }
+  case class ConstantF(data: Data) extends LogicalPlan[Nothing]
   object Constant {
     def apply(data: Data): Term[LogicalPlan] =
-      Term[LogicalPlan](Constant0(data))
-
-    def unapply(t: Term[LogicalPlan]): Option[Data] =
-      t.unFix match {
-        case Constant0(data) => Some(data)
-        case _ => None
-      }
-
-    object Attr {
-      def unapply[A](a: Cofree[LogicalPlan, A]): Option[Data] = Constant.unapply(forget(a))
-    }
+      Term[LogicalPlan](ConstantF(data))
   }
 
-  private case class Join0[A](left: A, right: A,
+  case class JoinF[A](left: A, right: A,
                                joinType: JoinType, joinRel: Mapping,
                                leftProj: A, rightProj: A) extends LogicalPlan[A] {
     override def toString = s"Join($left, $right, $joinType, $joinRel, $leftProj, $rightProj)"
@@ -156,24 +115,10 @@ object LogicalPlan {
     def apply(left: Term[LogicalPlan], right: Term[LogicalPlan],
                joinType: JoinType, joinRel: Mapping,
                leftProj: Term[LogicalPlan], rightProj: Term[LogicalPlan]): Term[LogicalPlan] =
-      Term[LogicalPlan](Join0(left, right, joinType, joinRel, leftProj, rightProj))
-
-    def unapply(t: Term[LogicalPlan]): Option[(Term[LogicalPlan], Term[LogicalPlan], JoinType, Mapping, Term[LogicalPlan], Term[LogicalPlan])] =
-      t.unFix match {
-        case Join0(left, right, joinType, joinRel, leftProj, rightProj) => Some((left, right, joinType, joinRel, leftProj, rightProj))
-        case _ => None
-      }
-
-    object Attr {
-      def unapply[A](a: Cofree[LogicalPlan, A]): Option[(Cofree[LogicalPlan, A], Cofree[LogicalPlan, A], JoinType, Mapping, Cofree[LogicalPlan, A], Cofree[LogicalPlan, A])] =
-        a.tail match {
-          case Join0(left, right, joinType, joinRel, leftProj, rightProj) => Some((left, right, joinType, joinRel, leftProj, rightProj))
-          case _ => None
-        }
-    }
+      Term[LogicalPlan](JoinF(left, right, joinType, joinRel, leftProj, rightProj))
   }
 
-  private case class Invoke0[A](func: Func, values: List[A]) extends LogicalPlan[A] {
+  case class InvokeF[A](func: Func, values: List[A]) extends LogicalPlan[A] {
     override def toString = {
       val funcName = if (func.name(0).isLetter) func.name.split('_').map(_.toLowerCase.capitalize).mkString
                       else "\"" + func.name + "\""
@@ -182,61 +127,19 @@ object LogicalPlan {
   }
   object Invoke {
     def apply(func: Func, values: List[Term[LogicalPlan]]): Term[LogicalPlan] =
-      Term[LogicalPlan](Invoke0(func, values))
-
-    def unapply(t: Term[LogicalPlan]): Option[(Func, List[Term[LogicalPlan]])] =
-      t.unFix match {
-        case Invoke0(func, values) => Some((func, values))
-        case _ => None
-      }
-
-    object Attr {
-      def unapply[A](a: Cofree[LogicalPlan, A]): Option[(Func, List[Cofree[LogicalPlan, A]])] =
-        a.tail match {
-          case Invoke0(func, values) => Some((func, values))
-          case _ => None
-        }
-    }
+      Term[LogicalPlan](InvokeF(func, values))
   }
 
-  private case class Free0(name: Symbol) extends LogicalPlan[Nothing] {
-    override def toString = s"Free($name)"
-  }
+  case class FreeF(name: Symbol) extends LogicalPlan[Nothing]
   object Free {
     def apply(name: Symbol): Term[LogicalPlan] =
-      Term[LogicalPlan](Free0(name))
-
-    def unapply(t: Term[LogicalPlan]): Option[Symbol] =
-      t.unFix match {
-        case Free0(name) => Some(name)
-        case _ => None
-      }
-
-    object Attr {
-      def unapply[A](a: Cofree[LogicalPlan, A]): Option[Symbol] = Free.unapply(forget(a))
-    }
+      Term[LogicalPlan](FreeF(name))
   }
 
-  private case class Let0[A](let: Symbol, form: A, in: A) extends LogicalPlan[A] {
-    override def toString = s"Let($let, $form, $in)"
-  }
+  case class LetF[A](let: Symbol, form: A, in: A) extends LogicalPlan[A]
   object Let {
     def apply(let: Symbol, form: Term[LogicalPlan], in: Term[LogicalPlan]): Term[LogicalPlan] =
-      Term[LogicalPlan](Let0(let, form, in))
-
-    def unapply(t: Term[LogicalPlan]): Option[(Symbol, Term[LogicalPlan], Term[LogicalPlan])] =
-      t.unFix match {
-        case Let0(let, form, in) => Some((let, form, in))
-        case _ => None
-      }
-
-    object Attr {
-      def unapply[A](a: Cofree[LogicalPlan, A]): Option[(Symbol, Cofree[LogicalPlan, A], Cofree[LogicalPlan, A])] =
-        a.tail match {
-          case Let0(let, form, in) => Some((let, form, in))
-          case _ => None
-        }
-    }
+      Term[LogicalPlan](LetF(let, form, in))
   }
 
   implicit val LogicalPlanBinder: Binder[LogicalPlan, ({type f[A]=Map[Symbol, Cofree[LogicalPlan, A]]})#f] = {
@@ -249,14 +152,10 @@ object LogicalPlan {
         def empty[A]: MapSymbol[A] = Map()
 
         def apply[X](plan: Cofree[LogicalPlan, X]): MapSymbol[X] = {
-          plan.tail.fold[MapSymbol[X]](
-            read      = κ(empty),
-            constant  = κ(empty),
-            join      = κ(empty),
-            invoke    = κ(empty),
-            free      = κ(empty),
-            let       = (ident, form, _) => Map(ident -> form)
-          )
+          plan.tail match {
+            case LetF(ident, form, _) => Map(ident -> form)
+            case _                    => empty
+          }
         }
       }
 
@@ -264,14 +163,14 @@ object LogicalPlan {
         def apply[Y](fa: `CofreeF * G`[Y]): Subst[Y] = {
           val (attr, map) = fa
 
-          attr.tail.fold[Subst[Y]](
-            read      = κ(None),
-            constant  = κ(None),
-            join      = κ(None),
-            invoke    = κ(None),
-            free      = symbol => map.get(symbol).map(p => (p, new Forall[Unsubst] { def apply[A] = { (a: A) => attrK(Free(symbol), a) } })),
-            let       = κ(None)
-          )
+          attr.tail match {
+            case FreeF(symbol) =>
+              map.get(symbol).map(p =>
+                (p, new Forall[Unsubst] {
+                  def apply[A] = { (a: A) => attrK(Free(symbol), a) }
+                }))
+            case _ => None
+          }
         }
       }
     }
@@ -318,20 +217,15 @@ object LogicalPlan {
           b <- f(rec)
         } yield Cofree[LogicalPlan, B](b, rec.map(_.map(_._2)))
 
-        attr.tail.fold[M[Cofree[LogicalPlan, B]]](
-          read     = _ => loop0,
-          constant = _ => loop0,
-          join     = (_, _, _, _, _, _) => loop0,
-          invoke   = (_, _) => loop0,
-
-          free     = name => vars.get(name).getOrElse(sys.error("not bound: " + name)).point[M],  // FIXME: should be surfaced with -\/? See #414
-          let      = (ident, form, in) => {
+        attr.tail match {
+          case FreeF(name) => vars.get(name).getOrElse(sys.error("not bound: " + name)).point[M] // FIXME: should be surfaced with -\/? See #414
+          case LetF(ident, form, in) =>
             for {
               form1 <- loop(form, vars)
               in1   <- loop(in, vars + (ident -> form1))
-            } yield Cofree(in1.head, Let0(ident, form1, in1))
-          }
-        )
+            } yield Cofree(in1.head, LetF(ident, form1, in1))
+          case _ => loop0
+        }
       }
 
       loop(_, Map())

--- a/core/src/main/scala/slamdata/engine/mra.scala
+++ b/core/src/main/scala/slamdata/engine/mra.scala
@@ -224,27 +224,26 @@ object MRA {
 
     liftPhaseE(Phase { (attr: Cofree[LogicalPlan,A]) =>
       synthPara2(forget(attr)) { (node: LogicalPlan[(Term[LogicalPlan], Output)]) =>
-        node.fold[Output](
-          read      = Dims.set(_),
-          constant  = κ(Dims.Value),
-          join      = (left, right, tpe, rel, lproj, rproj) => ???,
-          invoke    = (func, args) =>  {
-                        val d = Dims.combineAll(args.map(_._2))
+        node match {
+          case ReadF(path) => Dims.set(path)
+          case ConstantF(_) => Dims.Value
+          case JoinF(_, _, _, _, _, _) => ???
+          case InvokeF(func, args) =>
+            val d = Dims.combineAll(args.map(_._2))
 
-                        import MappingType._
+            import MappingType._
 
-                        func.mappingType match {
-                          case OneToOne       => d
-                          case OneToMany      => d.expand
-                          case OneToManyFlat  => d.flatten
-                          case ManyToOne      => d.aggregate
-                          case ManyToMany     => d
-                          case Squashing      => d.squash
-                        }
-                      },
-          free      = κ(Dims.Value),
-          let       = (_, _, in) => in._2
-        )
+            func.mappingType match {
+              case OneToOne       => d
+              case OneToMany      => d.expand
+              case OneToManyFlat  => d.flatten
+              case ManyToOne      => d.aggregate
+              case ManyToMany     => d
+              case Squashing      => d.squash
+            }
+          case FreeF(_) => Dims.Value
+          case LetF(_, _, in) => in._2
+        }
       }
     })
   }

--- a/core/src/main/scala/slamdata/engine/optimizer.scala
+++ b/core/src/main/scala/slamdata/engine/optimizer.scala
@@ -3,53 +3,33 @@ package slamdata.engine
 import slamdata.engine.fp._
 import slamdata.engine.analysis.fixplate._
 
+import scalaz._
+import Scalaz._
+
 object Optimizer {
+  import LogicalPlan._
 
-  def simplify(term: Term[LogicalPlan]): Term[LogicalPlan] = {
-    def countUsage(start: Term[LogicalPlan], target: Symbol): Int = {
-      (scanCata(attrUnit(start)) { (_ : Unit, lp: LogicalPlan[Int]) =>
-        lp.fold(
-          read      = κ(0),
-          constant  = κ(0),
-          join      = (l, r, _, _, lp, rp) => l + r + lp + rp,
-          invoke    = (_, args) => args.sum,
-          free      = symbol => if (symbol == target) 1 else 0,
-          let       = (_, form, in) => form + in
-        )
-      }).head
+  private def countUsage(target: Symbol): LogicalPlan[Int] => Int = {
+    case FreeF(symbol) if symbol == target => 1
+    case LetF(ident, form, _) if ident == target => form
+    case x => x.fold
+  }
+
+  private def inline[A](target: Symbol, repl: Term[LogicalPlan]):
+      LogicalPlan[(Term[LogicalPlan], Term[LogicalPlan])] => Term[LogicalPlan] =
+    {
+      case FreeF(symbol) if symbol == target => repl
+      case LetF(ident, form, body) if ident == target =>
+        Let(ident, form._2, body._1)
+      case x => Term(x.map(_._2))
     }
 
-    def inline(start: Term[LogicalPlan], target: Symbol, repl: Term[LogicalPlan]): Term[LogicalPlan] = {
-      start.topDownTransform { (term: Term[LogicalPlan]) =>
-        term.unFix.fold(
-          read      = κ(term),
-          constant  = κ(term),
-          join      = κ(term),
-          invoke    = κ(term),
-          free      = symbol => if (symbol == target) repl else term,
-          let       = κ(term)
-        )
-      }
+  val simplify: LogicalPlan[Term[LogicalPlan]] => Term[LogicalPlan] = {
+    case LetF(ident, form, in) => in.cata(countUsage(ident)) match {
+      case 0 => in
+      case 1 => in.para(inline(ident, form))
+      case _ => Let(ident, form, in)
     }
-
-    term.topDownTransform { (term: Term[LogicalPlan]) =>
-      def pass(term: Term[LogicalPlan]): Term[LogicalPlan] = {
-        term.unFix.fold(
-          read      = κ(term),
-          constant  = κ(term),
-          join      = κ(term),
-          invoke    = κ(term),
-          free      = κ(term),
-          let       = (ident, form, in) => {
-            if (countUsage(in, ident) <= 1)
-              pass(inline(in, ident, form))
-            else
-              LogicalPlan.Let(ident, form, in)
-          }
-        )
-      }
-
-      pass(term)
-    }
+    case x => Term(x)
   }
 }

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/optimize/optimize.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/optimize/optimize.scala
@@ -160,7 +160,7 @@ package object optimize {
         Option[(Workflow, Grouped, ExprOp \/ Reshape)] = {
       import ExprOp._
 
-      val (rs, src) = collectShapes(g.src)
+      val (rs, src) = g.src.para(collectShapes)
 
       type MapField[X] = ListMap[BsonField.Leaf, X]
 

--- a/core/src/main/scala/slamdata/engine/planner.scala
+++ b/core/src/main/scala/slamdata/engine/planner.scala
@@ -54,7 +54,7 @@ trait Planner[PhysicalPlan] {
       tree       <- withTree("Annotated Tree")(AllPhases(tree(select)).disjunction.leftMap(ManyErrors.apply))
       tree       <- withTree("Annotated Tree (variables substituted)")(Variables.substVars[SemanticAnalysis.Annotations](tree, _._2, req.variables))
       logical    <- withTree("Logical Plan")(Compiler.compile(tree))
-      simplified <- withTree("Simplified")(\/-(Optimizer.simplify(logical)))
+      simplified <- withTree("Simplified")(\/-(logical.cata(Optimizer.simplify)))
       physical   <- withTree("Physical Plan")(plan(simplified))
       _          <- withString(physical)(showNative)
     } yield physical).run.run

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -57,7 +57,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
 
   def plan(logical: Term[LogicalPlan]): Either[Error, Workflow] =
     (for {
-      simplified <- \/-(Optimizer.simplify(logical))
+      simplified <- \/-(logical.cata(Optimizer.simplify))
       phys <- MongoDbPlanner.plan(simplified)
     } yield phys).toEither
 


### PR DESCRIPTION
* Make unfixed `LogicalPlan` classes public and rename them with an `F` suffix,
* destroy `LogicalPlan.fold`, so it doesn’t shadow `Foldable.fold`,
* remove `unapply` and `Attr` from fixed `LogicalPlan` objects,
* expose a few `WorkflowOp` functions as F-algebras,
* make `Optimizer.simplify` handle shadowed variables properly (and expose as an
  F-algebra), and
* reduce code base by 140 lines.