### PR TITLE
Let the client specify if they want precise JSON.

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,9 @@ The server provides a simple JSON API.
 
 ### GET /query/fs/[path]?q=[query]
 
-Executes a SQL query, contained in the single, required query parameter, on the backend responsible for the
-request path. The result is returned in the response body, formatted as one JSON object per line.
+Executes a SQL query, contained in the single, required query parameter, on the backend responsible for the request path.
+
+The result is returned in the response body, formatted as one JSON object per line. By default, the “readable” JSON format (described below) is returned, but the “precise” format can be requested by including a header like `Accept: application/ldjson;mode=precise`.
 
 SQL `limit` syntax may be used to keep the result size reasonable.
 

--- a/web/src/main/scala/slamdata/engine/api/fs.scala
+++ b/web/src/main/scala/slamdata/engine/api/fs.scala
@@ -14,6 +14,7 @@ import Argonaut._
 import org.http4s.{Query => HQuery, _}
 import org.http4s.dsl.{Path => HPath, _}
 import org.http4s.argonaut._
+import org.http4s.headers._
 import org.http4s.server._
 import org.http4s.util.{CaseInsensitiveString, Renderable}
 
@@ -27,11 +28,40 @@ class FileSystemApi(fs: FSTable[Backend]) {
   import java.io.{FileSystem => _, _}
   import Method.{MOVE, OPTIONS}
 
-  private def jsonStream(v: Process[Task, Data])(implicit EE: EncodeJson[DataEncodingError]): Task[Response] = {
-    val codec = DataCodec.Readable
+  private def responseCodec(accept: Option[Accept]): (DataCodec, MediaType) = {
+    val jsonTypes = NonEmptyList(
+      new MediaType("application", "ldjson"),
+      new MediaType("application", "x-ldjson"),
+      new MediaType("application", "json",
+        extensions = Map("boundary" -> "NL")))
+
+    def responseType(mode: String) =
+      jsonTypes.head.withExtensions(jsonTypes.head.extensions ++ Map("mode" -> mode))
+
+    (for {
+      acc       <- accept
+      // TODO: MediaRange needs an Order instance – combining QValue ordering
+      //       with specificity (EG, application/json sorts before
+      //       application/* if they have the same q-value).
+      mediaType <- acc.values.toList.sortBy(_.qValue).find(a => jsonTypes.toList.exists(a.satisfies(_)))
+      mode      <- mediaType.extensions.get("mode")
+      codec     <- mode match {
+        case "precise" => Some((DataCodec.Precise, responseType("precise")))
+        case _         => None
+      }
+    } yield codec).getOrElse((DataCodec.Readable, responseType("readable")))
+  }
+
+  private def jsonStream(codec: DataCodec, v: Process[Task, Data])(implicit EE: EncodeJson[DataEncodingError]): Task[Response] = {
     Ok(v.map { data =>
       DataCodec.render(data)(codec).fold(err => EE.encode(err).toString, identity) + "\r\n"
     })
+  }
+
+  private def responseStream(accept: Option[Accept], v: Process[Task, Data]):
+      Task[Response] = {
+    val (codec, mediaType) = responseCodec(accept)
+    jsonStream(codec, v).map(_.putHeaders(`Content-Type`(mediaType, Some(Charset.`UTF-8`))))
   }
 
   private def lookupBackend(path: Path): Task[Response] \/ (Backend, Path, Path) =
@@ -121,14 +151,14 @@ class FileSystemApi(fs: FSTable[Backend]) {
 
   def queryService = {
     corsService {
-      case GET -> AsDirPath(path) :? Q(query) =>
+      case req @ GET -> AsDirPath(path) :? Q(query) =>
         (for {
           b     <- backendFor(path)
           (backend, mountPath) = b
 
           (phases, resultT) = backend.eval(QueryRequest(query, None, mountPath, path))
           result <- resultT.attemptRun.leftMap(e =>  errorResponse(BadRequest, e))
-        } yield jsonStream(result)).fold(identity, identity)
+        } yield responseStream(req.headers.get(Accept), result)).fold(identity, identity)
 
       case GET -> _ => QueryParameterMustContainQuery
 
@@ -211,11 +241,11 @@ class FileSystemApi(fs: FSTable[Backend]) {
   }
 
   def dataService = corsService {
-    case GET -> AsPath(path) :? Offset(offset) +& Limit(limit) =>
+    case req @ GET -> AsPath(path) :? Offset(offset) +& Limit(limit) =>
       (for {
         t <- dataSourceFor(path)
         (dataSource, relPath) = t
-      } yield jsonStream(dataSource.scan(relPath, offset, limit))).getOrElse(NotFound())
+      } yield responseStream(req.headers.get(Accept), dataSource.scan(relPath, offset, limit))).getOrElse(NotFound())
 
     case req @ PUT -> AsPath(path) => for {
       body <- EntityDecoder.decodeString(req)
@@ -232,7 +262,7 @@ class FileSystemApi(fs: FSTable[Backend]) {
 
     case req @ MOVE -> AsPath(path) =>
       (for {
-          dstRaw <- req.headers.get(Destination).map(_.value) \/> (BadRequest("Destination header required"))
+          dstRaw <- req.headers.get(Destination).map(_.value) \/> DestinationHeaderMustExist
           dst <- Path(dstRaw).from(path.dirOf).leftMap(e => BadRequest("Invalid destination path: " + e.getMessage))
 
           t1 <- dataSourceFor(path)

--- a/web/src/test/scala/slamdata/engine/api/fs.scala
+++ b/web/src/test/scala/slamdata/engine/api/fs.scala
@@ -92,7 +92,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
 
 
   /** Handler for response bodies containing newline-separated JSON documents, for use with Dispatch. */
-  object asJson extends (Response => String \/ List[Json]) {
+  object asJson extends (Response => String \/ (String, List[Json])) {
     private def sequenceStrs[A](vs: Seq[String \/ A]): String \/ List[A] =
       vs.toList.map(_.validation.toValidationNel).sequenceU.leftMap(_.list.mkString("; ")).disjunction
 
@@ -100,7 +100,8 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       if (str == "") \/-(Nil)
       else sequenceStrs(str.split("\n").map(Parse.parse(_)))
 
-    def apply(r: Response) = (dispatch.as.String andThen parseJsonLines)(r)
+    def apply(r: Response) =
+      (dispatch.as.String andThen parseJsonLines)(r).map((r.getContentType, _))
   }
 
   /** Handlers for use with Dispatch. */
@@ -111,7 +112,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
   val svc = dispatch.host("localhost", port)
 
   val files1 = Map(
-    Path("bar") -> List(Data.Obj(ListMap("a" -> Data.Int(1))), Data.Obj(ListMap("b" -> Data.Int(2)))),
+    Path("bar") -> List(Data.Obj(ListMap("a" -> Data.Int(1))), Data.Obj(ListMap("b" -> Data.Int(2))), Data.Obj(ListMap("c" -> Data.Set(List(Data.Int(3)))))),
     Path("dir/baz") -> List(),
     Path("tmp/out") -> List(Data.Obj(ListMap("0" -> Data.Str("ok")))),
     Path("a file") -> List(Data.Obj(ListMap("1" -> Data.Str("ok"))))
@@ -161,6 +162,10 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     }
   }
 
+  val jsonContentType = "application/json"
+  val preciseContentType = "application/ldjson; mode=precise; charset=UTF-8"
+  val readableContentType = "application/ldjson; mode=readable; charset=UTF-8"
+
   "/metadata/fs" should {
     val root = svc / "metadata" / "fs" / ""  // Note: trailing slash required
 
@@ -168,7 +173,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       withServer(Map()) {
         val meta = Http(root OK asJson)
 
-        meta() must beRightDisj(List(Json("children" := List[Json]())))
+        meta() must beRightDisj((jsonContentType, List(Json("children" := List[Json]()))))
       }
     }
 
@@ -186,7 +191,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
         val path = root / "empty" / ""
         val meta = Http(path OK asJson)
 
-        meta() must beRightDisj(List(Json("children" := List[Json]())))
+        meta() must beRightDisj((jsonContentType, List(Json("children" := List[Json]()))))
       }
     }
 
@@ -204,12 +209,14 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
         val meta = Http(root OK asJson)
 
         // Note: four backends will come in the right order and compare equal, but not 5 or more.
-        meta() must beRightDisj(List(
-          Json("children" := List(
-            Json("name" := "empty", "type" := "mount"),
-            Json("name" := "foo", "type" := "mount"),
-            Json("name" := "badPath1", "type" := "mount"),
-            Json("name" := "badPath2", "type" := "mount")))))
+        meta() must beRightDisj((
+          jsonContentType,
+          List(
+            Json("children" := List(
+              Json("name" := "empty", "type" := "mount"),
+              Json("name" := "foo", "type" := "mount"),
+              Json("name" := "badPath1", "type" := "mount"),
+              Json("name" := "badPath2", "type" := "mount"))))))
       }
     }
 
@@ -218,12 +225,14 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
         val path = root / "foo" / ""
         val meta = Http(path OK asJson)
 
-        meta() must beRightDisj(List(
-          Json("children" := List(
-            Json("name" := "bar", "type" := "file"),
-            Json("name" := "dir", "type" := "directory"),
-            Json("name" := "tmp", "type" := "directory"),
-            Json("name" := "a file", "type" := "file")))))
+        meta() must beRightDisj((
+          jsonContentType,
+          List(
+            Json("children" := List(
+              Json("name" := "bar", "type" := "file"),
+              Json("name" := "dir", "type" := "directory"),
+              Json("name" := "tmp", "type" := "directory"),
+              Json("name" := "a file", "type" := "file"))))))
       }
     }
 
@@ -251,12 +260,36 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
         }
       }.pendingUntilFixed  // FIXME: ResponseStreamer does not detect failure
 
-      "read entire file" in {
+      "read entire file readably by default" in {
         withServer(backends1) {
           val path = root / "foo" / "bar"
           val meta = Http(path OK asJson)
 
-          meta() must beRightDisj(List(Json("a" := 1), Json("b" := 2)))
+          meta() must beRightDisj((
+            readableContentType,
+            List(Json("a" := 1), Json("b" := 2), Json("c" := List(3)))))
+        }
+      }
+
+      "read entire file precisely when specified" in {
+        withServer(backends1) {
+          val path = root / "foo" / "bar"
+          val meta = Http(path.setHeader("Accept", "application/ldjson;mode=precise") OK asJson)
+
+          meta() must beRightDisj((
+            preciseContentType,
+            List(Json("a" := 1), Json("b" := 2), Json("c" := Json("$set" := List(3))))))
+        }
+      }
+
+      "read entire file precisely with complicated Accept" in {
+        withServer(backends1) {
+          val path = root / "foo" / "bar"
+          val meta = Http(path.setHeader("Accept", "application/ldjson;q=0.9;mode=readable,application/json;boundary=NL;mode=precise") OK asJson)
+
+          meta() must beRightDisj((
+            preciseContentType,
+            List(Json("a" := 1), Json("b" := 2), Json("c" := Json("$set" := List(3))))))
         }
       }
 
@@ -265,7 +298,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
           val path = root / "foo" / "a file"
           val meta = Http(path OK asJson)
 
-          meta() must beRightDisj(List(Json("1" := "ok")))
+          meta() must beRightDisj((readableContentType, List(Json("1" := "ok"))))
         }
       }
     }
@@ -364,13 +397,15 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
               |{"c": 3}""".stripMargin)
           val meta = Http(req > asJson)
 
-          meta() must beRightDisj((json: List[Json]) =>
+          meta() must beRightDisj { (resp: (String, List[Json])) =>
+            val (_, json) = resp
             json.length == 1 &&
             (for {
               obj <- json.head.obj
               errors <- obj("errors")
               eArr <- errors.array
-            } yield eArr.length == 2).getOrElse(false))
+            } yield eArr.length == 2).getOrElse(false)
+          }
         }
       }
 
@@ -536,8 +571,9 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
           val path = root / "foo" / "" <<? Map("q" -> "select * from bar")
           val result = Http(path OK asJson)
 
-          result() must beRightDisj(List(
-            Json("0" := "ok")))
+          result() must beRightDisj((
+            readableContentType,
+            List(Json("0" := "ok"))))
         }
       }
 


### PR DESCRIPTION
Fixes #644.

This supports using any of

* application/ldjson,
* application/x-ldjson, or
* application/json;boundary=NL

as a media type, along with an optional “mode=precise” (or
“mode=readable”) extension to specify which codec to use.

The response always has a Content-Type header with the value
“application/ldjson;mode=readable” (or “precise”, if the client
requested it).