### PR TITLE
Make aliases available when compiling sort keys.

### DIFF
--- a/core/src/main/scala/slamdata/engine/sql/ast.scala
+++ b/core/src/main/scala/slamdata/engine/sql/ast.scala
@@ -262,12 +262,11 @@ final case class SelectStmt(isDistinct:   IsDistinct,
   // TODO: move this logic to another file where it can be used by both the type checker and compiler?
   def namedProjections(relName: Option[String]): List[(String, Expr)] = {
     def extractName(expr: Expr): Option[String] = expr match {
-      case Ident(name) if Some(name) != relName => Some(name)
-      case Binop(_, StringLiteral(name), FieldDeref) if Some(name) != relName =>
-        Some(name)
-      case Unop(expr, ObjectFlatten)            => extractName(expr)
-      case Unop(expr, ArrayFlatten)             => extractName(expr)
-      case _                                    => None
+      case Ident(name) if Some(name) != relName      => Some(name)
+      case Binop(_, StringLiteral(name), FieldDeref) => Some(name)
+      case Unop(expr, ObjectFlatten)                 => extractName(expr)
+      case Unop(expr, ArrayFlatten)                  => extractName(expr)
+      case _                                         => None
     }
     projections.toList.zipWithIndex.map {
       case (Proj.Named(expr, alias), _)       => alias -> expr

--- a/it/src/test/resources/tests/orderJoinByAlias.test
+++ b/it/src/test/resources/tests/orderJoinByAlias.test
@@ -1,0 +1,16 @@
+{
+    "name": "order join by alias",
+    "data": "zips.data",
+    "query": "select z1._id as zip, z2.pop / 1000 as popK from zips z1 inner join zips z2 on z1._id = z2._id order by popK desc",
+    "predicate": "equalsInitial",
+    "expected": [{ "zip": "60623", "popK": 112.047 },
+                 { "zip": "11226", "popK": 111.396 },
+                 { "zip": "10021", "popK": 106.564 },
+                 { "zip": "10025", "popK": 100.027 },
+                 { "zip": "90201", "popK":  99.568 },
+                 { "zip": "60617", "popK":  98.612 },
+                 { "zip": "90011", "popK":  96.074 },
+                 { "zip": "60647", "popK":  95.971 },
+                 { "zip": "60628", "popK":  94.317 },
+                 { "zip": "90650", "popK":  94.188 }]
+}


### PR DESCRIPTION
Fixes #640.

Also, fix ambiguous relation error so it doesn’t say “no table”.