### PR TITLE
disable info-level logging from MongoDB (fixes #678)

### DIFF
--- a/core/src/main/scala/slamdata/engine/physical/mongodb/util.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/util.scala
@@ -15,10 +15,14 @@ object util {
   }
 
   def createMongoClient(config: MongoDbConfig): Task[MongoClient] = {
-    // Disable Mongo’s logger … by disabling all logging
-    val globalLogger = java.util.logging.Logger.getGlobal
-    globalLogger.getHandlers.map(globalLogger.removeHandler)
+    disableMongoLogging
 
     Task.delay(mongoClient(config.connectionUri))
+  }
+
+  private def disableMongoLogging = {
+    import java.util.logging._
+
+    Logger.getLogger("org.mongodb").setLevel(Level.WARNING)
   }
 }


### PR DESCRIPTION
Something changed in the 3.0 driver, and our previous approach no longer works.
Explicitly setting the level for `org.mongodb` does the trick.