### PR TITLE
Delete synthesized fields.

### DIFF
--- a/core/src/main/scala/slamdata/engine/compiler.scala
+++ b/core/src/main/scala/slamdata/engine/compiler.scala
@@ -347,14 +347,14 @@ trait Compiler[F[_]] {
               })
             val projs = projections.map(_.expr)
 
-            val nonSyntheticNames: CompilerM[List[String]] = names.flatMap(names => (names zip projections).map {
-              case (Some(name), proj) => syntheticOf(proj).map(_ match {
-                case Some(_) => None: Option[String]
-                case None => Some(name)
-              })
-              case (None, _) => emit(None: Option[String])
+            val syntheticNames: CompilerM[List[String]] =
+              names.flatMap(names => (names zip projections).map {
+                case (Some(name), proj) => syntheticOf(proj).map(_ match {
+                  case Some(_) => Some(name)
+                  case None => None: Option[String]
+                })
+                case (None, _) => emit(None: Option[String])
             }.sequenceU.map(_.flatten))
-            val anySynthetic = projections.map(syntheticOf).sequenceU.map(_.flatten.nonEmpty)
 
             relations match {
               case None => for {
@@ -406,11 +406,11 @@ trait Compiler[F[_]] {
                               val distincted = isDistinct match {
                                   case SelectDistinct => Some {
                                     for {
-                                      s <- anySynthetic
+                                      ns <- syntheticNames
                                       t <- CompilerState.rootTableReq
-                                      ns <- nonSyntheticNames
-                                      projs = ns.map(name => ObjectProject(t, LogicalPlan.Constant(Data.Str(name))))
-                                    } yield if (s) DistinctBy(t, MakeArrayN(projs: _*)) else Distinct(t)
+                                    } yield if (ns.nonEmpty)
+                                      DistinctBy(t, ns.foldLeft(t)((acc, field) => DeleteField(acc, LogicalPlan.Constant(Data.Str(field)))))
+                                    else Distinct(t)
                                   }
                                   case _ => None
                                 }
@@ -431,16 +431,13 @@ trait Compiler[F[_]] {
 
                                   stepBuilder(limited) {
                                     val pruned = for {
-                                      s <- anySynthetic
-                                    } yield
-                                      if (s) Some {
-                                        for {
-                                          t <- CompilerState.rootTableReq
-                                          ns <- nonSyntheticNames
-                                          ts = ns.map(name => ObjectProject(t, LogicalPlan.Constant(Data.Str(name))))
-                                        } yield if (ns.isEmpty) t else buildRecord(ns.map(name => Some(name)), ts)
-                                      }
-                                      else None
+                                      ns <- syntheticNames
+                                    } yield if (ns.nonEmpty)
+                                      Some(CompilerState.rootTableReq.map(
+                                        ns.foldLeft(_)((acc, field) =>
+                                          DeleteField(acc,
+                                            LogicalPlan.Constant(Data.Str(field))))))
+                                    else None
 
                                     pruned.flatMap(stepBuilder(_) {
                                       CompilerState.rootTableReq

--- a/core/src/main/scala/slamdata/engine/fp/EnvT.scala
+++ b/core/src/main/scala/slamdata/engine/fp/EnvT.scala
@@ -1,4 +1,4 @@
-package slamdata.engine.analysis
+package slamdata.engine.fp
 
 import scalaz._
 import Scalaz._

--- a/core/src/main/scala/slamdata/engine/javascript/jscore.scala
+++ b/core/src/main/scala/slamdata/engine/javascript/jscore.scala
@@ -101,6 +101,12 @@ object JsCore {
     case SpliceArrays(_)     => expr.toJs
   }
 
+  val findFunctionsƒ: JsCore[(Term[JsCore], Set[String])] => Set[String] = {
+    case Call((Term(Ident(name)), _), args) =>
+      Foldable[List].fold(args.map(_._2)) + name
+    case js => js.map(_._2).fold
+  }
+
   def copyAllFields(src: Term[JsCore], dst: Term[JsCore]): Js.Stmt = {
     val tmp = Js.Ident("__attr")  // TODO: use properly-generated temp name (see #581)
     Js.ForIn(tmp, src.toJs,

--- a/core/src/main/scala/slamdata/engine/optimizer.scala
+++ b/core/src/main/scala/slamdata/engine/optimizer.scala
@@ -8,6 +8,8 @@ import Scalaz._
 
 object Optimizer {
   import LogicalPlan._
+  import slamdata.engine.std.StdLib._
+  import structural._
 
   private def countUsage(target: Symbol): LogicalPlan[Int] => Int = {
     case FreeF(symbol) if symbol == target => 1
@@ -32,4 +34,35 @@ object Optimizer {
     }
     case x => Term(x)
   }
+
+  // TODO: implement `preferDeletions` for other backends that may have more
+  //       efficient deletes. Even better, a single function that takes a
+  //       function parameter deciding which way each case should be converted.
+  private val preferProjectionsƒ:
+      LogicalPlan[(
+        Term[LogicalPlan],
+        (Term[LogicalPlan], Option[List[Term[LogicalPlan]]]))] =>
+  (Term[LogicalPlan], Option[List[Term[LogicalPlan]]]) = { node =>
+    def preserveFree(x: (Term[LogicalPlan], (Term[LogicalPlan], Option[List[Term[LogicalPlan]]]))):
+        Term[LogicalPlan] = x._1.unFix match {
+      case FreeF(_) => x._1
+      case _        => x._2._1
+    }
+
+    (node match {
+      case InvokeF(DeleteField, List(src, field)) =>
+        src._2._2.fold(
+          Invoke(DeleteField, List(preserveFree(src), preserveFree(field)))) {
+          fields =>
+          val name = freshName("src", fields)
+            Let(name, preserveFree(src),
+                MakeObjectN(fields.filterNot(_ == field._2._1).map(f =>
+                  f -> Invoke(ObjectProject, List(Free(name), f))): _*))}
+      case lp => Term(lp.map(preserveFree))
+    },
+      shapeƒ(node.map(_._2)))
+  }
+
+  def preferProjections(t: Term[LogicalPlan]): Term [LogicalPlan] =
+    boundPara(t)(preferProjectionsƒ)._1.cata(simplify)
 }

--- a/core/src/main/scala/slamdata/engine/std/structural.scala
+++ b/core/src/main/scala/slamdata/engine/std/structural.scala
@@ -85,6 +85,15 @@ trait StructuralLib extends Library {
     case x => success(AnonElem(x) :: Int :: Nil)
   })
 
+  val DeleteField = Mapping("DELETE_FIELD", "Deletes a specified field from an object",
+    AnyObject :: Str :: Nil,
+    partialTyperV {
+      case v1 :: v2 :: Nil => success(AnyObject) // TODO: remove field from v1 type
+    }, {
+      case x if x.objectLike => success(AnyObject :: Str :: Nil)
+      case x => failure(nel(TypeError(AnyObject, x), Nil))
+    })
+
   val FlattenObject = ExpansionFlat("FLATTEN_OBJECT", "Flattens an object into a set", AnyObject :: Nil, partialTyper {
     case x :: Nil if (!x.objectType.isEmpty) => x.objectType.get
   }, {

--- a/core/src/test/scala/slamdata/engine/analysis/fixplate.scala
+++ b/core/src/test/scala/slamdata/engine/analysis/fixplate.scala
@@ -71,6 +71,10 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
     }
   }
 
+  implicit val ExpUnzip = new Unzip[Exp] {
+    def unzip[A, B](f: Exp[(A, B)]) = (f.map(_._1), f.map(_._2))
+  }
+
   implicit val ExpBinder: Binder[Exp] = new Binder[Exp] {
     type G[A] = Map[Symbol, A]
 
@@ -564,14 +568,6 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
 
       "be non-recursive" in {
         sizeF(mul(num(0), mul(num(1), num(2))).unFix) must_== 2
-      }
-    }
-  }
-
-  "zips" should {
-    "unzipF" should {
-      "unzip simple expr" in {
-        unzipF(Mul((num(0), 0), (num(1), 1)): Exp[(Term[Exp], Int)]) must_== (Mul(num(0), num(1)), Mul(0, 1))
       }
     }
   }

--- a/core/src/test/scala/slamdata/engine/analysis/fixplate.scala
+++ b/core/src/test/scala/slamdata/engine/analysis/fixplate.scala
@@ -403,21 +403,26 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
       }
     }
 
+    def strings(t: Exp[(Int, String)]): String = t match {
+      case Num(x) => x.toString
+      case Mul((x, xs), (y, ys)) =>
+        xs + " (" + x + ")" + ", " + ys + " (" + y + ")"
+      case _ => ???
+    }
+
     "zygo" should {
-      def eval(t: Exp[Int]): Int = t match {
-        case Num(x) => x
-        case Mul(x, y) => x*y
-        case _ => ???
+      "eval and strings" in {
+        mul(mul(num(0), num(0)), mul(num(2), num(5))).zygo(eval, strings) must_==
+        "0 (0), 0 (0) (0), 2 (2), 5 (5) (10)"
       }
-      def strings(t: Exp[(Int, String)]): String = t match {
-        case Num(x) => x.toString
-        case Mul((x, xs), (y, ys)) => xs + ", " + ys
-        case _ => ???
+    }
+
+    "paraZygo" should {
+      "peval and strings" in {
+        mul(mul(num(0), num(0)), mul(num(2), num(5))).paraZygo(peval, strings) must_==
+        "0 (0), 0 (0) (-1), 2 (2), 5 (5) (10)"
       }
 
-      "eval and strings" in {
-        mul(num(0), num(1)).zygo(eval, strings) must_== "0, 1"
-      }
     }
 
     // NB: This is better done with cata, but we fake it here

--- a/core/src/test/scala/slamdata/engine/compiler.scala
+++ b/core/src/test/scala/slamdata/engine/compiler.scala
@@ -639,9 +639,8 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
                   MakeArrayN(
                     Constant(Data.Str("ASC")))),
                 Let('tmp4,
-                  makeObj(
-                    "name" -> ObjectProject(Free('tmp3), Constant(Data.Str("name")))),
-                    Free('tmp4)))))))
+                  DeleteField(Free('tmp3), Constant(Data.Str("__sd__0"))),
+                  Free('tmp4)))))))
     }
 
     "compile simple order by with filter" in {
@@ -670,8 +669,7 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
                       Constant(Data.Str("ASC")),
                       Constant(Data.Str("ASC")))),
                   Let('tmp5,
-                    makeObj(
-                      "name" -> ObjectProject(Free('tmp4), Constant(Data.Str("name")))),
+                    DeleteField(Free('tmp4), Constant(Data.Str("__sd__0"))),
                     Free('tmp5))))))))
     }
 
@@ -732,7 +730,7 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
                     MakeArrayN(
                       Constant(Data.Str("ASC")))),
                 Let('tmp4,
-                  Free('tmp3),
+                  DeleteField(Free('tmp3), Constant(Data.Str("__sd__0"))),
                   Free('tmp4)))))))
     }
 
@@ -776,9 +774,7 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
                   MakeArrayN(
                     Constant(Data.Str("ASC")))),
                 Let('tmp4,
-                  makeObj(
-                    "name" ->
-                      ObjectProject(Free('tmp3), Constant(Data.Str("name")))),
+                  DeleteField(Free('tmp3), Constant(Data.Str("__sd__0"))),
                   Free('tmp4)))))))
     }
 
@@ -807,9 +803,7 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
                     MakeArrayN(
                       Constant(Data.Str("ASC")))),
                   Let('tmp4,
-                    makeObj(
-                      "bar" ->
-                        ObjectProject(Free('tmp3), Constant(Data.Str("bar")))),
+                    DeleteField(Free('tmp3), Constant(Data.Str("__sd__0"))),
                     Free('tmp4))))))))
     }
 
@@ -1096,11 +1090,9 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
                   Constant(Data.Str("DESC")))),
               Let('tmp4,
                 DistinctBy(Free('tmp3),
-                  MakeArrayN(
-                    ObjectProject(Free('tmp3), Constant(Data.Str("city"))))),
+                  DeleteField(Free('tmp3), Constant(Data.Str("__sd__0")))),
                 Let('tmp5,
-                  makeObj(
-                   "city" -> ObjectProject(Free('tmp4), Constant(Data.Str("city")))),
+                  DeleteField(Free('tmp4), Constant(Data.Str("__sd__0"))),
                   Free('tmp5))))))))
     }
 

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/workflowop.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/workflowop.scala
@@ -702,7 +702,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
                       Call(Ident("ObjectId").fix, Nil).fix,
                       Ident("each").fix)).fix)).fix.toJs))),
             Js.Return(Js.Ident("rez"))))),
-          ListMap("clone" -> Bson.JavaScript($SimpleMap.jsClone))))
+          $SimpleMap.implicitScope(Set("clone"))))
       Workflow.finalize(given) must beTree(expected)
     }
 
@@ -756,7 +756,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
                       Call(Ident("ObjectId").fix, Nil).fix,
                       Ident("each").fix)).fix)).fix.toJs))),
             Js.Return(Js.Ident("rez"))))),
-          ListMap("clone" -> Bson.JavaScript($SimpleMap.jsClone))))
+          $SimpleMap.implicitScope(Set("clone"))))
       Workflow.finalize(given) must beTree(expected)
     }
 
@@ -783,7 +783,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
                       Call(Ident("ObjectId").fix, Nil).fix,
                       Ident("each").fix)).fix)).fix.toJs))),
             Js.Return(Js.Ident("rez")))),
-          ListMap("clone" -> Bson.JavaScript($SimpleMap.jsClone))),
+          $SimpleMap.implicitScope(Set("clone"))),
         $reduce($Reduce.reduceNOP, ListMap()))
       Workflow.finalize(given) must beTree(expected)
     }
@@ -1105,8 +1105,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
                     Js.AnonFunDecl(List("__rez"), List(
                       Js.Call(Js.Select(Js.Ident("emit"), "apply"), List(Js.Null, Js.Ident("__rez"))))))))),
               $Reduce.reduceNOP,
-              scope = ListMap(
-                "clone" -> Bson.JavaScript($SimpleMap.jsClone)))),
+              scope = $SimpleMap.implicitScope(Set("clone")))),
           List(
             $Project((),
               Reshape(ListMap(
@@ -1158,8 +1157,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
                     Js.AnonFunDecl(List("__rez"), List(
                       Js.Call(Js.Select(Js.Ident("emit"), "apply"), List(Js.Null, Js.Ident("__rez"))))))))),
               $Reduce.reduceNOP,
-              scope = ListMap(
-                "clone" -> Bson.JavaScript($SimpleMap.jsClone)))),
+              scope = $SimpleMap.implicitScope(Set("clone")))),
           List(
             $Project((),
               Reshape(ListMap(

--- a/it/src/test/resources/tests/doubleFlatten.test
+++ b/it/src/test/resources/tests/doubleFlatten.test
@@ -1,0 +1,20 @@
+{
+    "name": "flatten a flattened field",
+    "backends": { "mongodb": "pending" },
+    "data": "slamengine_commits.data",
+    "query": "select parents[*]{*} from slamengine_commits",
+    "predicate": "containsAtLeast",
+    "expected": [
+        { "parents": "3d44ce48fc0670aaf39ba1acd0e1c161f14cc2d6" },
+        { "parents": "https://api.github.com/repos/slamdata/slamengine/commits/3d44ce48fc0670aaf39ba1acd0e1c161f14cc2d6" },
+        { "parents": "https://github.com/slamdata/slamengine/commit/3d44ce48fc0670aaf39ba1acd0e1c161f14cc2d6" },
+        { "parents": "18164870e8803e5885a88f8dfd53b82c80721503" },
+        { "parents": "https://api.github.com/repos/slamdata/slamengine/commits/18164870e8803e5885a88f8dfd53b82c80721503" },
+        { "parents": "https://github.com/slamdata/slamengine/commit/18164870e8803e5885a88f8dfd53b82c80721503" },
+        { "parents": "b29d8f254e5df2c4d1792f077625924cd1fde2db" },
+        { "parents": "https://api.github.com/repos/slamdata/slamengine/commits/b29d8f254e5df2c4d1792f077625924cd1fde2db" },
+        { "parents": "https://github.com/slamdata/slamengine/commit/b29d8f254e5df2c4d1792f077625924cd1fde2db" },
+        { "parents": "3d44ce48fc0670aaf39ba1acd0e1c161f14cc2d6" },
+        { "parents": "https://api.github.com/repos/slamdata/slamengine/commits/3d44ce48fc0670aaf39ba1acd0e1c161f14cc2d6" },
+        { "parents": "https://github.com/slamdata/slamengine/commit/3d44ce48fc0670aaf39ba1acd0e1c161f14cc2d6" }]
+}

--- a/it/src/test/resources/tests/orderedWildcardWithProjection.test
+++ b/it/src/test/resources/tests/orderedWildcardWithProjection.test
@@ -1,0 +1,17 @@
+{
+    "name": "wildcard with projection and synthetic field",
+    "data": "zips.data",
+    "query": "select *, pop * 10 from zips order by pop / 10 desc",
+    "predicate": "equalsInitial",
+    "expected": [
+        { "value": { "_id": "60623", "city": "CHICAGO",      "loc": [ -87.7157,   41.849015], "pop": 112047.0, "state": "IL", "1": 1120470.0 } },
+        { "value": { "_id": "11226", "city": "BROOKLYN",     "loc": [ -73.956985, 40.646694], "pop": 111396.0, "state": "NY", "1": 1113960.0 } },
+        { "value": { "_id": "10021", "city": "NEW YORK",     "loc": [ -73.958805, 40.768476], "pop": 106564.0, "state": "NY", "1": 1065640.0 } },
+        { "value": { "_id": "10025", "city": "NEW YORK",     "loc": [ -73.968312, 40.797466], "pop": 100027.0, "state": "NY", "1": 1000270.0 } },
+        { "value": { "_id": "90201", "city": "BELL GARDENS", "loc": [-118.17205,  33.969177], "pop":  99568.0, "state": "CA", "1":  995680.0 } },
+        { "value": { "_id": "60617", "city": "CHICAGO",      "loc": [ -87.556012, 41.725743], "pop":  98612.0, "state": "IL", "1":  986120.0 } },
+        { "value": { "_id": "90011", "city": "LOS ANGELES",  "loc": [-118.258189, 34.007856], "pop":  96074.0, "state": "CA", "1":  960740.0 } },
+        { "value": { "_id": "60647", "city": "CHICAGO",      "loc": [ -87.704322, 41.920903], "pop":  95971.0, "state": "IL", "1":  959710.0 } },
+        { "value": { "_id": "60628", "city": "CHICAGO",      "loc": [ -87.624277, 41.693443], "pop":  94317.0, "state": "IL", "1":  943170.0 } },
+        { "value": { "_id": "90650", "city": "NORWALK",      "loc": [-118.081767, 33.90564 ], "pop":  94188.0, "state": "CA", "1":  941880.0 } }]
+}

--- a/it/src/test/resources/tests/shortCities.test
+++ b/it/src/test/resources/tests/shortCities.test
@@ -1,15 +1,11 @@
 {
-  "name": "shortest city names",
-
-  "query": "select distinct city from zips order by length(city), city limit 5",
-
-  "predicate": "equalsExactly",
-
-  "expected": [
-    { "city": "ADA"},
-    { "city": "AMA"},
-    { "city": "ARP"},
-    { "city": "ART"},
-    { "city": "ARY"}
-  ]
+    "name": "shortest city names",
+    "data": "zips.data",
+    "query": "select distinct city from zips order by length(city), city limit 5",
+    "predicate": "equalsExactly",
+    "expected": [{ "city": "ADA" },
+                 { "city": "AMA" },
+                 { "city": "ARP" },
+                 { "city": "ART" },
+                 { "city": "ARY" }]
 }

--- a/it/src/test/resources/tests/sortWildcardOnExpression.test
+++ b/it/src/test/resources/tests/sortWildcardOnExpression.test
@@ -4,14 +4,14 @@
     "query": "select * from zips order by pop/10 desc",
     "predicate": "equalsInitial",
     "expected": [
-        {"value": {"_id": "60623", "city": "CHICAGO", "loc": [-87.7157, 41.849015], "pop": 112047.0, "state": "IL", "__sd__0": 11204.7}},
-        {"value": {"_id": "11226", "city": "BROOKLYN", "loc": [-73.956985, 40.646694], "pop": 111396.0, "state": "NY", "__sd__0": 11139.6}},
-        {"value": {"_id": "10021", "city": "NEW YORK", "loc": [-73.958805, 40.768476], "pop": 106564.0, "state": "NY", "__sd__0": 10656.4}},
-        {"value": {"_id": "10025", "city": "NEW YORK", "loc": [-73.968312, 40.797466], "pop": 100027.0, "state": "NY", "__sd__0": 10002.7}},
-        {"value": {"_id": "90201", "city": "BELL GARDENS", "loc": [-118.17205, 33.969177], "pop": 99568.0, "state": "CA", "__sd__0": 9956.8}},
-        {"value": {"_id": "60617", "city": "CHICAGO", "loc": [-87.556012, 41.725743], "pop": 98612.0, "state": "IL", "__sd__0": 9861.2}},
-        {"value": {"_id": "90011", "city": "LOS ANGELES", "loc": [-118.258189, 34.007856], "pop": 96074.0, "state": "CA", "__sd__0": 9607.4}},
-        {"value": {"_id": "60647", "city": "CHICAGO", "loc": [-87.704322, 41.920903], "pop": 95971.0, "state": "IL", "__sd__0": 9597.1}},
-        {"value": {"_id": "60628", "city": "CHICAGO", "loc": [-87.624277, 41.693443], "pop": 94317.0, "state": "IL", "__sd__0": 9431.7}},
-        {"value": {"_id": "90650", "city": "NORWALK", "loc": [-118.081767, 33.90564], "pop": 94188.0, "state": "CA", "__sd__0": 9418.8}}]
+        {"value": {"_id": "60623", "city": "CHICAGO",      "loc": [ -87.7157,   41.849015], "pop": 112047.0, "state": "IL"}},
+        {"value": {"_id": "11226", "city": "BROOKLYN",     "loc": [ -73.956985, 40.646694], "pop": 111396.0, "state": "NY"}},
+        {"value": {"_id": "10021", "city": "NEW YORK",     "loc": [ -73.958805, 40.768476], "pop": 106564.0, "state": "NY"}},
+        {"value": {"_id": "10025", "city": "NEW YORK",     "loc": [ -73.968312, 40.797466], "pop": 100027.0, "state": "NY"}},
+        {"value": {"_id": "90201", "city": "BELL GARDENS", "loc": [-118.17205,  33.969177], "pop":  99568.0, "state": "CA"}},
+        {"value": {"_id": "60617", "city": "CHICAGO",      "loc": [ -87.556012, 41.725743], "pop":  98612.0, "state": "IL"}},
+        {"value": {"_id": "90011", "city": "LOS ANGELES",  "loc": [-118.258189, 34.007856], "pop":  96074.0, "state": "CA"}},
+        {"value": {"_id": "60647", "city": "CHICAGO",      "loc": [ -87.704322, 41.920903], "pop":  95971.0, "state": "IL"}},
+        {"value": {"_id": "60628", "city": "CHICAGO",      "loc": [ -87.624277, 41.693443], "pop":  94317.0, "state": "IL"}},
+        {"value": {"_id": "90650", "city": "NORWALK",      "loc": [-118.081767, 33.90564],  "pop":  94188.0, "state": "CA"}}]
 }


### PR DESCRIPTION
Fixes #310.

* Add a DeleteField function to the stdlib,
* have the compiler generate the simplest plan, then provide a fold to
  convert deletes to projections for backends to use as an optional
  pass;
* provide a jsLibrary for Workflow that automatically includes
  referenced functions in mapReduce scope;
* move EnvT to the fp package;
* get rid of unzipF in favor of using the Unzip type class;
* fix a bug in boundPara where it ignored bindings;
* add a pending test that flattens a flattened object; and
* add a missing data source to a test.