### PR TITLE
Prepare the SQL AST for functorization.

### DIFF
--- a/core/src/main/scala/slamdata/engine/compiler.scala
+++ b/core/src/main/scala/slamdata/engine/compiler.scala
@@ -308,7 +308,7 @@ trait Compiler[F[_]] {
       case Type.Const(data) => emit(LogicalPlan.Constant(data))
       case _ =>
         node match {
-          case s @ SelectStmt(isDistinct, projections, relations, filter, groupBy, orderBy, limit, offset) =>
+          case s @ Select(isDistinct, projections, relations, filter, groupBy, orderBy, limit, offset) =>
             /*
              * 1. Joins, crosses, subselects (FROM)
              * 2. Filter (WHERE)
@@ -440,8 +440,6 @@ trait Compiler[F[_]] {
               }
             }
 
-          case Subselect(select) => compile0(select)
-
           case SetLiteral(values0) =>
             val values = (values0.map {
               case IntLiteral(v) => emit[Data](Data.Int(v))
@@ -556,7 +554,7 @@ trait Compiler[F[_]] {
 
           case TableRelationAST(name, _) => emit(LogicalPlan.Read(Path(name)))
 
-          case SubqueryRelationAST(subquery, _) => compile0(subquery)
+          case ExprRelationAST(expr, _) => compile0(expr)
 
           case JoinRelation(left, right, tpe, clause) =>
             for {

--- a/core/src/main/scala/slamdata/engine/errors.scala
+++ b/core/src/main/scala/slamdata/engine/errors.scala
@@ -69,10 +69,10 @@ object SemanticError {
   }
   case class DuplicateRelationName(defined: String, duplicated: SqlRelation) extends SemanticError {
     private def nameOf(r: SqlRelation) = r match {
-      case r @ TableRelationAST(name, aliasOpt) => aliasOpt.getOrElse(name)
-      case r @ SubqueryRelationAST(subquery, alias) => alias
-      case r @ JoinRelation(left, right, join, clause) => "unknown"
-      case r @ CrossRelation(left, right) => "unknown"
+      case TableRelationAST(name, aliasOpt) => aliasOpt.getOrElse(name)
+      case ExprRelationAST(_, alias)        => alias
+      case JoinRelation(_, _, _, _)         => "unknown"
+      case CrossRelation(_, _)              => "unknown"
     }
 
     def message = "Found relation with duplicate name '" + defined + "': " + defined

--- a/core/src/main/scala/slamdata/engine/sql/ast.scala
+++ b/core/src/main/scala/slamdata/engine/sql/ast.scala
@@ -22,15 +22,13 @@ sealed trait Node {
 
   type Self = this.type
 
-  def mapUpM[F[_]: Monad](select:   SelectStmt => F[SelectStmt],
-                          proj:     Proj => F[Proj],
+  def mapUpM[F[_]: Monad](proj:     Proj => F[Proj],
                           relation: SqlRelation => F[SqlRelation],
                           expr:     Expr => F[Expr],
                           groupBy:  GroupBy => F[GroupBy],
                           orderBy:  OrderBy => F[OrderBy],
                           case0:    Case => F[Case]): F[Self] = {
     mapUpM0[F](
-      v => select(v._2),
       v => proj(v._2),
       v => relation(v._2),
       v => expr(v._2),
@@ -39,23 +37,12 @@ sealed trait Node {
       v => case0(v._2))
   }
 
-  def mapUpM0[F[_]: Monad](select:  ((SelectStmt, SelectStmt)) => F[SelectStmt],
-                          proj:     ((Proj, Proj)) => F[Proj],
-                          relation: ((SqlRelation, SqlRelation)) => F[SqlRelation],
-                          expr:     ((Expr, Expr)) => F[Expr],
-                          groupBy:  ((GroupBy, GroupBy)) => F[GroupBy],
-                          orderBy:  ((OrderBy, OrderBy)) => F[OrderBy],
-                          case0:    ((Case, Case)) => F[Case]): F[Self] = {
-
-    def selectLoop(node: SelectStmt): F[SelectStmt] = node match {
-      case select0 @ SelectStmt(d, p, r, f, g, o, limit, offset) => (for {
-        p2 <- p.map(projLoop).sequence
-        r2 <- r.map(relationLoop).sequence
-        f2 <- f.map(exprLoop).sequence
-        g2 <- g.map(groupByLoop).sequence
-        o2 <- o.map(orderByLoop).sequence
-      } yield select0 -> SelectStmt(d, p2, r2, f2, g2, o2, limit, offset)).flatMap(select)
-    }
+  def mapUpM0[F[_]: Monad](proj:     ((Proj, Proj)) => F[Proj],
+                           relation: ((SqlRelation, SqlRelation)) => F[SqlRelation],
+                           expr:     ((Expr, Expr)) => F[Expr],
+                           groupBy:  ((GroupBy, GroupBy)) => F[GroupBy],
+                           orderBy:  ((OrderBy, OrderBy)) => F[OrderBy],
+                           case0:    ((Case, Case)) => F[Case]): F[Self] = {
 
     def caseLoop(node: Case): F[Case] = (for {
       cond <- exprLoop(node.cond)
@@ -65,17 +52,16 @@ sealed trait Node {
     def projLoop(node: Proj): F[Proj] = (for {
       x2 <- exprLoop(node.expr)
     } yield node -> (node match {
-      case Proj.Anon(_)               => Proj.Anon(x2)
-      case Proj.Named(_, alias)       => Proj.Named(x2, alias)
+      case Proj(_, alias) => Proj(x2, alias)
     })).flatMap(proj)
 
     def relationLoop(node: SqlRelation): F[SqlRelation] = node match {
       case t @ TableRelationAST(_, _) => relation(t -> t)
 
-      case r @ SubqueryRelationAST(s, alias) =>
+      case r @ ExprRelationAST(expr, alias) =>
         (for {
-          s2 <- selectLoop(s)
-        } yield r -> SubqueryRelationAST(s2, alias)).flatMap(relation)
+          expr2 <- exprLoop(expr)
+        } yield r -> ExprRelationAST(expr2, alias)).flatMap(relation)
 
       case r @ CrossRelation(left, right) =>
         (for {
@@ -131,10 +117,13 @@ sealed trait Node {
           d2 <- default.map(exprLoop).sequence
         } yield e -> Switch(c2, d2)).flatMap(expr)
 
-      case e @ Subselect(sel) =>
-        (for {
-          s2 <- selectLoop(sel)
-        } yield e -> Subselect(s2)).flatMap(expr)
+      case select0 @ Select(d, p, r, f, g, o, limit, offset) => (for {
+        p2 <- p.map(projLoop).sequence
+        r2 <- r.map(relationLoop).sequence
+        f2 <- f.map(exprLoop).sequence
+        g2 <- g.map(groupByLoop).sequence
+        o2 <- o.map(orderByLoop).sequence
+      } yield select0 -> Select(d, p2, r2, f2, g2, o2, limit, offset)).flatMap(expr)
 
       case e @ Splice(Some(x)) =>
         (for {
@@ -160,12 +149,11 @@ sealed trait Node {
     } yield node -> OrderBy(k2)).flatMap(orderBy)
 
     (this match {
-      case x : SelectStmt  => selectLoop(x)
-      case x : SqlRelation => relationLoop(x)
-      case x : Expr        => exprLoop(x)
-      case x : GroupBy     => groupByLoop(x)
-      case x : OrderBy     => orderByLoop(x)
-      case x               => x.point[F]
+      case x: SqlRelation => relationLoop(x)
+      case x: Expr        => exprLoop(x)
+      case x: GroupBy     => groupByLoop(x)
+      case x: OrderBy     => orderByLoop(x)
+      case x              => x.point[F]
     }).asInstanceOf[F[Self]]
   }
 }
@@ -174,7 +162,7 @@ trait NodeInstances {
   implicit def NodeRenderTree[A <: Node]: RenderTree[A] = new RenderTree[A] {
     override def render(n: A) = {
       n match {
-        case SelectStmt(isDistinct, projections, relations, filter, groupBy, orderBy, limit, offset) =>
+        case Select(isDistinct, projections, relations, filter, groupBy, orderBy, limit, offset) =>
           NonTerminal(isDistinct match { case `SelectDistinct` =>  "distinct"; case _ => "" },
                       projections.map(p => NodeRenderTree.render(p)) ++
                         (relations.map(r => NodeRenderTree.render(r)) ::
@@ -186,10 +174,9 @@ trait NodeInstances {
                           Nil).flatten,
                     List("AST", "Select"))
 
-        case Proj.Named(expr, alias)       => NonTerminal(alias, NodeRenderTree.render(expr) :: Nil, List("AST", "Proj"))
-        case Proj.Anon(expr)               => NonTerminal("", NodeRenderTree.render(expr) :: Nil, List("AST", "Proj"))
+        case Proj(expr, alias) => NonTerminal(alias.getOrElse(""), NodeRenderTree.render(expr) :: Nil, List("AST", "Proj"))
 
-        case SubqueryRelationAST(select, alias) => NonTerminal("Subquery as " + alias, NodeRenderTree.render(select) :: Nil, List("AST", "SubqueryRelation"))
+        case ExprRelationAST(select, alias) => NonTerminal("Expr as " + alias, NodeRenderTree.render(select) :: Nil, List("AST", "ExprRelation"))
 
         case TableRelationAST(name, Some(alias)) => Terminal(name + " as " + alias, List("AST", "TableRelation"))
         case TableRelationAST(name, None)        => Terminal(name, List("AST", "TableRelation"))
@@ -204,8 +191,6 @@ trait NodeInstances {
 
         case GroupBy(keys, Some(having)) => NonTerminal("", keys.map(NodeRenderTree.render(_)) :+ NodeRenderTree.render(having), List("AST", "GroupBy"))
         case GroupBy(keys, None)         => NonTerminal("", keys.map(NodeRenderTree.render(_)), List("AST", "GroupBy"))
-
-        case Subselect(select) => NodeRenderTree.render(select)
 
         case SetLiteral(exprs) => NonTerminal("", exprs.map(NodeRenderTree.render(_)), List("AST", "Set"))
         case ArrayLiteral(exprs) => NonTerminal("", exprs.map(NodeRenderTree.render(_)), List("AST", "Array"))
@@ -238,24 +223,37 @@ trait NodeInstances {
 
 object Node extends NodeInstances
 
-final case class SelectStmt(isDistinct:   IsDistinct,
-                            projections:  List[Proj],
-                            relations:    Option[SqlRelation],
-                            filter:       Option[Expr],
-                            groupBy:      Option[GroupBy],
-                            orderBy:      Option[OrderBy],
-                            limit:        Option[Long],
-                            offset:       Option[Long]) extends Node {
+trait IsDistinct
+case object SelectDistinct extends IsDistinct
+case object SelectAll extends IsDistinct
+
+case class Proj(expr: Expr, alias: Option[String]) extends Node {
+  def children = expr :: Nil
+  def sql = alias.foldLeft(expr.sql)(_ + " as " + _qq(_))
+}
+
+sealed trait Expr extends Node
+
+final case class Select(isDistinct:   IsDistinct,
+                        projections:  List[Proj],
+                        relations:    Option[SqlRelation],
+                        filter:       Option[Expr],
+                        groupBy:      Option[GroupBy],
+                        orderBy:      Option[OrderBy],
+                        limit:        Option[Long],
+                        offset:       Option[Long]) extends Expr {
   def sql =
-    List(Some("select"),
-      isDistinct match { case `SelectDistinct` => Some("distinct"); case _ => None },
-        Some(projections.map(_.sql).mkString(", ")),
-        relations.headOption.map(κ("from " + relations.map(_.sql).mkString(", "))),
-        filter.map(x => "where " + x.sql),
-        groupBy.map(_.sql),
-        orderBy.map(_.sql),
-        limit.map(x => "limit " + x.toString),
-        offset.map(x => "offset " + x.toString)).flatten.mkString(" ")
+    "(" +
+      List(Some("select"),
+           isDistinct match { case `SelectDistinct` => Some("distinct"); case _ => None },
+           Some(projections.map(_.sql).mkString(", ")),
+           relations.headOption.map(κ("from " + relations.map(_.sql).mkString(", "))),
+           filter.map(x => "where " + x.sql),
+           groupBy.map(_.sql),
+           orderBy.map(_.sql),
+           limit.map(x => "limit " + x.toString),
+           offset.map(x => "offset " + x.toString)).flatten.mkString(" ") +
+      ")"
 
   def children: List[Node] = projections.toList ++ relations ++ filter.toList ++ groupBy.toList ++ orderBy.toList
 
@@ -270,37 +268,10 @@ final case class SelectStmt(isDistinct:   IsDistinct,
       case _                                    => None
     }
     projections.toList.zipWithIndex.map {
-      case (Proj.Named(expr, alias), _)       => alias -> expr
-      case (Proj.Anon(expr), index)           => extractName(expr).getOrElse(index.toString()) -> expr
+      case (Proj(expr, alias), index) =>
+        (alias <+> extractName(expr)).getOrElse(index.toString()) -> expr
     }
   }
-}
-
-trait IsDistinct
-case object SelectDistinct extends IsDistinct
-case object SelectAll extends IsDistinct
-
-sealed trait Proj extends Node {
-  def expr: Expr
-  def children = expr :: Nil
-}
-object Proj {
-  case class Anon(expr: Expr) extends Proj {
-    def sql = expr.sql
-  }
-  case class Named(expr: Expr, alias: String) extends Proj {
-    def sql = expr.sql + " as " + _qq(alias)
-  }
-}
-
-sealed trait Expr extends Node
-
-sealed trait SetExpr extends Expr
-
-final case class Subselect(select: SelectStmt) extends SetExpr {
-  def sql = List("(", select.sql, ")") mkString ""
-
-  def children = select :: Nil
 }
 
 final case class Vari(symbol: String) extends Expr {
@@ -309,13 +280,13 @@ final case class Vari(symbol: String) extends Expr {
   def children = Nil
 }
 
-final case class SetLiteral(exprs: List[Expr]) extends SetExpr {
+final case class SetLiteral(exprs: List[Expr]) extends Expr {
   def sql = exprs.map(_.sql).mkString("(", ", ", ")")
 
   def children = exprs.toList
 }
 
-final case class ArrayLiteral(exprs: List[Expr]) extends SetExpr {
+final case class ArrayLiteral(exprs: List[Expr]) extends Expr {
   def sql = exprs.map(_.sql).mkString("[", ", ", "]")
 
   def children = exprs.toList
@@ -472,7 +443,7 @@ sealed trait SqlRelation extends Node {
   def namedRelations: Map[String, List[NamedRelation]] = {
     def collect(n: SqlRelation): List[(String, NamedRelation)] = n match {
       case t @ TableRelationAST(_, _) => (t.aliasName -> t) :: Nil
-      case t @ SubqueryRelationAST(_, _) => (t.aliasName -> t) :: Nil
+      case t @ ExprRelationAST(_, _) => (t.aliasName -> t) :: Nil
       case CrossRelation(left, right) => collect(left) ++ collect(right)
       case JoinRelation(left, right, _, _) => collect(left) ++ collect(right)
     }
@@ -493,10 +464,11 @@ final case class TableRelationAST(name: String, alias: Option[String]) extends N
   def children = Nil
 }
 
-final case class SubqueryRelationAST(subquery: SelectStmt, aliasName: String) extends NamedRelation {
-  def sql = List("(", subquery.sql, ")", "as", aliasName) mkString " "
+final case class ExprRelationAST(expr: Expr, aliasName: String)
+    extends NamedRelation {
+  def sql = List(expr.sql, "as", aliasName) mkString " "
 
-  def children = subquery :: Nil
+  def children = expr :: Nil
 }
 
 final case class CrossRelation(left: SqlRelation, right: SqlRelation) extends SqlRelation {

--- a/core/src/main/scala/slamdata/engine/variables.scala
+++ b/core/src/main/scala/slamdata/engine/variables.scala
@@ -58,7 +58,6 @@ object Variables {
     tree.root.mapUpM0[M](
       unchanged _,
       unchanged _,
-      unchanged _,
       {
         case (old, v @ Vari(name)) if vars.value.contains(VarName(name)) =>
           val tpe  = typeOf(v)

--- a/core/src/test/scala/slamdata/engine/backend.scala
+++ b/core/src/test/scala/slamdata/engine/backend.scala
@@ -12,14 +12,14 @@ class BackendSpecs extends Specification with DisjunctionMatchers {
     import slamdata.engine.fs.{Path}
 
     "make simple table name relative to base path" in {
-      val q = SelectStmt(SelectAll,
-        Proj.Anon(Splice(None)) :: Nil,
+      val q = Select(SelectAll,
+        Proj(Splice(None), None) :: Nil,
         Some(TableRelationAST("bar", None)),
         None, None, None, None, None)
       val mountPath = Path("/")
       val basePath = Path("/foo/")
-      val exp = SelectStmt(SelectAll,
-        Proj.Anon(Splice(None)) :: Nil,
+      val exp = Select(SelectAll,
+        Proj(Splice(None), None) :: Nil,
         Some(TableRelationAST("./foo/bar", None)),
         None, None, None, None, None)
 
@@ -27,21 +27,21 @@ class BackendSpecs extends Specification with DisjunctionMatchers {
     }
 
     "make sub-query table names relative to base path" in {
-      val q = SelectStmt(SelectAll,
-        Proj.Anon(Splice(None)) :: Nil,
-        Some(SubqueryRelationAST(
-          SelectStmt(SelectAll,
-            Proj.Anon(Splice(None)) :: Nil,
+      val q = Select(SelectAll,
+        Proj(Splice(None), None) :: Nil,
+        Some(ExprRelationAST(
+          Select(SelectAll,
+            Proj(Splice(None), None) :: Nil,
             Some(TableRelationAST("bar", None)),
             None, None, None, None, None), "t")),
         None, None, None, None, None)
       val mountPath = Path("/")
       val basePath = Path("/foo/")
-      val exp = SelectStmt(SelectAll,
-        Proj.Anon(Splice(None)) :: Nil,
-        Some(SubqueryRelationAST(
-          SelectStmt(SelectAll,
-            Proj.Anon(Splice(None)) :: Nil,
+      val exp = Select(SelectAll,
+        Proj(Splice(None), None) :: Nil,
+        Some(ExprRelationAST(
+          Select(SelectAll,
+            Proj(Splice(None), None) :: Nil,
             Some(TableRelationAST("./foo/bar", None)),
             None, None, None, None, None), "t")),
         None, None, None, None, None)
@@ -50,8 +50,8 @@ class BackendSpecs extends Specification with DisjunctionMatchers {
     }
 
     "make join table names relative to base path" in {
-      val q = SelectStmt(SelectAll,
-        Proj.Anon(Splice(None)) :: Nil,
+      val q = Select(SelectAll,
+        Proj(Splice(None), None) :: Nil,
         Some(JoinRelation(
           TableRelationAST("bar", None),
           TableRelationAST("baz", None),
@@ -61,8 +61,8 @@ class BackendSpecs extends Specification with DisjunctionMatchers {
         None, None, None, None, None)
       val mountPath = Path("/")
       val basePath = Path("/foo/")
-      val exp = SelectStmt(SelectAll,
-        Proj.Anon(Splice(None)) :: Nil,
+      val exp = Select(SelectAll,
+        Proj(Splice(None), None) :: Nil,
         Some(JoinRelation(
           TableRelationAST("./foo/bar", None),
           TableRelationAST("./foo/baz", None),
@@ -75,16 +75,16 @@ class BackendSpecs extends Specification with DisjunctionMatchers {
     }
 
     "make cross table names relative to base path" in {
-      val q = SelectStmt(SelectAll,
-        Proj.Anon(Splice(None)) :: Nil,
+      val q = Select(SelectAll,
+        Proj(Splice(None), None) :: Nil,
         Some(CrossRelation(
           TableRelationAST("bar", None),
           TableRelationAST("baz", None))),
         None, None, None, None, None)
       val mountPath = Path("/")
       val basePath = Path("/foo/")
-      val exp = SelectStmt(SelectAll,
-        Proj.Anon(Splice(None)) :: Nil,
+      val exp = Select(SelectAll,
+        Proj(Splice(None), None) :: Nil,
         Some(CrossRelation(
           TableRelationAST("./foo/bar", None),
           TableRelationAST("./foo/baz", None))),
@@ -94,30 +94,28 @@ class BackendSpecs extends Specification with DisjunctionMatchers {
     }
 
     "make sub-select table names relative to base path" in {
-      val q = SelectStmt(SelectAll,
-        Proj.Anon(Splice(None)) :: Nil,
+      val q = Select(SelectAll,
+        Proj(Splice(None), None) :: Nil,
         Some(TableRelationAST("bar", None)),
         Some(Binop(
           Ident("widgetId"),
-          Subselect(
-            SelectStmt(SelectAll,
-              Proj.Anon(Ident("id")) :: Nil,
-              Some(TableRelationAST("widget", None)),
-              None, None, None, None, None)),
+          Select(SelectAll,
+            Proj(Ident("id"), None) :: Nil,
+            Some(TableRelationAST("widget", None)),
+            None, None, None, None, None),
           In)),
         None, None, None, None)
       val mountPath = Path("/")
       val basePath = Path("/foo/")
-      val exp = SelectStmt(SelectAll,
-        Proj.Anon(Splice(None)) :: Nil,
+      val exp = Select(SelectAll,
+        Proj(Splice(None), None) :: Nil,
         Some(TableRelationAST("./foo/bar", None)),
         Some(Binop(
           Ident("widgetId"),
-          Subselect(
-            SelectStmt(SelectAll,
-              Proj.Anon(Ident("id")) :: Nil,
-              Some(TableRelationAST("./foo/widget", None)),
-              None, None, None, None, None)),
+          Select(SelectAll,
+            Proj(Ident("id"), None) :: Nil,
+            Some(TableRelationAST("./foo/widget", None)),
+            None, None, None, None, None),
           In)),
         None, None, None, None)
 

--- a/core/src/test/scala/slamdata/engine/semantics.scala
+++ b/core/src/test/scala/slamdata/engine/semantics.scala
@@ -21,137 +21,129 @@ class SemanticsSpec extends Specification with PendingWithAccurateCoverage {
       SemanticAnalysis.TransformSelect(tree(q)).fold(e => None, tree => Some(tree.root))
 
     "add single field for order by" in {
-      val q = SelectStmt(SelectAll,
-                         Proj.Anon(Ident("name")) :: Nil,
-                         Some(TableRelationAST("person", None)),
-                         None,
-                         None,
-                         Some(OrderBy((Ident("height"), ASC) :: Nil)),
-                         None,
-                         None)
+      val q = Select(SelectAll,
+                     Proj(Ident("name"), None) :: Nil,
+                     Some(TableRelationAST("person", None)),
+                     None,
+                     None,
+                     Some(OrderBy((Ident("height"), ASC) :: Nil)),
+                     None,
+                     None)
       transform(q) must beSome(
-               SelectStmt(SelectAll,
-                         Proj.Anon(Ident("name")) :: Proj.Named(Ident("height"), "__sd__0") :: Nil,
-                         Some(TableRelationAST("person", None)),
-                         None,
-                         None,
-                         Some(OrderBy((Ident("__sd__0"), ASC) :: Nil)),
-                         None,
-                         None)
+               Select(SelectAll,
+                      Proj(Ident("name"), None) :: Proj(Ident("height"), Some("__sd__0")) :: Nil,
+                      Some(TableRelationAST("person", None)),
+                      None,
+                      None,
+                      Some(OrderBy((Ident("__sd__0"), ASC) :: Nil)),
+                      None,
+                      None)
                )
     }
 
     "not add a field that appears in the projections" in {
-      val q = SelectStmt(SelectAll,
-                         Proj.Anon(Ident("name")) :: Nil,
-                         Some(TableRelationAST("person", None)),
-                         None,
-                         None,
-                         Some(OrderBy((Ident("name"), ASC) :: Nil)),
-                         None,
-                         None)
+      val q = Select(SelectAll,
+                     Proj(Ident("name"), None) :: Nil,
+                     Some(TableRelationAST("person", None)),
+                     None,
+                     None,
+                     Some(OrderBy((Ident("name"), ASC) :: Nil)),
+                     None,
+                     None)
       transform(q) must beSome(q)
     }
 
     "not add a field that appears as an alias in the projections" in {
-      val q = SelectStmt(SelectAll,
-                         Proj.Named(Ident("foo"), "name") :: Nil,
-                         Some(TableRelationAST("person", None)),
-                         None,
-                         None,
-                         Some(OrderBy((Ident("name"), ASC) :: Nil)),
-                         None,
-                         None)
+      val q = Select(SelectAll,
+                     Proj(Ident("foo"), Some("name")) :: Nil,
+                     Some(TableRelationAST("person", None)),
+                     None,
+                     None,
+                     Some(OrderBy((Ident("name"), ASC) :: Nil)),
+                     None,
+                     None)
       transform(q) must beSome(q)
     }
 
     "not add a field with wildcard present" in {
-      val q = SelectStmt(SelectAll,
-                         Proj.Anon(Splice(None)) :: Nil,
-                         Some(TableRelationAST("person", None)),
-                         None,
-                         None,
-                         Some(OrderBy((Ident("height"), ASC) :: Nil)),
-                         None,
-                         None)
+      val q = Select(SelectAll,
+                     Proj(Splice(None), None) :: Nil,
+                     Some(TableRelationAST("person", None)),
+                     None,
+                     None,
+                     Some(OrderBy((Ident("height"), ASC) :: Nil)),
+                     None,
+                     None)
       transform(q) must beSome(q)
     }
 
     "add single field for order by" in {
-      val q = SelectStmt(SelectAll,
-                         Proj.Anon(Ident("name")) :: Nil,
-                         Some(TableRelationAST("person", None)),
-                         None,
-                         None,
-                         Some(OrderBy((Ident("height"), ASC) ::
-                                       (Ident("name"), ASC) :: Nil)),
-                         None,
-                         None)
+      val q = Select(SelectAll,
+                     Proj(Ident("name"), None) :: Nil,
+                     Some(TableRelationAST("person", None)),
+                     None,
+                     None,
+                     Some(OrderBy((Ident("height"), ASC) ::
+                                   (Ident("name"), ASC) :: Nil)),
+                     None,
+                     None)
       transform(q) must beSome(
-               SelectStmt(SelectAll,
-                         Proj.Anon(Ident("name")) ::
-                           Proj.Named(Ident("height"), "__sd__0") ::
-                           Nil,
-                         Some(TableRelationAST("person", None)),
-                         None,
-                         None,
-                         Some(OrderBy((Ident("__sd__0"), ASC) ::
-                                       (Ident("name"), ASC) ::
-                                       Nil)),
-                         None,
-                         None)
-               )
+               Select(SelectAll,
+                      Proj(Ident("name"), None) ::
+                        Proj(Ident("height"), Some("__sd__0")) ::
+                        Nil,
+                      Some(TableRelationAST("person", None)),
+                      None,
+                      None,
+                      Some(OrderBy((Ident("__sd__0"), ASC) ::
+                                    (Ident("name"), ASC) ::
+                                    Nil)),
+                      None,
+                      None))
     }
 
     "transform sub-select" in {
-      val q = SelectStmt(SelectAll,
-                         Proj.Anon(Splice(None)) :: Nil,
-                         Some(TableRelationAST("foo", None)),
-                         Some(
-                           Binop(
-                             Ident("a"),
-                             Subselect(
-                               SelectStmt(SelectAll,
-                                          Proj.Anon(Ident("a")) :: Nil,
-                                          Some(TableRelationAST("bar", None)),
-                                          None,
-                                          None,
-                                          Some(OrderBy((Ident("b"), ASC) :: Nil)),
-                                          None,
-                                          None)
-                             ),
-                             In)
-                         ),
-                         None,
-                         None,
-                         None,
-                         None)
+      val q = Select(SelectAll,
+                     Proj(Splice(None), None) :: Nil,
+                     Some(TableRelationAST("foo", None)),
+                     Some(
+                       Binop(
+                         Ident("a"),
+                         Select(SelectAll,
+                                Proj(Ident("a"), None) :: Nil,
+                                Some(TableRelationAST("bar", None)),
+                                None,
+                                None,
+                                Some(OrderBy((Ident("b"), ASC) :: Nil)),
+                                None,
+                                None),
+                         In)),
+                     None,
+                     None,
+                     None,
+                     None)
       transform(q) must beSome(
-              SelectStmt(SelectAll,
-                         Proj.Anon(Splice(None)) :: Nil,
-                         Some(TableRelationAST("foo", None)),
-                         Some(
-                           Binop(
-                             Ident("a"),
-                             Subselect(
-                               SelectStmt(SelectAll,
-                                          Proj.Anon(Ident("a")) ::
-                                            Proj.Named(Ident("b"), "__sd__0") ::
-                                            Nil,
-                                          Some(TableRelationAST("bar", None)),
-                                          None,
-                                          None,
-                                          Some(OrderBy((Ident("__sd__0"), ASC) :: Nil)),
-                                          None,
-                                          None)
-                             ),
-                             In)
-                         ),
-                         None,
-                         None,
-                         None,
-                         None)
-      )
+              Select(SelectAll,
+                     Proj(Splice(None), None) :: Nil,
+                     Some(TableRelationAST("foo", None)),
+                     Some(
+                       Binop(
+                         Ident("a"),
+                         Select(SelectAll,
+                                Proj(Ident("a"), None) ::
+                                  Proj(Ident("b"), Some("__sd__0")) ::
+                                  Nil,
+                                Some(TableRelationAST("bar", None)),
+                                None,
+                                None,
+                                Some(OrderBy((Ident("__sd__0"), ASC) :: Nil)),
+                                None,
+                                None),
+                         In)),
+                     None,
+                     None,
+                     None,
+                     None))
     }.pendingUntilFixed
 
   }


### PR DESCRIPTION
Simplify some structure and eliminate mutual recursion. Actually making
it a functor will require major changes to semantics.scala and
compiler.scala, so … holding off on that.

* Combine `Proj.Anon` and `Proj.Named` (the alias is handled with
  `Option[String]`);
* generalize `SubqueryRelationAST` to `ExprRelationAST`; and
* merge `SelectStmt` and `Subselect` into `Select` (which is an `Expr`).

Consequently, we now use `expr` as the primary parser, rather than
`select`. This means that `1 + 2` could be parsed at the top level, but
neither our admin tool nor REPL currently allow this.