### PR TITLE
Upgrade to WartRemover 0.13.

### DIFF
--- a/admin/src/main/scala/slamdata/engine/admin/admin.scala
+++ b/admin/src/main/scala/slamdata/engine/admin/admin.scala
@@ -172,7 +172,7 @@ class AdminUI(configPath: Option[String]) {
       fsTable.map { fs =>
         val contextPath = Option(workingDir.selection.item).map(_.asDir).getOrElse(Path.Root)
         fs.lookup(contextPath).map { case (backend, mountPath, relPath) =>
-          \/.fromTryCatchNonFatal(backend.run(QueryRequest(slamdata.engine.sql.Query(queryArea.text), None, mountPath, mountPath))).bimap(
+          \/.fromTryCatchNonFatal(backend.run(QueryRequest(slamdata.engine.sql.Query(queryArea.text), None, mountPath, mountPath, Variables(Map())))).bimap(
             ExecutionFailed(_),
             t => (t._1, backend.dataSource, t._2))
         }.getOrElse(-\/(NoMount(contextPath)))

--- a/admin/src/main/scala/slamdata/engine/admin/config.scala
+++ b/admin/src/main/scala/slamdata/engine/admin/config.scala
@@ -70,7 +70,7 @@ class ConfigDialog(parent: Window, configPath: Option[String]) extends Dialog(pa
 
   def startMounts = startConfig.mountings.toList
 
-  case object MountsUpdated extends Event
+  final case object MountsUpdated extends Event
 
   object mountTM extends javax.swing.table.AbstractTableModel with Publisher {
     private val columnNames = List("Host", "Database", "SlamData Path")

--- a/admin/src/main/scala/slamdata/engine/admin/table.scala
+++ b/admin/src/main/scala/slamdata/engine/admin/table.scala
@@ -140,14 +140,14 @@ class DataCellRenderer extends Table.AbstractRenderer[AnyRef, Label](new Label) 
 
 sealed trait LazyValue[+A]
 object LazyValue {
-  case object Loading extends LazyValue[Nothing]
-  case object Missing extends LazyValue[Nothing]
-  case class Value[A](value: A) extends LazyValue[A]
+  final case object Loading extends LazyValue[Nothing]
+  final case object Missing extends LazyValue[Nothing]
+  final case class Value[A](value: A) extends LazyValue[A]
 }
 
-case class Chunk(chunkIndex: Int, firstRow: Int, size: Int)
-case object Loading
-case class PartialResultSet[A](chunkSize: Int, chunks: Map[Int, Loading.type \/ Vector[A]] = Map[Int, Loading.type \/ Vector[A]]()) {
+final case class Chunk(chunkIndex: Int, firstRow: Int, size: Int)
+final case object Loading
+final case class PartialResultSet[A](chunkSize: Int, chunks: Map[Int, Loading.type \/ Vector[A]] = Map[Int, Loading.type \/ Vector[A]]()) {
   import PartialResultSet._
 
   /**

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -27,7 +27,6 @@ wartremoverErrors ++= Warts.allBut(
   Wart.NoNeedForMonad,    //  62
   Wart.NonUnitStatements, //  24
   Wart.Nothing,           // 366
-  Wart.Null,              //   1
   Wart.Product,           // 180  _ these two are highly correlated
   Wart.Serializable,      // 182  /
   Wart.Throw)             // 412

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -22,7 +22,6 @@ wartremoverErrors ++= Warts.allBut(
   // NB: violation counts are from running `compile`
   Wart.Any,               // 113
   Wart.AsInstanceOf,      //  75
-  Wart.DefaultArguments,  //   6
   Wart.IsInstanceOf,      //  79
   Wart.NoNeedForMonad,    //  62
   Wart.NonUnitStatements, //  24

--- a/core/src/main/scala/slamdata/engine/backend.scala
+++ b/core/src/main/scala/slamdata/engine/backend.scala
@@ -25,13 +25,13 @@ object PhaseResult {
 
   import slamdata.engine.{Error => SDError}
 
-  case class Error(name: String, value: SDError) extends PhaseResult {
+  final case class Error(name: String, value: SDError) extends PhaseResult {
     override def toString = name + "\n" + value.toString
   }
-  case class Tree(name: String, value: RenderedTree) extends PhaseResult {
+  final case class Tree(name: String, value: RenderedTree) extends PhaseResult {
     override def toString = name + "\n" + Show[RenderedTree].shows(value)
   }
-  case class Detail(name: String, value: String) extends PhaseResult {
+  final case class Detail(name: String, value: String) extends PhaseResult {
     override def toString = name + "\n" + value
   }
 
@@ -137,8 +137,8 @@ object Backend {
     def log: Cord
   }
   object TestResult {
-    case class Success(log: Cord) extends TestResult
-    case class Failure(error: Throwable, log: Cord) extends TestResult
+    final case class Success(log: Cord) extends TestResult
+    final case class Failure(error: Throwable, log: Cord) extends TestResult
   }
   def test(config: BackendConfig): Task[TestResult] = {
     val tests = for {
@@ -165,7 +165,7 @@ object Backend {
   }
 }
 
-case class BackendDefinition(create: PartialFunction[BackendConfig, Task[Backend]]) extends (BackendConfig => Option[Task[Backend]]) {
+final case class BackendDefinition(create: PartialFunction[BackendConfig, Task[Backend]]) extends (BackendConfig => Option[Task[Backend]]) {
   def apply(config: BackendConfig): Option[Task[Backend]] = create.lift(config)
 }
 

--- a/core/src/main/scala/slamdata/engine/codec.scala
+++ b/core/src/main/scala/slamdata/engine/codec.scala
@@ -9,19 +9,19 @@ import slamdata.engine.fp._
 
 trait DataEncodingError extends slamdata.engine.Error
 object DataEncodingError {
-  case class UnrepresentableDataError(data: Data) extends DataEncodingError {
+  final case class UnrepresentableDataError(data: Data) extends DataEncodingError {
     def message = "not representable: " + data
   }
 
-  case class UnescapedKeyError(json: Json) extends DataEncodingError {
+  final case class UnescapedKeyError(json: Json) extends DataEncodingError {
     def message = "un-escaped key: " + json
   }
 
-  case class UnexpectedValueError(expected: String, json: Json) extends DataEncodingError {
+  final case class UnexpectedValueError(expected: String, json: Json) extends DataEncodingError {
     def message = "expected " + expected + ", found: " + json.pretty(minspace)
   }
 
-  case class ParseError(cause: String) extends DataEncodingError {
+  final case class ParseError(cause: String) extends DataEncodingError {
     def message = cause
   }
 

--- a/core/src/main/scala/slamdata/engine/compiler.scala
+++ b/core/src/main/scala/slamdata/engine/compiler.scala
@@ -43,7 +43,7 @@ trait Compiler[F[_]] {
     rez     <- funcOpt.map(emit _).getOrElse(fail(FunctionNotBound(node)))
   } yield rez
 
-  private case class TableContext(
+  private final case class TableContext(
     root: Option[Term[LogicalPlan]],
     full: () => Term [LogicalPlan],
     subtables: Map[String, Term[LogicalPlan]]) {
@@ -54,7 +54,7 @@ trait Compiler[F[_]] {
         this.subtables ++ that.subtables)
   }
 
-  private case class CompilerState(
+  private final case class CompilerState(
     tree:         AnnotatedTree[Node, Annotations],
     fields:       List[String],
     tableContext: List[TableContext],
@@ -124,10 +124,10 @@ trait Compiler[F[_]] {
   }
 
   sealed trait JoinDir
-  case object Left extends JoinDir {
+  final case object Left extends JoinDir {
     override def toString: String = "left"
   }
-  case object Right extends JoinDir {
+  final case object Right extends JoinDir {
     override def toString: String = "right"
   }
 

--- a/core/src/main/scala/slamdata/engine/data.scala
+++ b/core/src/main/scala/slamdata/engine/data.scala
@@ -21,12 +21,12 @@ sealed trait Data {
 }
 
 object Data {
-  case object Null extends Data {
+  final case object Null extends Data {
     def dataType = Type.Null
     def toJs = JsCore.Literal(Js.Null).fix
   }
 
-  case class Str(value: String) extends Data {
+  final case class Str(value: String) extends Data {
     def dataType = Type.Str
     def toJs = JsCore.Literal(Js.Str(value)).fix
   }
@@ -41,10 +41,10 @@ object Data {
       case False => Some(false)
     }
   }
-  case object True extends Bool {
+  final case object True extends Bool {
     def toJs = JsCore.Literal(Js.Bool(true)).fix
   }
-  case object False extends Bool {
+  final case object False extends Bool {
     override def toString = "Data.False"
     def toJs = JsCore.Literal(Js.Bool(false)).fix
   }
@@ -57,54 +57,54 @@ object Data {
       case _ => None
     }
   }
-  case class Dec(value: BigDecimal) extends Number {
+  final case class Dec(value: BigDecimal) extends Number {
     def dataType = Type.Dec
     def toJs = JsCore.Literal(Js.Num(value.doubleValue, true)).fix
   }
-  case class Int(value: BigInt) extends Number {
+  final case class Int(value: BigInt) extends Number {
     def dataType = Type.Int
     def toJs = JsCore.Literal(Js.Num(value.doubleValue, false)).fix
   }
 
-  case class Obj(value: Map[String, Data]) extends Data {
+  final case class Obj(value: Map[String, Data]) extends Data {
     def dataType = Type.Obj(value ∘ (Type.Const(_)), None)
     def toJs =
       JsCore.Obj(value.toList.map { case (k, v) => k -> v.toJs }.toListMap).fix
   }
 
-  case class Arr(value: List[Data]) extends Data {
+  final case class Arr(value: List[Data]) extends Data {
     def dataType = Type.Arr(value ∘ (Type.Const(_)))
     def toJs = JsCore.Arr(value.map(_.toJs)).fix
   }
 
-  case class Set(value: List[Data]) extends Data {
+  final case class Set(value: List[Data]) extends Data {
     def dataType = (value.headOption.map { head =>
       value.drop(1).map(_.dataType).foldLeft(head.dataType)(Type.lub _)
     }).getOrElse(Type.Bottom) // TODO: ???
     def toJs = JsCore.Arr(value.map(_.toJs)).fix
   }
 
-  case class Timestamp(value: Instant) extends Data {
+  final case class Timestamp(value: Instant) extends Data {
     def dataType = Type.Timestamp
     def toJs = JsCore.Call(JsCore.Ident("ISODate").fix, List(JsCore.Literal(Js.Str(value.toString)).fix)).fix
   }
 
-  case class Date(value: LocalDate) extends Data {
+  final case class Date(value: LocalDate) extends Data {
     def dataType = Type.Date
     def toJs = JsCore.Call(JsCore.Ident("ISODate").fix, List(JsCore.Literal(Js.Str(value.toString)).fix)).fix
   }
 
-  case class Time(value: LocalTime) extends Data {
+  final case class Time(value: LocalTime) extends Data {
     def dataType = Type.Time
     def toJs = JsCore.Literal(Js.Str(value.toString)).fix
   }
 
-  case class Interval(value: Duration) extends Data {
+  final case class Interval(value: Duration) extends Data {
     def dataType = Type.Interval
     def toJs = JsCore.Literal(Js.Num(value.getSeconds*1000 + value.getNano*1e-6, true)).fix
   }
 
-  case class Binary(value: ImmutableArray[Byte]) extends Data {
+  final case class Binary(value: ImmutableArray[Byte]) extends Data {
     def dataType = Type.Binary
     def toJs = JsCore.Call(JsCore.Ident("BinData").fix, List(
       JsCore.Literal(Js.Num(0, false)).fix,
@@ -124,7 +124,7 @@ object Data {
     def apply(array: Array[Byte]): Binary = Binary(ImmutableArray.fromArray(array))
   }
 
-  case class Id(value: String) extends Data {
+  final case class Id(value: String) extends Data {
     def dataType = Type.Id
     def toJs = JsCore.Call(JsCore.Ident("ObjectId").fix, List(JsCore.Literal(Js.Str(value)).fix)).fix
   }
@@ -135,7 +135,7 @@ object Data {
    with JS's `undefined`, just because no other value will ever be translated
    that way.
    */
-  case object NA extends Data {
+  final case object NA extends Data {
     def dataType = Type.Bottom
     def toJs = JsCore.Ident(Js.Undefined.ident).fix
   }

--- a/core/src/main/scala/slamdata/engine/debug.scala
+++ b/core/src/main/scala/slamdata/engine/debug.scala
@@ -6,7 +6,7 @@ import Scalaz._
 import argonaut._
 import Argonaut._
 
-case class RenderedTree(label: String, children: List[RenderedTree], nodeType: List[String]) {
+final case class RenderedTree(label: String, children: List[RenderedTree], nodeType: List[String]) {
   def relabel(label: String): RenderedTree = relabel(_ => label)
 
   def relabel(f: String => String): RenderedTree = copy(label = f(label))
@@ -149,7 +149,7 @@ object RenderTree {
         _ <- put(i+1)
       } yield "n" + i
 
-    case class Node(name: String, dot: Cord)
+    final case class Node(name: String, dot: Cord)
 
     def render(t: RenderedTree): State[Int, Node] = {
       def escape(str: String) = str.replace("\\\\", "\\\\").replace("\"", "\\\"")
@@ -200,7 +200,7 @@ object RenderTree {
     trait Node {
       def children: List[TreeNode]
     }
-    case object RootNode extends Node {
+    final case object RootNode extends Node {
       val children = roots.map(new TreeNode(_))
     }
     // Not a case class, because JTree gets confused if there are multiple

--- a/core/src/main/scala/slamdata/engine/errors.scala
+++ b/core/src/main/scala/slamdata/engine/errors.scala
@@ -23,14 +23,14 @@ object Error {
   }
 }
 
-case class ManyErrors(errors: NonEmptyList[Error]) extends Error {
+final case class ManyErrors(errors: NonEmptyList[Error]) extends Error {
   def message = errors.map(_.message).list.mkString("[", "\n", "]")
 
   override val stackTrace = errors.head.stackTrace
 
   override def fullMessage = errors.head.fullMessage
 }
-case class PhaseError(phases: Vector[PhaseResult], causedBy: Error) extends Error {
+final case class PhaseError(phases: Vector[PhaseResult], causedBy: Error) extends Error {
   def message = phases.mkString("\n\n")
 
   override val stackTrace = causedBy.stackTrace
@@ -39,7 +39,7 @@ case class PhaseError(phases: Vector[PhaseResult], causedBy: Error) extends Erro
 }
 
 sealed trait ParsingError extends Error
-case class GenericParsingError(message: String) extends ParsingError
+final case class GenericParsingError(message: String) extends ParsingError
 
 sealed trait SemanticError extends Error
 object SemanticError {
@@ -49,25 +49,25 @@ object SemanticError {
     override def show(value: SemanticError) = Cord(value.message)
   }
 
-  case class GenericError(message: String) extends SemanticError
+  final case class GenericError(message: String) extends SemanticError
 
-  case class DomainError(data: Data, hint: Option[String]) extends SemanticError {
+  final case class DomainError(data: Data, hint: Option[String]) extends SemanticError {
     def message = "The data '" + data + "' did not fall within its expected domain" + hint.map(": " + _)
   }
 
-  case class FunctionNotFound(name: String) extends SemanticError {
+  final case class FunctionNotFound(name: String) extends SemanticError {
     def message = "The function '" + name + "' could not be found in the standard library"
   }
-  case class FunctionNotBound(node: Node) extends SemanticError {
+  final case class FunctionNotBound(node: Node) extends SemanticError {
     def message = "A function was not bound to the node " + node
   }
-  case class TypeError(expected: Type, actual: Type, hint: Option[String]) extends SemanticError {
+  final case class TypeError(expected: Type, actual: Type, hint: Option[String]) extends SemanticError {
     def message = "Expected type " + expected + " but found " + actual + hint.map(": " + _).getOrElse("")
   }
-  case class VariableTypeError(vari: VarName, expected: Type, actual: VarValue) extends SemanticError {
+  final case class VariableTypeError(vari: VarName, expected: Type, actual: VarValue) extends SemanticError {
     def message = "The variable " + vari + " should be convertible to type " + expected + " but found: " + actual
   }
-  case class DuplicateRelationName(defined: String, duplicated: SqlRelation) extends SemanticError {
+  final case class DuplicateRelationName(defined: String, duplicated: SqlRelation) extends SemanticError {
     private def nameOf(r: SqlRelation) = r match {
       case TableRelationAST(name, aliasOpt) => aliasOpt.getOrElse(name)
       case ExprRelationAST(_, alias)        => alias
@@ -77,75 +77,75 @@ object SemanticError {
 
     def message = "Found relation with duplicate name '" + defined + "': " + defined
   }
-  case class NoTableDefined(node: Node) extends SemanticError {
+  final case class NoTableDefined(node: Node) extends SemanticError {
     def message = "No table was defined in the scope of \'" + node.sql + "\'"
   }
-  case class UnboundVariable(v: Vari) extends SemanticError {
+  final case class UnboundVariable(v: Vari) extends SemanticError {
     def message = "The variable " + v + " is not bound to any value"
   }
-  case class MissingField(name: String) extends SemanticError {
+  final case class MissingField(name: String) extends SemanticError {
     def message = "No field named '" + name + "' exists"
   }
-  case class MissingIndex(index: Int) extends SemanticError {
+  final case class MissingIndex(index: Int) extends SemanticError {
     def message = "No element exists at array index '" + index
   }
-  case class WrongArgumentCount(func: Func, expected: Int, actual: Int) extends SemanticError {
+  final case class WrongArgumentCount(func: Func, expected: Int, actual: Int) extends SemanticError {
     def message = "Wrong number of arguments for function '" + func.name + "': expected " + expected + " but found " + actual
   }
-  case class NonCompilableNode(node: Node) extends SemanticError {
+  final case class NonCompilableNode(node: Node) extends SemanticError {
     def message = "The node " + node + " cannot be compiled"
   }
-  case class ExpectedLiteral(node: Node) extends SemanticError {
+  final case class ExpectedLiteral(node: Node) extends SemanticError {
     def message = "Expected literal but found '" + node.sql + "'"
   }
-  case class AmbiguousReference(node: Node, relations: List[SqlRelation]) extends SemanticError {
+  final case class AmbiguousReference(node: Node, relations: List[SqlRelation]) extends SemanticError {
     def message = "The expression '" + node.sql + "' is ambiguous and might refer to any of the tables " + relations.mkString(", ")
   }
-  case class UnsupportedJoinCondition(clause: Expr) extends SemanticError {
+  final case class UnsupportedJoinCondition(clause: Expr) extends SemanticError {
     def message = "The join clause is not supported: " + clause.sql
   }
-  case class ExpectedOneTableInJoin(expr: Expr) extends SemanticError {
+  final case class ExpectedOneTableInJoin(expr: Expr) extends SemanticError {
     def message = "In a join clause, expected to find an expression with a single table, but found: " + expr.sql
   }
-  case object CompiledTableMissing extends SemanticError {
+  final case object CompiledTableMissing extends SemanticError {
     def message = "Expected the root table to be compiled but found nothing"
   }
-  case class CompiledSubtableMissing(name: String) extends SemanticError {
+  final case class CompiledSubtableMissing(name: String) extends SemanticError {
     def message = "Expected to find a compiled subtable with name \"" + name + "\""
   }
-  case class DateFormatError(func: Func, str: String) extends SemanticError {
+  final case class DateFormatError(func: Func, str: String) extends SemanticError {
     def message = "Date/time string could not be parsed as " + func.name + ": " + str
   }
 }
 
 sealed trait PlannerError extends Error
 object PlannerError {
-  case class InternalError(message: String) extends PlannerError
-  case class NonRepresentableData(data: Data) extends PlannerError {
+  final case class InternalError(message: String) extends PlannerError
+  final case class NonRepresentableData(data: Data) extends PlannerError {
     def message = "The back-end has no representation for the constant: " + data
   }
-  case class UnsupportedFunction(func: Func, message: String) extends PlannerError {
+  final case class UnsupportedFunction(func: Func, message: String) extends PlannerError {
   }
   object UnsupportedFunction extends ((Func, String) => PlannerError) {
     def apply(func: Func): PlannerError =
       new UnsupportedFunction(func, "The function '" + func.name + "' is recognized but not supported by this back-end")
   }
-  case class UnsupportedPlan(plan: LogicalPlan[_], hint: Option[String]) extends PlannerError {
+  final case class UnsupportedPlan(plan: LogicalPlan[_], hint: Option[String]) extends PlannerError {
     def message = "The back-end has no or no efficient means of implementing the plan" + hint.map(" (" + _ + ")").getOrElse("")+ ": " + plan
   }
-  case class FuncApply(func: Func, expected: String, actual: String) extends PlannerError {
+  final case class FuncApply(func: Func, expected: String, actual: String) extends PlannerError {
     def message = "A parameter passed to function " + func.name + " is invalid: Expected " + expected + " but found: " + actual
   }
-  case class FuncArity(func: Func, actual: Int) extends PlannerError {
+  final case class FuncArity(func: Func, actual: Int) extends PlannerError {
     def message = "The wrong number of parameters were passed to " + func.name + "; expected " + func.arity + " but found " + actual
   }
-  case class ObjectIdFormatError(str: String) extends PlannerError {
+  final case class ObjectIdFormatError(str: String) extends PlannerError {
     def message = "Invalid ObjectId string: " + str
   }
-  case class NonRepresentableInJS(value: String) extends PlannerError {
+  final case class NonRepresentableInJS(value: String) extends PlannerError {
     def message = "Operation/value could not be compiled to JavaScript: " + value
   }
-  case class UnsupportedJS(value: String) extends PlannerError {
+  final case class UnsupportedJS(value: String) extends PlannerError {
     def message = "Conversion of operation/value to JavaScript not implemented: " + value
   }
 

--- a/core/src/main/scala/slamdata/engine/evaluator.scala
+++ b/core/src/main/scala/slamdata/engine/evaluator.scala
@@ -5,7 +5,7 @@ import scalaz.concurrent.Task
 
 import slamdata.engine.fs._
 
-case class EvaluationError(cause: Throwable) extends Error {
+final case class EvaluationError(cause: Throwable) extends Error {
   def message = "An error occurred during evaluation: " + cause.toString
 }
 
@@ -14,10 +14,10 @@ sealed trait ResultPath {
 }
 object ResultPath {
   /** Path to a result which names an unaltered source resource or the requested destination. */
-  case class User(path: Path) extends ResultPath
+  final case class User(path: Path) extends ResultPath
 
   /** Path to a result which is a new temporary resource created during query execution. */
-  case class Temp(path: Path) extends ResultPath
+  final case class Temp(path: Path) extends ResultPath
 }
 
 trait Evaluator[PhysicalPlan] {

--- a/core/src/main/scala/slamdata/engine/fs/filesystem.scala
+++ b/core/src/main/scala/slamdata/engine/fs/filesystem.scala
@@ -8,7 +8,7 @@ import argonaut._, Argonaut._
 
 import slamdata.engine.{Data, DataCodec}
 
-case class WriteError(value: Data, hint: Option[String]) extends slamdata.engine.Error {
+final case class WriteError(value: Data, hint: Option[String]) extends slamdata.engine.Error {
   def message = hint.getOrElse("error writing data") + "; value: " + value
 }
 object WriteError {
@@ -76,7 +76,7 @@ object FileSystem {
     def defaultPath = Path(".")
   }
 
-  case class FileNotFoundError(path: Path) extends slamdata.engine.Error {
+  final case class FileNotFoundError(path: Path) extends slamdata.engine.Error {
     def message = "No file/dir at path: " + path
   }
 }

--- a/core/src/main/scala/slamdata/engine/fs/path.scala
+++ b/core/src/main/scala/slamdata/engine/fs/path.scala
@@ -137,11 +137,11 @@ object DirNode {
 }
 final case class FileNode(value: String)
 
-case class PathError(hint: Option[String]) extends slamdata.engine.Error {
+final case class PathError(hint: Option[String]) extends slamdata.engine.Error {
   def message = hint.getOrElse("invalid path")
 }
 
-case class FSTable[A](private val table0: Map[Path, A]) {
+final case class FSTable[A](private val table0: Map[Path, A]) {
   val table = table0.mapKeys(_.asAbsolute.asDir)
 
   def isEmpty = table.isEmpty

--- a/core/src/main/scala/slamdata/engine/functions.scala
+++ b/core/src/main/scala/slamdata/engine/functions.scala
@@ -81,10 +81,10 @@ final case class Transformation(name: String, help: String, domain: List[Type], 
 sealed trait MappingType
 
 object MappingType {
-  case object OneToOne      extends MappingType
-  case object OneToMany     extends MappingType
-  case object OneToManyFlat extends MappingType
-  case object ManyToOne     extends MappingType
-  case object ManyToMany    extends MappingType
-  case object Squashing     extends MappingType
+  final case object OneToOne      extends MappingType
+  final case object OneToMany     extends MappingType
+  final case object OneToManyFlat extends MappingType
+  final case object ManyToOne     extends MappingType
+  final case object ManyToMany    extends MappingType
+  final case object Squashing     extends MappingType
 }

--- a/core/src/main/scala/slamdata/engine/javascript/javascript.scala
+++ b/core/src/main/scala/slamdata/engine/javascript/javascript.scala
@@ -140,11 +140,11 @@ private object JavascriptPrinter {
   }
 
   def print(ast: Js, indent: Int): String = {
-    def ind(c: Int = 0) = " " * (indent + c)
+    def ind(c: Int) = " " * (indent + c)
     def p(ast: Js) = print(ast, indent)
     def p2(ast: Js) = ind(2) + p3(ast)
     def p3(ast: Js) = print(ast, indent + 2)
-    def p4(ast: Js) = ind() + p(ast)
+    def p4(ast: Js) = ind(0) + p(ast)
     def s(ast: Js) = ast match {
       case _: Lit => p(ast)
       case _: Ident => p(ast)
@@ -162,7 +162,7 @@ private object JavascriptPrinter {
           content.mkString(
             open + "\n" + ind(2),
             sep + "\n" + ind(2),
-            if (isBlock) "\n" + ind() + close else close)
+            if (isBlock) "\n" + ind(0) + close else close)
     }
 
     simplify(ast) match {
@@ -199,7 +199,7 @@ private object JavascriptPrinter {
       case If(cond, thenp, elsep)             => s"if (${p(cond)}) ${p(thenp)}" + elsep.map(e => s" else ${p(e)}").getOrElse("")
       case Switch(expr, cases, default)       =>
         seqOut(default.foldLeft(cases.map(p2))((l, d) => l :+ p2(d)), s"switch (${p(expr)}) {", "", "}")
-      case Case(consts, body)                 => consts.map(c => s"case ${p(c)}:\n").mkString(ind()) + p2(body) + ";\n" + ind(2) + "break;"
+      case Case(consts, body)                 => consts.map(c => s"case ${p(c)}:\n").mkString(ind(0)) + p2(body) + ";\n" + ind(2) + "break;"
       case Default(body)                      => "default:\n" + p2(body) + ";\n" + ind(2) + "break;"
       case While(cond, body)                  => s"while (${p(cond)}) ${p(body)}"
       case Try(body, cat, fin)                =>
@@ -226,7 +226,7 @@ private object JavascriptPrinter {
       case ObjDecl(name, FunDecl(_, params, stmts), fields) =>
         val fs = for ((n, v) <- fields) yield ind(2) + s"this.$n = ${p(v)};"
         val body = fs ++ stmts.map(s => ind(2) + p(s)) mkString "\n"
-        s"""function $name(${params.mkString(", ")}) {\n$body\n${ind()}}"""
+        s"""function $name(${params.mkString(", ")}) {\n$body\n${ind(0)}}"""
       case Return(jsExpr)                     => s"return ${p(jsExpr)}"
       case Unit                               => ""
       case Stmts(stmts)                       => stmts.map(p).mkString("", ";\n", ";\n")

--- a/core/src/main/scala/slamdata/engine/javascript/javascript.scala
+++ b/core/src/main/scala/slamdata/engine/javascript/javascript.scala
@@ -55,43 +55,43 @@ object Js {
   sealed trait Expr extends Stmt
   sealed trait Lit extends Expr
 
-  case class Bool(value: Boolean) extends Lit
-  case class Str(value: String) extends Lit
-  case class Num(value: Double, isFloat: Boolean) extends Lit
-  case class AnonElem(values: List[Expr]) extends Lit
-  case object Unit extends Lit
-  case object Null extends Lit
+  final case class Bool(value: Boolean) extends Lit
+  final case class Str(value: String) extends Lit
+  final case class Num(value: Double, isFloat: Boolean) extends Lit
+  final case class AnonElem(values: List[Expr]) extends Lit
+  final case object Unit extends Lit
+  final case object Null extends Lit
 
-  case class Lazy[A <: Js](ast: () => A) extends Expr
-  case class Ident(ident: String) extends Expr
-  case class Raw(js: String) extends Expr
-  case class Access(qualifier: Expr, key: Expr) extends Expr
-  case class Select(qualifier: Expr, name: String) extends Expr
-  case class UnOp(operator: String, operand: Expr) extends Expr
-  case class BinOp(operator: String, lhs: Expr, rhs: Expr) extends Expr
-  case class Call(callee: Expr, params: List[Expr]) extends Expr
-  case class New(ctor: Expr) extends Expr
-  case class Throw(expr: Expr) extends Expr
-  case class AnonFunDecl(params: List[String], body: List[Stmt]) extends Expr
-  case class AnonObjDecl(fields: List[(String, Expr)]) extends Expr
-  case class Ternary(cond: Expr, `then`: Expr, `else`: Expr) extends Expr
+  final case class Lazy[A <: Js](ast: () => A) extends Expr
+  final case class Ident(ident: String) extends Expr
+  final case class Raw(js: String) extends Expr
+  final case class Access(qualifier: Expr, key: Expr) extends Expr
+  final case class Select(qualifier: Expr, name: String) extends Expr
+  final case class UnOp(operator: String, operand: Expr) extends Expr
+  final case class BinOp(operator: String, lhs: Expr, rhs: Expr) extends Expr
+  final case class Call(callee: Expr, params: List[Expr]) extends Expr
+  final case class New(ctor: Expr) extends Expr
+  final case class Throw(expr: Expr) extends Expr
+  final case class AnonFunDecl(params: List[String], body: List[Stmt]) extends Expr
+  final case class AnonObjDecl(fields: List[(String, Expr)]) extends Expr
+  final case class Ternary(cond: Expr, `then`: Expr, `else`: Expr) extends Expr
 
-  case class Block(stmts: List[Stmt]) extends Stmt
-  case class Try(body: Stmt, cat: Option[Catch], fin: Option[Stmt]) extends Stmt
-  case class Catch(ident: Ident, body: Stmt) extends Stmt
-  case class If(cond: Expr, `then`: Stmt, `else`: Option[Stmt]) extends Stmt
-  case class While(cond: Expr, body: Stmt) extends Stmt
-  case class For(init: List[Stmt], check: Expr, update: List[Stmt], body: Stmt) extends Stmt
-  case class ForIn(ident: Ident, coll: Expr, body: Stmt) extends Stmt
+  final case class Block(stmts: List[Stmt]) extends Stmt
+  final case class Try(body: Stmt, cat: Option[Catch], fin: Option[Stmt]) extends Stmt
+  final case class Catch(ident: Ident, body: Stmt) extends Stmt
+  final case class If(cond: Expr, `then`: Stmt, `else`: Option[Stmt]) extends Stmt
+  final case class While(cond: Expr, body: Stmt) extends Stmt
+  final case class For(init: List[Stmt], check: Expr, update: List[Stmt], body: Stmt) extends Stmt
+  final case class ForIn(ident: Ident, coll: Expr, body: Stmt) extends Stmt
   sealed trait Switchable extends Stmt
-  case class Case(const: List[Expr], body: Stmt) extends Switchable
-  case class Default(body: Stmt) extends Switchable
-  case class Switch(expr: Expr, cases: List[Case], default: Option[Default]) extends Stmt
-  case class VarDef(idents: List[(String, Expr)]) extends Stmt
-  case class FunDecl(ident: String, params: List[String], body: List[Stmt]) extends Stmt
-  case class ObjDecl(name: String, constructor: FunDecl, fields: List[(String, Expr)]) extends Stmt
-  case class Return(jsExpr: Expr) extends Stmt
-  case class Stmts(stmts: List[Stmt]) extends Stmt
+  final case class Case(const: List[Expr], body: Stmt) extends Switchable
+  final case class Default(body: Stmt) extends Switchable
+  final case class Switch(expr: Expr, cases: List[Case], default: Option[Default]) extends Stmt
+  final case class VarDef(idents: List[(String, Expr)]) extends Stmt
+  final case class FunDecl(ident: String, params: List[String], body: List[Stmt]) extends Stmt
+  final case class ObjDecl(name: String, constructor: FunDecl, fields: List[(String, Expr)]) extends Stmt
+  final case class Return(jsExpr: Expr) extends Stmt
+  final case class Stmts(stmts: List[Stmt]) extends Stmt
 
   // Because they're not just identifiers.
   val This = Ident("this")

--- a/core/src/main/scala/slamdata/engine/javascript/jscore.scala
+++ b/core/src/main/scala/slamdata/engine/javascript/jscore.scala
@@ -19,40 +19,40 @@ object JsCore {
     val js: String
   }
   abstract sealed class BinaryOperator(val js: String) extends Operator
-  case object Add extends BinaryOperator("+")
-  case object BitAnd extends BinaryOperator("&")
-  case object BitLShift extends BinaryOperator("<<")
-  case object BitNot extends BinaryOperator("~")
-  case object BitOr  extends BinaryOperator("|")
-  case object BitRShift  extends BinaryOperator(">>")
-  case object BitXor  extends BinaryOperator("^")
-  case object Lt extends BinaryOperator("<")
-  case object Lte extends BinaryOperator("<=")
-  case object Gt extends BinaryOperator(">")
-  case object Gte extends BinaryOperator(">=")
-  case object Eq extends BinaryOperator("===")
-  case object Neq extends BinaryOperator("!==")
-  case object Div extends BinaryOperator("/")
-  case object In extends BinaryOperator("in")
-  case object And extends BinaryOperator("&&")
-  case object Or extends BinaryOperator("||")
-  case object Mod extends BinaryOperator("%")
-  case object Mult extends BinaryOperator("*")
-  case object Sub extends BinaryOperator("-")
+  final case object Add extends BinaryOperator("+")
+  final case object BitAnd extends BinaryOperator("&")
+  final case object BitLShift extends BinaryOperator("<<")
+  final case object BitNot extends BinaryOperator("~")
+  final case object BitOr  extends BinaryOperator("|")
+  final case object BitRShift  extends BinaryOperator(">>")
+  final case object BitXor  extends BinaryOperator("^")
+  final case object Lt extends BinaryOperator("<")
+  final case object Lte extends BinaryOperator("<=")
+  final case object Gt extends BinaryOperator(">")
+  final case object Gte extends BinaryOperator(">=")
+  final case object Eq extends BinaryOperator("===")
+  final case object Neq extends BinaryOperator("!==")
+  final case object Div extends BinaryOperator("/")
+  final case object In extends BinaryOperator("in")
+  final case object And extends BinaryOperator("&&")
+  final case object Or extends BinaryOperator("||")
+  final case object Mod extends BinaryOperator("%")
+  final case object Mult extends BinaryOperator("*")
+  final case object Sub extends BinaryOperator("-")
 
   abstract sealed class UnaryOperator(val js: String) extends Operator
-  case object Neg extends UnaryOperator("-")
-  case object Not extends UnaryOperator("!")
+  final case object Neg extends UnaryOperator("-")
+  final case object Not extends UnaryOperator("!")
 
-  case class Literal(value: Js.Lit) extends JsCore[Nothing]
-  case class Ident(name: String) extends JsCore[Nothing]
+  final case class Literal(value: Js.Lit) extends JsCore[Nothing]
+  final case class Ident(name: String) extends JsCore[Nothing]
 
-  case class Access[A](expr: A, key: A) extends JsCore[A]
-  case class Call[A](callee: A, args: List[A]) extends JsCore[A]
-  case class New[A](name: String, args: List[A]) extends JsCore[A]
-  case class If[A](condition: A, consequent: A, alternative: A) extends JsCore[A]
-  case class UnOp[A](op: UnaryOperator, arg: A) extends JsCore[A]
-  case class BinOp[A](op: BinaryOperator, left: A, right: A) extends JsCore[A]
+  final case class Access[A](expr: A, key: A) extends JsCore[A]
+  final case class Call[A](callee: A, args: List[A]) extends JsCore[A]
+  final case class New[A](name: String, args: List[A]) extends JsCore[A]
+  final case class If[A](condition: A, consequent: A, alternative: A) extends JsCore[A]
+  final case class UnOp[A](op: UnaryOperator, arg: A) extends JsCore[A]
+  final case class BinOp[A](op: BinaryOperator, left: A, right: A) extends JsCore[A]
   object BinOp {
     def apply[A](op: BinaryOperator, a1: Term[JsCore], a2: Term[JsCore], a3: Term[JsCore], args: Term[JsCore]*): Term[JsCore] = args.toList match {
       case Nil    => BinOp(op, a1, BinOp(op, a2, a3).fix).fix
@@ -62,17 +62,17 @@ object JsCore {
   // TODO: Cond
   // TODO: Fn?
 
-  case class Arr[A](values: List[A]) extends JsCore[A]
-  case class Fun[A](params: List[String], body: A) extends JsCore[A]
+  final case class Arr[A](values: List[A]) extends JsCore[A]
+  final case class Fun[A](params: List[String], body: A) extends JsCore[A]
 
   // NB: at runtime, JS may not preserve the order of fields, but using
   // ListMap here lets us be explicit about what result we'd like to see.
-  case class Obj[A](values: ListMap[String, A]) extends JsCore[A]
+  final case class Obj[A](values: ListMap[String, A]) extends JsCore[A]
 
-  case class Let[A](name: Ident, expr: A, body: A) extends JsCore[A]
+  final case class Let[A](name: Ident, expr: A, body: A) extends JsCore[A]
 
-  case class SpliceObjects[A](srcs: List[A]) extends JsCore[A]
-  case class SpliceArrays[A](srcs: List[A]) extends JsCore[A]
+  final case class SpliceObjects[A](srcs: List[A]) extends JsCore[A]
+  final case class SpliceArrays[A](srcs: List[A]) extends JsCore[A]
 
   def Select(expr: Term[JsCore], name: String): Access[Term[JsCore]] =
     Access(expr, Literal(Js.Str(name)).fix)
@@ -325,7 +325,7 @@ object JsCore {
   }
 }
 
-case class JsFn(base: JsCore.Ident, expr: Term[JsCore]) {
+final case class JsFn(base: JsCore.Ident, expr: Term[JsCore]) {
   def apply(x: Term[JsCore]) = expr.substitute(base.fix, x)
 
   def >>>(that: JsFn): JsFn =

--- a/core/src/main/scala/slamdata/engine/logicalplan.scala
+++ b/core/src/main/scala/slamdata/engine/logicalplan.scala
@@ -96,7 +96,7 @@ object LogicalPlan {
     }
   }
 
-  case class ReadF(path: Path) extends LogicalPlan[Nothing] {
+  final case class ReadF(path: Path) extends LogicalPlan[Nothing] {
     override def toString = s"""Read(Path("${path.simplePathname}"))"""
   }
   object Read {
@@ -104,13 +104,13 @@ object LogicalPlan {
       Term[LogicalPlan](new ReadF(path))
   }
 
-  case class ConstantF(data: Data) extends LogicalPlan[Nothing]
+  final case class ConstantF(data: Data) extends LogicalPlan[Nothing]
   object Constant {
     def apply(data: Data): Term[LogicalPlan] =
       Term[LogicalPlan](ConstantF(data))
   }
 
-  case class JoinF[A](left: A, right: A,
+  final case class JoinF[A](left: A, right: A,
                                joinType: JoinType, joinRel: Mapping,
                                leftProj: A, rightProj: A) extends LogicalPlan[A] {
     override def toString = s"Join($left, $right, $joinType, $joinRel, $leftProj, $rightProj)"
@@ -122,7 +122,7 @@ object LogicalPlan {
       Term[LogicalPlan](JoinF(left, right, joinType, joinRel, leftProj, rightProj))
   }
 
-  case class InvokeF[A](func: Func, values: List[A]) extends LogicalPlan[A] {
+  final case class InvokeF[A](func: Func, values: List[A]) extends LogicalPlan[A] {
     override def toString = {
       val funcName = if (func.name(0).isLetter) func.name.split('_').map(_.toLowerCase.capitalize).mkString
                       else "\"" + func.name + "\""
@@ -134,13 +134,13 @@ object LogicalPlan {
       Term[LogicalPlan](InvokeF(func, values))
   }
 
-  case class FreeF(name: Symbol) extends LogicalPlan[Nothing]
+  final case class FreeF(name: Symbol) extends LogicalPlan[Nothing]
   object Free {
     def apply(name: Symbol): Term[LogicalPlan] =
       Term[LogicalPlan](FreeF(name))
   }
 
-  case class LetF[A](let: Symbol, form: A, in: A) extends LogicalPlan[A]
+  final case class LetF[A](let: Symbol, form: A, in: A) extends LogicalPlan[A]
   object Let {
     def apply(let: Symbol, form: Term[LogicalPlan], in: Term[LogicalPlan]): Term[LogicalPlan] =
       Term[LogicalPlan](LetF(let, form, in))
@@ -251,9 +251,9 @@ object LogicalPlan {
 
   sealed trait JoinType
   object JoinType {
-    case object Inner extends JoinType
-    case object LeftOuter extends JoinType
-    case object RightOuter extends JoinType
-    case object FullOuter extends JoinType
+    final case object Inner extends JoinType
+    final case object LeftOuter extends JoinType
+    final case object RightOuter extends JoinType
+    final case object FullOuter extends JoinType
   }
 }

--- a/core/src/main/scala/slamdata/engine/mounter.scala
+++ b/core/src/main/scala/slamdata/engine/mounter.scala
@@ -10,7 +10,7 @@ import scalaz.concurrent._
 
 object Mounter {
   sealed trait MountError extends Error
-  case class MissingFileSystem(path: Path, config: BackendConfig) extends MountError {
+  final case class MissingFileSystem(path: Path, config: BackendConfig) extends MountError {
     def message = "No data source could be mounted at the path " + path + " using the config " + config
   }
 

--- a/core/src/main/scala/slamdata/engine/mra.scala
+++ b/core/src/main/scala/slamdata/engine/mra.scala
@@ -214,10 +214,10 @@ object MRA {
   }
 
   sealed trait DimContract
-  case object DimContract extends DimContract
+  final case object DimContract extends DimContract
 
   sealed trait DimExpand
-  case object DimExpand extends DimExpand
+  final case object DimExpand extends DimExpand
 
   val dimsƒ: LogicalPlan[Dims] => Dims = {
     case ReadF(path) => Dims.set(path)

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/bsoncodec.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/bsoncodec.scala
@@ -8,7 +8,7 @@ import slamdata.engine.fp._
 
 object BsonCodec {
   trait ConversionError extends Error
-  case class InvalidObjectIdError(data: Data.Id) extends Error {
+  final case class InvalidObjectIdError(data: Data.Id) extends Error {
     def message = "Not a valid MongoDB ObjectId: " + data.value
   }
 

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/collection.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/collection.scala
@@ -12,7 +12,7 @@ import scala.util.parsing.combinator.lexical._
 import scala.util.parsing.combinator.syntactical._
 import scala.util.parsing.combinator.token._
 
-case class Collection(databaseName: String, collectionName: String) {
+final case class Collection(databaseName: String, collectionName: String) {
   def asPath: Path = Path(databaseName + '/' + Collection.PathUnparser(collectionName))
 }
 object Collection {

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/evaluator.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/evaluator.scala
@@ -33,7 +33,7 @@ trait Executor[F[_]] {
   def fail[A](e: EvaluationError): F[A]
 }
 
-case class UnsupportedMongoVersion(version: List[Int]) extends slamdata.engine.Error {
+final case class UnsupportedMongoVersion(version: List[Int]) extends slamdata.engine.Error {
   def message = "Unsupported MongoDB version: " + version.mkString(".")
 }
 
@@ -188,7 +188,7 @@ trait NameGenerator[F[_]] {
 }
 
 object SequenceNameGenerator {
-  case class EvalState(tmp: String, counter: Int) {
+  final case class EvalState(tmp: String, counter: Int) {
     def inc: EvalState = copy(counter = counter + 1)
   }
 
@@ -197,7 +197,7 @@ object SequenceNameGenerator {
   def startUnique: Task[EvalState] = Task.delay(EvalState("tmp.gen_" + scala.util.Random.nextInt().toHexString + "_", 0))
   def startSimple: EvalState = EvalState("tmp.gen_", 0)
 
-  case object Gen extends NameGenerator[SequenceState] {
+  final case object Gen extends NameGenerator[SequenceState] {
     def generateTempName(dbName: String): SequenceState[Collection] = for {
       st <- get
       _  <- put(st.inc)

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/exprop.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/exprop.scala
@@ -177,7 +177,7 @@ object ExprOp {
     def bson = Bson.Doc(ListMap(op -> rhs))
   }
 
-  case object Include extends ExprOp { def bson = Bson.Bool(true) }
+  final case object Include extends ExprOp { def bson = Bson.Bool(true) }
 
   sealed trait FieldLike extends ExprOp
   object DocField {
@@ -188,7 +188,7 @@ object ExprOp {
       case _ => None
     }
   }
-  case class DocVar(name: DocVar.Name, deref: Option[BsonField]) extends FieldLike {
+  final case class DocVar(name: DocVar.Name, deref: Option[BsonField]) extends FieldLike {
     def path: List[BsonField.Leaf] = deref.toList.flatMap(_.flatten.toList)
 
     def startsWith(that: DocVar) = (this.name == that.name) && {
@@ -234,7 +234,7 @@ object ExprOp {
     }
   }
   object DocVar {
-    case class Name(name: String) {
+    final case class Name(name: String) {
       def apply() = DocVar(this, None)
 
       def apply(field: BsonField) = DocVar(this, Some(field))
@@ -280,29 +280,29 @@ object ExprOp {
       }
     }
   }
-  case class AddToSet(value: ExprOp) extends GroupOp { val op = "$addToSet" }
-  case class Push(value: ExprOp)     extends GroupOp { val op = "$push" }
-  case class First(value: ExprOp)    extends GroupOp { val op = "$first" }
-  case class Last(value: ExprOp)     extends GroupOp { val op = "$last" }
-  case class Max(value: ExprOp)      extends GroupOp { val op = "$max" }
-  case class Min(value: ExprOp)      extends GroupOp { val op = "$min" }
-  case class Avg(value: ExprOp)      extends GroupOp { val op = "$avg" }
-  case class Sum(value: ExprOp)      extends GroupOp { val op = "$sum" }
+  final case class AddToSet(value: ExprOp) extends GroupOp { val op = "$addToSet" }
+  final case class Push(value: ExprOp)     extends GroupOp { val op = "$push" }
+  final case class First(value: ExprOp)    extends GroupOp { val op = "$first" }
+  final case class Last(value: ExprOp)     extends GroupOp { val op = "$last" }
+  final case class Max(value: ExprOp)      extends GroupOp { val op = "$max" }
+  final case class Min(value: ExprOp)      extends GroupOp { val op = "$min" }
+  final case class Avg(value: ExprOp)      extends GroupOp { val op = "$avg" }
+  final case class Sum(value: ExprOp)      extends GroupOp { val op = "$sum" }
 
   implicit object GroupOpRenderTree extends RenderTree[GroupOp] {
     override def render(v: GroupOp) = Terminal(v.toString, List("GroupOp"))
   }
 
   sealed trait BoolOp extends SimpleOp
-  case class And(values: NonEmptyList[ExprOp]) extends BoolOp {
+  final case class And(values: NonEmptyList[ExprOp]) extends BoolOp {
     val op = "$and"
     def rhs = Bson.Arr(values.list.map(_.bson))
   }
-  case class Or(values: NonEmptyList[ExprOp]) extends BoolOp {
+  final case class Or(values: NonEmptyList[ExprOp]) extends BoolOp {
     val op = "$or"
     def rhs = Bson.Arr(values.list.map(_.bson))
   }
-  case class Not(value: ExprOp) extends BoolOp {
+  final case class Not(value: ExprOp) extends BoolOp {
     val op = "$not"
     def rhs = value.bson
   }
@@ -313,19 +313,19 @@ object ExprOp {
 
     def rhs = Bson.Arr(left.bson :: right.bson :: Nil)
   }
-  case class SetEquals(left: ExprOp, right: ExprOp) extends BinarySetOp {
+  final case class SetEquals(left: ExprOp, right: ExprOp) extends BinarySetOp {
     val op = "$setEquals"
   }
-  case class SetIntersection(left: ExprOp, right: ExprOp) extends BinarySetOp {
+  final case class SetIntersection(left: ExprOp, right: ExprOp) extends BinarySetOp {
     val op = "$setIntersection"
   }
-  case class SetDifference(left: ExprOp, right: ExprOp) extends BinarySetOp {
+  final case class SetDifference(left: ExprOp, right: ExprOp) extends BinarySetOp {
     val op = "$setDifference"
   }
-  case class SetUnion(left: ExprOp, right: ExprOp) extends BinarySetOp {
+  final case class SetUnion(left: ExprOp, right: ExprOp) extends BinarySetOp {
     val op = "$setUnion"
   }
-  case class SetIsSubset(left: ExprOp, right: ExprOp) extends BinarySetOp {
+  final case class SetIsSubset(left: ExprOp, right: ExprOp) extends BinarySetOp {
     val op = "$setIsSubset"
   }
 
@@ -334,10 +334,10 @@ object ExprOp {
 
     def rhs = value.bson
   }
-  case class AnyElementTrue(value: ExprOp) extends UnarySetOp {
+  final case class AnyElementTrue(value: ExprOp) extends UnarySetOp {
     val op = "$anyElementTrue"
   }
-  case class AllElementsTrue(value: ExprOp) extends UnarySetOp {
+  final case class AllElementsTrue(value: ExprOp) extends UnarySetOp {
     val op = "$allElementsTrue"
   }
 
@@ -347,13 +347,13 @@ object ExprOp {
 
     def rhs = Bson.Arr(left.bson :: right.bson :: Nil)
   }
-  case class Cmp(left: ExprOp, right: ExprOp) extends CompOp { val op = "$cmp" }
-  case class Eq(left: ExprOp, right: ExprOp)  extends CompOp { val op = "$eq" }
-  case class Gt(left: ExprOp, right: ExprOp)  extends CompOp { val op = "$gt" }
-  case class Gte(left: ExprOp, right: ExprOp) extends CompOp { val op = "$gte" }
-  case class Lt(left: ExprOp, right: ExprOp)  extends CompOp { val op = "$lt" }
-  case class Lte(left: ExprOp, right: ExprOp) extends CompOp { val op = "$lte" }
-  case class Neq(left: ExprOp, right: ExprOp) extends CompOp { val op = "$ne" }
+  final case class Cmp(left: ExprOp, right: ExprOp) extends CompOp { val op = "$cmp" }
+  final case class Eq(left: ExprOp, right: ExprOp)  extends CompOp { val op = "$eq" }
+  final case class Gt(left: ExprOp, right: ExprOp)  extends CompOp { val op = "$gt" }
+  final case class Gte(left: ExprOp, right: ExprOp) extends CompOp { val op = "$gte" }
+  final case class Lt(left: ExprOp, right: ExprOp)  extends CompOp { val op = "$lt" }
+  final case class Lte(left: ExprOp, right: ExprOp) extends CompOp { val op = "$lte" }
+  final case class Neq(left: ExprOp, right: ExprOp) extends CompOp { val op = "$ne" }
 
   sealed trait MathOp extends SimpleOp {
     def left: ExprOp
@@ -361,59 +361,59 @@ object ExprOp {
 
     def rhs = Bson.Arr(left.bson :: right.bson :: Nil)
   }
-  case class Add(left: ExprOp, right: ExprOp) extends MathOp {
+  final case class Add(left: ExprOp, right: ExprOp) extends MathOp {
     val op = "$add"
   }
-  case class Divide(left: ExprOp, right: ExprOp) extends MathOp {
+  final case class Divide(left: ExprOp, right: ExprOp) extends MathOp {
     val op = "$divide"
   }
-  case class Mod(left: ExprOp, right: ExprOp) extends MathOp {
+  final case class Mod(left: ExprOp, right: ExprOp) extends MathOp {
     val op = "$mod"
   }
-  case class Multiply(left: ExprOp, right: ExprOp) extends MathOp {
+  final case class Multiply(left: ExprOp, right: ExprOp) extends MathOp {
     val op = "$multiply"
   }
-  case class Subtract(left: ExprOp, right: ExprOp) extends MathOp {
+  final case class Subtract(left: ExprOp, right: ExprOp) extends MathOp {
     val op = "$subtract"
   }
 
   sealed trait StringOp extends SimpleOp
-  case class Concat(first: ExprOp, second: ExprOp, others: List[ExprOp]) extends StringOp {
+  final case class Concat(first: ExprOp, second: ExprOp, others: List[ExprOp]) extends StringOp {
     val op = "$concat"
     def rhs = Bson.Arr(first.bson :: second.bson :: others.map(_.bson))
   }
-  case class Strcasecmp(left: ExprOp, right: ExprOp) extends StringOp {
+  final case class Strcasecmp(left: ExprOp, right: ExprOp) extends StringOp {
     val op = "$strcasecmp"
     def rhs = Bson.Arr(left.bson :: right.bson :: Nil)
   }
-  case class Substr(value: ExprOp, start: ExprOp, count: ExprOp)
+  final case class Substr(value: ExprOp, start: ExprOp, count: ExprOp)
       extends StringOp {
     val op = "$substr"
     def rhs = Bson.Arr(value.bson :: start.bson :: count.bson :: Nil)
   }
-  case class ToLower(value: ExprOp) extends StringOp {
+  final case class ToLower(value: ExprOp) extends StringOp {
     val op = "$toLower"
     def rhs = value.bson
   }
-  case class ToUpper(value: ExprOp) extends StringOp {
+  final case class ToUpper(value: ExprOp) extends StringOp {
     val op = "$toUpper"
     def rhs = value.bson
   }
 
   sealed trait TextSearchOp extends SimpleOp
-  case object Meta extends TextSearchOp {
+  final case object Meta extends TextSearchOp {
     val op = "$meta"
     def rhs = Bson.Text("textScore")
   }
 
   sealed trait ArrayOp extends SimpleOp
-  case class Size(array: ExprOp) extends ArrayOp {
+  final case class Size(array: ExprOp) extends ArrayOp {
     val op = "$size"
     def rhs = array.bson
   }
 
   sealed trait ProjOp extends ExprOp
-  case class ArrayMap(input: ExprOp, as: DocVar.Name, in: ExprOp)
+  final case class ArrayMap(input: ExprOp, as: DocVar.Name, in: ExprOp)
       extends SimpleOp {
     val op = "$map"
     def rhs = Bson.Doc(ListMap(
@@ -422,14 +422,14 @@ object ExprOp {
       "in"    -> in.bson
     ))
   }
-  case class Let(vars: ListMap[DocVar.Name, ExprOp], in: ExprOp) extends SimpleOp {
+  final case class Let(vars: ListMap[DocVar.Name, ExprOp], in: ExprOp) extends SimpleOp {
     val op = "$let"
     def rhs = Bson.Doc(ListMap(
       "vars" -> Bson.Doc(vars.map(t => (t._1.name, t._2.bson))),
       "in"   -> in.bson
     ))
   }
-  case class Literal(value: Bson) extends ProjOp {
+  final case class Literal(value: Bson) extends ProjOp {
     def bson = Bson.Doc(ListMap("$literal" -> value))
   }
 
@@ -438,24 +438,24 @@ object ExprOp {
 
     def rhs = date.bson
   }
-  case class DayOfYear(date: ExprOp)   extends DateOp { val op = "$dayOfYear" }
-  case class DayOfMonth(date: ExprOp)  extends DateOp { val op = "$dayOfMonth" }
-  case class DayOfWeek(date: ExprOp)   extends DateOp { val op = "$dayOfWeek" }
-  case class Year(date: ExprOp)        extends DateOp { val op = "$year" }
-  case class Month(date: ExprOp)       extends DateOp { val op = "$month" }
-  case class Week(date: ExprOp)        extends DateOp { val op = "$week" }
-  case class Hour(date: ExprOp)        extends DateOp { val op = "$hour" }
-  case class Minute(date: ExprOp)      extends DateOp { val op = "$minute" }
-  case class Second(date: ExprOp)      extends DateOp { val op = "$second" }
-  case class Millisecond(date: ExprOp) extends DateOp { val op = "$millisecond" }
+  final case class DayOfYear(date: ExprOp)   extends DateOp { val op = "$dayOfYear" }
+  final case class DayOfMonth(date: ExprOp)  extends DateOp { val op = "$dayOfMonth" }
+  final case class DayOfWeek(date: ExprOp)   extends DateOp { val op = "$dayOfWeek" }
+  final case class Year(date: ExprOp)        extends DateOp { val op = "$year" }
+  final case class Month(date: ExprOp)       extends DateOp { val op = "$month" }
+  final case class Week(date: ExprOp)        extends DateOp { val op = "$week" }
+  final case class Hour(date: ExprOp)        extends DateOp { val op = "$hour" }
+  final case class Minute(date: ExprOp)      extends DateOp { val op = "$minute" }
+  final case class Second(date: ExprOp)      extends DateOp { val op = "$second" }
+  final case class Millisecond(date: ExprOp) extends DateOp { val op = "$millisecond" }
 
   sealed trait CondOp extends SimpleOp
-  case class Cond(predicate: ExprOp, ifTrue: ExprOp, ifFalse: ExprOp)
+  final case class Cond(predicate: ExprOp, ifTrue: ExprOp, ifFalse: ExprOp)
       extends CondOp {
     val op = "$cond"
     def rhs = Bson.Arr(predicate.bson :: ifTrue.bson :: ifFalse.bson :: Nil)
   }
-  case class IfNull(expr: ExprOp, replacement: ExprOp) extends CondOp {
+  final case class IfNull(expr: ExprOp, replacement: ExprOp) extends CondOp {
     val op = "$ifNull"
     def rhs = Bson.Arr(expr.bson :: replacement.bson :: Nil)
   }

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/findquery.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/findquery.scala
@@ -97,28 +97,28 @@ object Selector {
   }
 
   sealed trait Comparison extends Condition
-  case class Eq(bson: Bson) extends Condition with Comparison
-  case class Gt(rhs: Bson) extends SimpleCondition("$gt") with Comparison
-  case class Gte(rhs: Bson) extends SimpleCondition("$gte") with Comparison
-  case class In(rhs: Bson) extends SimpleCondition("$in") with Comparison
-  case class Lt(rhs: Bson) extends SimpleCondition("$lt") with Comparison
-  case class Lte(rhs: Bson) extends SimpleCondition("$lte") with Comparison
-  case class Neq(rhs: Bson) extends SimpleCondition("$ne") with Comparison
-  case class Nin(rhs: Bson) extends SimpleCondition("$nin") with Comparison
+  final case class Eq(bson: Bson) extends Condition with Comparison
+  final case class Gt(rhs: Bson) extends SimpleCondition("$gt") with Comparison
+  final case class Gte(rhs: Bson) extends SimpleCondition("$gte") with Comparison
+  final case class In(rhs: Bson) extends SimpleCondition("$in") with Comparison
+  final case class Lt(rhs: Bson) extends SimpleCondition("$lt") with Comparison
+  final case class Lte(rhs: Bson) extends SimpleCondition("$lte") with Comparison
+  final case class Neq(rhs: Bson) extends SimpleCondition("$ne") with Comparison
+  final case class Nin(rhs: Bson) extends SimpleCondition("$nin") with Comparison
 
   sealed trait Element extends Condition
-  case class Exists(exists: Boolean) extends SimpleCondition("$exists") with Element {
+  final case class Exists(exists: Boolean) extends SimpleCondition("$exists") with Element {
     protected def rhs = Bson.Bool(exists)
   }
-  case class Type(bsonType: BsonType) extends SimpleCondition("$type") with Element {
+  final case class Type(bsonType: BsonType) extends SimpleCondition("$type") with Element {
     protected def rhs = Bson.Int32(bsonType.ordinal)
   }
 
   sealed trait Evaluation extends Condition
-  case class Mod(divisor: Int, remainder: Int) extends SimpleCondition("$mod") with Evaluation {
+  final case class Mod(divisor: Int, remainder: Int) extends SimpleCondition("$mod") with Evaluation {
     protected def rhs = Bson.Arr(Bson.Int32(divisor) :: Bson.Int32(remainder) :: Nil)
   }
-  case class Regex(pattern: String, caseInsensitive: Boolean, multiLine: Boolean, extended: Boolean, dotAll: Boolean) extends Evaluation {
+  final case class Regex(pattern: String, caseInsensitive: Boolean, multiLine: Boolean, extended: Boolean, dotAll: Boolean) extends Evaluation {
     def bson = Bson.Doc(ListMap(
                   "$regex" -> Bson.Text(pattern),  // Note: _not_ a Bson regex. Those can be use without the $regex operator, but we don't model that
                   "$options" ->
@@ -132,32 +132,32 @@ object Selector {
   //     {foo: 1, $where: "this.bar < this.baz"}),
   // but the same thing can be accomplished with $and, so we always wrap $where
   // in its own Bson.Doc.
-  case class Where(code: Js.Expr) extends Selector {
+  final case class Where(code: Js.Expr) extends Selector {
     def bson =
       Bson.Doc(ListMap(
         "$where" -> Bson.JavaScript(Js.AnonFunDecl(Nil, List(Js.Return(code))))))
   }
 
   sealed trait Geospatial extends Condition
-  case class GeoWithin(geometry: String, coords: List[List[(Double, Double)]]) extends SimpleCondition("$geoWithin") with Geospatial {
+  final case class GeoWithin(geometry: String, coords: List[List[(Double, Double)]]) extends SimpleCondition("$geoWithin") with Geospatial {
     protected def rhs = Bson.Doc(ListMap(
       "$geometry" -> Bson.Doc(ListMap(
         "type"        -> Bson.Text(geometry),
         "coordinates" -> Bson.Arr(coords.map(v => Bson.Arr(v.map(t => Bson.Arr(Bson.Dec(t._1) :: Bson.Dec(t._2) :: Nil)))))))))
   }
-  case class GeoIntersects(geometry: String, coords: List[List[(Double, Double)]]) extends SimpleCondition("$geoIntersects") with Geospatial {
+  final case class GeoIntersects(geometry: String, coords: List[List[(Double, Double)]]) extends SimpleCondition("$geoIntersects") with Geospatial {
     protected def rhs = Bson.Doc(ListMap(
       "$geometry" -> Bson.Doc(ListMap(
         "type"        -> Bson.Text(geometry),
         "coordinates" -> Bson.Arr(coords.map(v => Bson.Arr(v.map(t => Bson.Arr(Bson.Dec(t._1) :: Bson.Dec(t._2) :: Nil)))))))))
   }
-  case class Near(lat: Double, long: Double, maxDistance: Double) extends SimpleCondition("$near") with Geospatial {
+  final case class Near(lat: Double, long: Double, maxDistance: Double) extends SimpleCondition("$near") with Geospatial {
     protected def rhs = Bson.Doc(ListMap(
       "$geometry" -> Bson.Doc(ListMap(
         "type"        -> Bson.Text("Point"),
         "coordinates" -> Bson.Arr(Bson.Dec(long) :: Bson.Dec(lat) :: Nil)))))
   }
-  case class NearSphere(lat: Double, long: Double, maxDistance: Double) extends SimpleCondition("$nearSphere") with Geospatial {
+  final case class NearSphere(lat: Double, long: Double, maxDistance: Double) extends SimpleCondition("$nearSphere") with Geospatial {
     protected def rhs = Bson.Doc(ListMap(
       "$geometry" -> Bson.Doc(ListMap(
         "type"        -> Bson.Text("Point"),
@@ -166,14 +166,14 @@ object Selector {
   }
 
   sealed trait Arr extends Condition
-  case class All(selectors: List[Selector]) extends SimpleCondition("$all") with Arr {
+  final case class All(selectors: List[Selector]) extends SimpleCondition("$all") with Arr {
     protected def rhs = Bson.Arr(selectors.map(_.bson))
   }
-  case class ElemMatch(selector: Selector \/ SimpleCondition)
+  final case class ElemMatch(selector: Selector \/ SimpleCondition)
       extends SimpleCondition("$elemMatch") with Arr {
     protected def rhs = selector.fold(_.bson, _.bson)
   }
-  case class Size(size: Int) extends SimpleCondition("$size") with Arr {
+  final case class Size(size: Int) extends SimpleCondition("$size") with Arr {
     protected def rhs = Bson.Int32(size)
   }
 
@@ -181,15 +181,15 @@ object Selector {
     def bson: Bson
   }
 
-  case class Expr(value: Condition) extends SelectorExpr {
+  final case class Expr(value: Condition) extends SelectorExpr {
     def bson = value.bson
   }
 
-  case class NotExpr(value: Condition) extends SelectorExpr {
+  final case class NotExpr(value: Condition) extends SelectorExpr {
     def bson = Bson.Doc(ListMap("$not" -> value.bson))
   }
 
-  case class Doc(pairs: ListMap[BsonField, SelectorExpr]) extends Selector {
+  final case class Doc(pairs: ListMap[BsonField, SelectorExpr]) extends Selector {
     def bson = Bson.Doc(pairs.map { case (f, e) => f.asText -> e.bson })
 
     override def toString = {
@@ -223,9 +223,9 @@ object Selector {
     def bson = Bson.Doc(ListMap(op -> Bson.Arr(flatten.map(_.bson))))
   }
 
-  case class And(left: Selector, right: Selector) extends Abstract("$and")
-  case class Or(left: Selector, right: Selector) extends Abstract("$or")
-  case class Nor(left: Selector, right: Selector) extends Abstract("$nor")
+  final case class And(left: Selector, right: Selector) extends Abstract("$and")
+  final case class Or(left: Selector, right: Selector) extends Abstract("$or")
+  final case class Nor(left: Selector, right: Selector) extends Abstract("$nor")
 
   implicit val SelectorAndSemigroup: Semigroup[Selector] = new Semigroup[Selector] {
     def append(s1: Selector, s2: => Selector): Selector = {

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/findquery.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/findquery.scala
@@ -11,18 +11,17 @@ import slamdata.engine.javascript._
 
 final case class FindQuery(
   query:        Selector,
-  comment:      Option[String] = None,
-  explain:      Option[Boolean] = None,
-  hint:         Option[Bson] = None,
-  maxScan:      Option[Long] = None,
-  max:          Option[ListMap[BsonField, Bson]] = None,
-  min:          Option[ListMap[BsonField, Bson]] = None,
-  orderby:      Option[NonEmptyList[(BsonField, SortType)]] = None,
-  returnKey:    Option[Boolean] = None,
-  showDiskLoc:  Option[Boolean] = None,
-  snapshot:     Option[Boolean] = None,
-  natural:      Option[SortType] = None
-) {
+  comment:      Option[String],
+  explain:      Option[Boolean],
+  hint:         Option[Bson],
+  maxScan:      Option[Long],
+  max:          Option[ListMap[BsonField, Bson]],
+  min:          Option[ListMap[BsonField, Bson]],
+  orderby:      Option[NonEmptyList[(BsonField, SortType)]],
+  returnKey:    Option[Boolean],
+  showDiskLoc:  Option[Boolean],
+  snapshot:     Option[Boolean],
+  natural:      Option[SortType]) {
   def bson = Bson.Doc(List[List[(String, Bson)]](
     List("$query" -> query.bson),
     comment.toList.map    (comment      => ("$comment",     Bson.Text(comment))),
@@ -46,7 +45,7 @@ sealed trait Selector {
 
   import Selector._
 
-  // // TODO: Replace this with fixplate!!!
+  // TODO: Replace this with fixplate!!!
 
   def mapUpFields(f0: PartialFunction[BsonField, BsonField]): Selector = {
     val f0l = f0.lift

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/mapreduce.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/mapreduce.scala
@@ -8,6 +8,7 @@ import com.mongodb._
 
 import slamdata.engine.javascript._
 
+@SuppressWarnings(Array("org.brianmckenna.wartremover.warts.DefaultArguments"))
 final case class MapReduce(
   map:        Js.Expr, // "function if (...) emit(...) }"
   reduce:     Js.Expr, // "function (key, values) { ...; return ... }"
@@ -26,7 +27,7 @@ final case class MapReduce(
     Bson.Doc(ListMap(
       (// "map" -> Bson.JavaScript(map) ::
        //  "reduce" -> Bson.JavaScript(reduce) ::
-        Some("out" -> out.getOrElse(WithAction()).bson(dst)) ::
+        Some("out" -> out.getOrElse(WithAction(Action.Replace, None, None, None)).bson(dst)) ::
         selection.map("query" -> _.bson) ::
         limit.map("limit" -> Bson.Int64(_)) ::
         finalizer.map("finalize" -> Bson.JavaScript(_)) ::
@@ -52,10 +53,10 @@ object MapReduce {
   }
 
   final case class WithAction(
-    action:    Action = Action.Replace,
-    db:        Option[String] = None,
-    sharded:   Option[Boolean] = None,
-    nonAtomic: Option[Boolean] = None) extends Output {
+    action:    Action,
+    db:        Option[String],
+    sharded:   Option[Boolean],
+    nonAtomic: Option[Boolean]) extends Output {
 
     def outputTypeEnum = action match {
       case Action.Replace => MapReduceCommand.OutputType.REPLACE

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/mapreduce.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/mapreduce.scala
@@ -8,7 +8,7 @@ import com.mongodb._
 
 import slamdata.engine.javascript._
 
-case class MapReduce(
+final case class MapReduce(
   map:        Js.Expr, // "function if (...) emit(...) }"
   reduce:     Js.Expr, // "function (key, values) { ...; return ... }"
   out:        Option[MapReduce.Output] = None,
@@ -46,12 +46,12 @@ object MapReduce {
 
   sealed trait Action
   object Action {
-    case object Replace extends Action
-    case object Merge extends Action
-    case object Reduce extends Action
+    final case object Replace extends Action
+    final case object Merge extends Action
+    final case object Reduce extends Action
   }
 
-  case class WithAction(
+  final case class WithAction(
     action:    Action = Action.Replace,
     db:        Option[String] = None,
     sharded:   Option[Boolean] = None,
@@ -72,7 +72,7 @@ object MapReduce {
       ).flatten: _*))
   }
 
-  case object Inline extends Output {
+  final case object Inline extends Output {
     def outputTypeEnum = MapReduceCommand.OutputType.INLINE
     def bson(dst: Collection) = Bson.Doc(ListMap("inline" -> Bson.Int64(1)))
   }

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/package.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/package.scala
@@ -6,7 +6,7 @@ import slamdata.engine.javascript.JsCore
 
 package object mongodb {
 
-  case class NameGen(nameGen: Int)
+  final case class NameGen(nameGen: Int)
 
   // used by State(T).runZero
   implicit val NameGenMonoid: Monoid[NameGen] = new Monoid[NameGen] {

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/reshape.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/reshape.scala
@@ -9,7 +9,7 @@ import slamdata.engine.{Error, RenderTree, Terminal, NonTerminal, RenderedTree}
 import slamdata.engine.fp._
 import slamdata.engine.javascript._
 
-case class Grouped(value: ListMap[BsonField.Leaf, ExprOp.GroupOp]) {
+final case class Grouped(value: ListMap[BsonField.Leaf, ExprOp.GroupOp]) {
   type LeafMap[V] = ListMap[BsonField.Leaf, V]
 
   def bson = Bson.Doc(value.map(t => t._1.asText -> t._2.bson))

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/sort.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/sort.scala
@@ -6,5 +6,5 @@ sealed trait SortType {
     case Descending => Bson.Int32(-1)
   }
 }
-case object Ascending extends SortType
-case object Descending extends SortType
+final case object Ascending extends SortType
+final case object Descending extends SortType

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -17,12 +17,12 @@ import monocle.syntax._
 
 sealed trait WorkflowBuilderError extends Error
 object WorkflowBuilderError {
-  case class InvalidOperation(operation: String, msg: String)
+  final case class InvalidOperation(operation: String, msg: String)
       extends WorkflowBuilderError {
     def message = "Can not perform `" + operation + "`, because " + msg
   }
-  case class UnsupportedDistinct(message: String) extends WorkflowBuilderError
-  case class UnsupportedJoinCondition(func: Mapping) extends WorkflowBuilderError {
+  final case class UnsupportedDistinct(message: String) extends WorkflowBuilderError
+  final case class UnsupportedJoinCondition(func: Mapping) extends WorkflowBuilderError {
     def message = "Joining with " + func.name + " is not currently supported"
   }
 }
@@ -46,7 +46,7 @@ object WorkflowBuilder {
           js => RJM.render(js))
     }
 
-  case class CollectionBuilderF(
+  final case class CollectionBuilderF(
     graph: Workflow,
     base: DocVar,
     struct: Schema) extends WorkflowBuilderF[Nothing]
@@ -54,7 +54,7 @@ object WorkflowBuilder {
     def apply(graph: Workflow, base: DocVar, struct: Schema) =
       Term[WorkflowBuilderF](new CollectionBuilderF(graph, base, struct))
   }
-  case class ShapePreservingBuilderF[A](
+  final case class ShapePreservingBuilderF[A](
     src: A,
     inputs: List[A],
     op: PartialFunction[List[BsonField], WorkflowOp])
@@ -83,11 +83,11 @@ object WorkflowBuilder {
         })(
         $read(Collection("", "")))
   }
-  case class ValueBuilderF(value: Bson) extends WorkflowBuilderF[Nothing]
+  final case class ValueBuilderF(value: Bson) extends WorkflowBuilderF[Nothing]
   object ValueBuilder {
     def apply(value: Bson) = Term[WorkflowBuilderF](new ValueBuilderF(value))
   }
-  case class ExprBuilderF[A](src: A, expr: Expr) extends WorkflowBuilderF[A]
+  final case class ExprBuilderF[A](src: A, expr: Expr) extends WorkflowBuilderF[A]
   object ExprBuilder {
     def apply(src: WorkflowBuilder, expr: Expr) =
       Term[WorkflowBuilderF](new ExprBuilderF(src, expr))
@@ -96,14 +96,14 @@ object WorkflowBuilder {
   // NB: The shape is more restrictive than $project because we may need to
   //     convert it to a GroupBuilder, and a nested Reshape can be realized with
   //     a chain of DocBuilders, leaving the collapsing to Workflow.coalesce.
-  case class DocBuilderF[A](src: A, shape: ListMap[BsonField.Name, Expr])
+  final case class DocBuilderF[A](src: A, shape: ListMap[BsonField.Name, Expr])
       extends WorkflowBuilderF[A]
   object DocBuilder {
     def apply(src: WorkflowBuilder, shape: ListMap[BsonField.Name, Expr]) =
       Term[WorkflowBuilderF](new DocBuilderF(src, shape))
   }
 
-  case class ArrayBuilderF[A](src: A, shape: List[Expr])
+  final case class ArrayBuilderF[A](src: A, shape: List[Expr])
       extends WorkflowBuilderF[A]
   object ArrayBuilder {
     def apply(src: WorkflowBuilder, shape: List[Expr]) =
@@ -114,9 +114,9 @@ object WorkflowBuilder {
   sealed trait DocContents[+A] extends Contents[A]
   sealed trait ArrayContents[+A] extends Contents[A]
   object Contents {
-    case class Expr[A](contents: A) extends DocContents[A] with ArrayContents[A]
-    case class Doc[A](contents: ListMap[BsonField.Name, A]) extends DocContents[A]
-    case class Array[A](contents: List[A]) extends ArrayContents[A]
+    final case class Expr[A](contents: A) extends DocContents[A] with ArrayContents[A]
+    final case class Doc[A](contents: ListMap[BsonField.Name, A]) extends DocContents[A]
+    final case class Array[A](contents: List[A]) extends ArrayContents[A]
 
     implicit def ContentsRenderTree[A](implicit RA: RenderTree[A], RB: RenderTree[ListMap[BsonField.Name, A]]) =
       new RenderTree[Contents[A]] {
@@ -133,11 +133,11 @@ object WorkflowBuilder {
   type GroupValue = ExprOp \/ GroupOp
   type GroupContents = DocContents[GroupValue]
 
-  case class GroupId(srcs: List[WorkflowBuilder]) {
+  final case class GroupId(srcs: List[WorkflowBuilder]) {
     override def toString = hashCode.toHexString
   }
 
-  case class GroupBuilderF[A](
+  final case class GroupBuilderF[A](
     src: A, keys: List[A], contents: GroupContents, id: GroupId)
       extends WorkflowBuilderF[A]
   object GroupBuilder {
@@ -151,11 +151,11 @@ object WorkflowBuilder {
 
   sealed trait StructureType
   object StructureType {
-    case object Array extends StructureType
-    case object Object extends StructureType
+    final case object Array extends StructureType
+    final case object Object extends StructureType
   }
 
-  case class FlatteningBuilderF[A](src: A, typ: StructureType, field: DocVar)
+  final case class FlatteningBuilderF[A](src: A, typ: StructureType, field: DocVar)
       extends WorkflowBuilderF[A]
   object FlatteningBuilder {
     def apply(src: WorkflowBuilder, typ: StructureType, field: DocVar) =
@@ -167,7 +167,7 @@ object WorkflowBuilder {
     entries are known. There should be at least one Expr in the list, otherwise
     it should be a DocBuilder.
     */
-  case class SpliceBuilderF[A](src: A, structure: List[DocContents[Expr]])
+  final case class SpliceBuilderF[A](src: A, structure: List[DocContents[Expr]])
       extends WorkflowBuilderF[A] {
     def toJs: Error \/ JsFn =
       structure.map {
@@ -183,7 +183,7 @@ object WorkflowBuilder {
       Term[WorkflowBuilderF](new SpliceBuilderF(src, structure))
   }
 
-  case class ArraySpliceBuilderF[A](src: A, structure: List[ArrayContents[Expr]])
+  final case class ArraySpliceBuilderF[A](src: A, structure: List[ArrayContents[Expr]])
       extends WorkflowBuilderF[A] {
     def toJs: Error \/ JsFn =
       structure.map {

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowop.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowop.scala
@@ -334,6 +334,8 @@ object Workflow {
                   mr applyLens MapReduce._out set
                     Some(MapReduce.WithAction(
                       MapReduce.Action.Reduce,
+                      db = None,
+                      sharded = None,
                       nonAtomic = Some(true))))
               // NB: `finalize` should ensure that the final op is always a
               //     $Reduce.

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowtask.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowtask.scala
@@ -122,17 +122,17 @@ object WorkflowTask {
   /**
    * A task that returns a necessarily small amount of raw data.
    */
-  case class PureTask(value: Bson) extends WorkflowTask
+  final case class PureTask(value: Bson) extends WorkflowTask
 
   /**
    * A task that merely sources data from some specified collection.
    */
-  case class ReadTask(value: Collection) extends WorkflowTask
+  final case class ReadTask(value: Collection) extends WorkflowTask
 
   /**
    * A task that executes a Mongo read query.
    */
-  case class QueryTask(
+  final case class QueryTask(
     source: WorkflowTask,
     query: FindQuery,
     skip: Option[Int],
@@ -142,13 +142,13 @@ object WorkflowTask {
   /**
    * A task that executes a Mongo pipeline aggregation.
    */
-  case class PipelineTask(source: WorkflowTask, pipeline: Pipeline)
+  final case class PipelineTask(source: WorkflowTask, pipeline: Pipeline)
       extends WorkflowTask
 
   /**
    * A task that executes a Mongo map/reduce job.
    */
-  case class MapReduceTask(source: WorkflowTask, mapReduce: MapReduce)
+  final case class MapReduceTask(source: WorkflowTask, mapReduce: MapReduce)
       extends WorkflowTask
 
   /**
@@ -157,7 +157,7 @@ object WorkflowTask {
    * collection, and the remaining tasks must be able to merge their results
    * into an existing collection, hence the types.
    */
-  case class FoldLeftTask(head: WorkflowTask, tail: NonEmptyList[MapReduceTask])
+  final case class FoldLeftTask(head: WorkflowTask, tail: NonEmptyList[MapReduceTask])
       extends WorkflowTask
 
   /**
@@ -165,6 +165,6 @@ object WorkflowTask {
    * must accept two parameters: the source collection, and the destination
    * collection.
    */
-  // case class EvalTask(source: WorkflowTask, code: Js.FuncDecl)
+  // final case class EvalTask(source: WorkflowTask, code: Js.FuncDecl)
   //     extends WorkflowTask
 }

--- a/core/src/main/scala/slamdata/engine/query.scala
+++ b/core/src/main/scala/slamdata/engine/query.scala
@@ -6,6 +6,6 @@ import slamdata.engine.fs.Path
 final case class QueryRequest(
   query:      Query,
   out:        Option[Path],
-  mountPath:  Path = Path.Root,
-  basePath:   Path = Path.Root,
-  variables:  Variables = Variables(Map()))
+  mountPath:  Path,
+  basePath:   Path,
+  variables:  Variables) // Variables(Map())

--- a/core/src/main/scala/slamdata/engine/query.scala
+++ b/core/src/main/scala/slamdata/engine/query.scala
@@ -3,7 +3,7 @@ package slamdata.engine
 import slamdata.engine.sql.Query
 import slamdata.engine.fs.Path
 
-case class QueryRequest(
+final case class QueryRequest(
   query:      Query,
   out:        Option[Path],
   mountPath:  Path = Path.Root,

--- a/core/src/main/scala/slamdata/engine/repl/prettify.scala
+++ b/core/src/main/scala/slamdata/engine/repl/prettify.scala
@@ -10,10 +10,10 @@ import slamdata.engine.fp._
 
 object Prettify {
   sealed trait Segment
-  case class FieldSeg(name: String) extends Segment
-  case class IndexSeg(index: Int) extends Segment
+  final case class FieldSeg(name: String) extends Segment
+  final case class IndexSeg(index: Int) extends Segment
 
-  case class Path(segs: List[Segment]) {
+  final case class Path(segs: List[Segment]) {
     def label = segs.foldLeft(List[String]() -> true) { case ((acc, first), seg) =>
       (acc :+ (seg match {
         case FieldSeg(name) if first => name
@@ -55,8 +55,8 @@ object Prettify {
     def value: A
   }
   object Aligned {
-    case class Left[A](value: A) extends Aligned[A]
-    case class Right[A](value: A) extends Aligned[A]
+    final case class Left[A](value: A) extends Aligned[A]
+    final case class Right[A](value: A) extends Aligned[A]
   }
 
   /**

--- a/core/src/main/scala/slamdata/engine/repl/repl.scala
+++ b/core/src/main/scala/slamdata/engine/repl/repl.scala
@@ -45,29 +45,29 @@ object Repl {
     val UnsetVarPattern     = "(?i)unset +(\\w+)".r
     val ListVarPattern      = "(?i)env".r
 
-    case object Exit extends Command
-    case object Unknown extends Command
-    case object Help extends Command
-    case object ListVars extends Command
-    case class Cd(dir: Path) extends Command
-    case class Select(name: Option[String], query: String) extends Command
-    case class Ls(dir: Option[Path]) extends Command
-    case class Save(path: Path, value: String) extends Command
-    case class Append(path: Path, value: String) extends Command
-    case class Delete(path: Path) extends Command
-    case class Debug(level: DebugLevel) extends Command
-    case class SummaryCount(rows: Int) extends Command
-    case class SetVar(name: String, value: String) extends Command
-    case class UnsetVar(name: String) extends Command
+    final case object Exit extends Command
+    final case object Unknown extends Command
+    final case object Help extends Command
+    final case object ListVars extends Command
+    final case class Cd(dir: Path) extends Command
+    final case class Select(name: Option[String], query: String) extends Command
+    final case class Ls(dir: Option[Path]) extends Command
+    final case class Save(path: Path, value: String) extends Command
+    final case class Append(path: Path, value: String) extends Command
+    final case class Delete(path: Path) extends Command
+    final case class Debug(level: DebugLevel) extends Command
+    final case class SummaryCount(rows: Int) extends Command
+    final case class SetVar(name: String, value: String) extends Command
+    final case class UnsetVar(name: String) extends Command
   }
 
   private type Printer = String => Task[Unit]
 
   sealed trait DebugLevel
   object DebugLevel {
-    case object Silent extends DebugLevel
-    case object Normal extends DebugLevel
-    case object Verbose extends DebugLevel
+    final case object Silent extends DebugLevel
+    final case object Normal extends DebugLevel
+    final case object Verbose extends DebugLevel
 
     def fromInt(code: Int): Option[DebugLevel] = code match {
       case 0 => Some(Silent)
@@ -77,7 +77,7 @@ object Repl {
     }
   }
 
-  case class RunState(
+  final case class RunState(
     printer:      Printer,
     mounted:      FSTable[Backend],
     path:         Path = Path.Root,
@@ -91,6 +91,7 @@ object Repl {
   def targetPath(s: RunState, path: Option[Path]): Path =
     path.flatMap(_.from(s.path).toOption).getOrElse(s.path)
 
+  @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Null"))
   private def parseCommand(input: String): Command = {
     import Command._
 

--- a/core/src/main/scala/slamdata/engine/repl/repl.scala
+++ b/core/src/main/scala/slamdata/engine/repl/repl.scala
@@ -80,11 +80,11 @@ object Repl {
   final case class RunState(
     printer:      Printer,
     mounted:      FSTable[Backend],
-    path:         Path = Path.Root,
-    unhandled:    Option[Command] = None,
-    debugLevel:   DebugLevel = DebugLevel.Normal,
-    summaryCount: Int = 10,
-    variables:    Map[String, String] = Map())
+    path:         Path,
+    unhandled:    Option[Command],
+    debugLevel:   DebugLevel,
+    summaryCount: Int,
+    variables:    Map[String, String])
 
   val codec = DataCodec.Readable  // TODO: make this settable (see #592)
 
@@ -265,7 +265,7 @@ object Repl {
       (printer, commands) = tuple
       mounted <- Config.load(args.headOption).flatMap(Mounter.mount(_))
     } yield
-      commands.scan(RunState(printer, mounted)) { (state, input) =>
+      commands.scan(RunState(printer, mounted, Path.Root, None, DebugLevel.Normal, 10, Map())) { (state, input) =>
         input match {
           case Cd(path)     =>
             state.copy(

--- a/core/src/main/scala/slamdata/engine/semantics.scala
+++ b/core/src/main/scala/slamdata/engine/semantics.scala
@@ -46,7 +46,7 @@ trait SemanticAnalysis {
 
   sealed trait Synthetic
   object Synthetic {
-    case object SortKey extends Synthetic
+    final case object SortKey extends Synthetic
   }
 
   implicit val SyntheticRenderTree = new RenderTree[Synthetic] {
@@ -104,7 +104,6 @@ trait SemanticAnalysis {
 
     tree1 => ann(tree(transform(tree1.root)))
   }
-
 
   case class TableScope(scope: Map[String, SqlRelation])
 

--- a/core/src/main/scala/slamdata/engine/sql/ast.scala
+++ b/core/src/main/scala/slamdata/engine/sql/ast.scala
@@ -224,10 +224,10 @@ trait NodeInstances {
 object Node extends NodeInstances
 
 trait IsDistinct
-case object SelectDistinct extends IsDistinct
-case object SelectAll extends IsDistinct
+final case object SelectDistinct extends IsDistinct
+final case object SelectAll extends IsDistinct
 
-case class Proj(expr: Expr, alias: Option[String]) extends Node {
+final case class Proj(expr: Expr, alias: Option[String]) extends Node {
   def children = expr :: Nil
   def sql = alias.foldLeft(expr.sql)(_ + " as " + _qq(_))
 }
@@ -291,7 +291,7 @@ final case class ArrayLiteral(exprs: List[Expr]) extends Expr {
   def children = exprs.toList
 }
 
-case class Splice(expr: Option[Expr]) extends Expr {
+final case class Splice(expr: Option[Expr]) extends Expr {
   def sql = expr.fold("*")(x => "(" + x.sql + ").*")
 
   def children = expr.toList
@@ -327,23 +327,23 @@ sealed abstract class BinaryOperator(val sql: String) extends Node with ((Expr, 
   override def toString = sql
 }
 
-case object Or      extends BinaryOperator("or")
-case object And     extends BinaryOperator("and")
-case object Eq      extends BinaryOperator("=")
-case object Neq     extends BinaryOperator("<>")
-case object Ge      extends BinaryOperator(">=")
-case object Gt      extends BinaryOperator(">")
-case object Le      extends BinaryOperator("<=")
-case object Lt      extends BinaryOperator("<")
-case object Concat  extends BinaryOperator("||")
-case object Plus    extends BinaryOperator("+")
-case object Minus   extends BinaryOperator("-")
-case object Mult    extends BinaryOperator("*")
-case object Div     extends BinaryOperator("/")
-case object Mod     extends BinaryOperator("%")
-case object In      extends BinaryOperator("in")
-case object FieldDeref extends BinaryOperator("{}")
-case object IndexDeref extends BinaryOperator("[]")
+final case object Or      extends BinaryOperator("or")
+final case object And     extends BinaryOperator("and")
+final case object Eq      extends BinaryOperator("=")
+final case object Neq     extends BinaryOperator("<>")
+final case object Ge      extends BinaryOperator(">=")
+final case object Gt      extends BinaryOperator(">")
+final case object Le      extends BinaryOperator("<=")
+final case object Lt      extends BinaryOperator("<")
+final case object Concat  extends BinaryOperator("||")
+final case object Plus    extends BinaryOperator("+")
+final case object Minus   extends BinaryOperator("-")
+final case object Mult    extends BinaryOperator("*")
+final case object Div     extends BinaryOperator("/")
+final case object Mod     extends BinaryOperator("%")
+final case object In      extends BinaryOperator("in")
+final case object FieldDeref extends BinaryOperator("{}")
+final case object IndexDeref extends BinaryOperator("[]")
 
 final case class Unop(expr: Expr, op: UnaryOperator) extends Expr {
   def sql = op match {
@@ -366,19 +366,19 @@ sealed abstract class UnaryOperator(val sql: String) extends Node with (Expr => 
   def children = Nil
 }
 
-case object Not           extends UnaryOperator("not")
-case object IsNull        extends UnaryOperator("is_null")
-case object Exists        extends UnaryOperator("exists")
-case object Positive      extends UnaryOperator("+")
-case object Negative      extends UnaryOperator("-")
-case object Distinct      extends UnaryOperator("distinct")
-case object ToDate        extends UnaryOperator("date")
-case object ToTime        extends UnaryOperator("time")
-case object ToTimestamp   extends UnaryOperator("timestamp")
-case object ToInterval    extends UnaryOperator("interval")
-case object ToId          extends UnaryOperator("oid")
-case object ObjectFlatten extends UnaryOperator("flatten_object")
-case object ArrayFlatten  extends UnaryOperator("flatten_array")
+final case object Not           extends UnaryOperator("not")
+final case object IsNull        extends UnaryOperator("is_null")
+final case object Exists        extends UnaryOperator("exists")
+final case object Positive      extends UnaryOperator("+")
+final case object Negative      extends UnaryOperator("-")
+final case object Distinct      extends UnaryOperator("distinct")
+final case object ToDate        extends UnaryOperator("date")
+final case object ToTime        extends UnaryOperator("time")
+final case object ToTimestamp   extends UnaryOperator("timestamp")
+final case object ToInterval    extends UnaryOperator("interval")
+final case object ToId          extends UnaryOperator("oid")
+final case object ObjectFlatten extends UnaryOperator("flatten_object")
+final case object ArrayFlatten  extends UnaryOperator("flatten_array")
 
 final case class Ident(name: String) extends Expr {
   def sql = _qq(name)
@@ -483,14 +483,14 @@ final case class JoinRelation(left: SqlRelation, right: SqlRelation, tpe: JoinTy
 }
 
 sealed abstract class JoinType(val sql: String)
-case object LeftJoin extends JoinType("left join")
-case object RightJoin extends JoinType("right join")
-case object InnerJoin extends JoinType("inner join")
-case object FullJoin extends JoinType("full join")
+final case object LeftJoin extends JoinType("left join")
+final case object RightJoin extends JoinType("right join")
+final case object InnerJoin extends JoinType("inner join")
+final case object FullJoin extends JoinType("full join")
 
 sealed trait OrderType
-case object ASC extends OrderType
-case object DESC extends OrderType
+final case object ASC extends OrderType
+final case object DESC extends OrderType
 
 final case class GroupBy(keys: List[Expr], having: Option[Expr]) extends Node {
   def sql = List(Some("group by"), Some(keys.map(_.sql).mkString(", ")), having.map(e => "having " + e.sql)).flatten.mkString(" ")

--- a/core/src/main/scala/slamdata/engine/sql/parser.scala
+++ b/core/src/main/scala/slamdata/engine/sql/parser.scala
@@ -16,7 +16,7 @@ import scala.util.parsing.input.CharArrayReader.EofCh
 import scalaz._
 import Scalaz._
 
-case class Query(value: String)
+final case class Query(value: String)
 
 class SQLParser extends StandardTokenParsers {
   class SqlLexical extends StdLexical {

--- a/core/src/main/scala/slamdata/engine/types.scala
+++ b/core/src/main/scala/slamdata/engine/types.scala
@@ -209,7 +209,7 @@ trait TypeInstances {
   }
 }
 
-case object Type extends TypeInstances {
+final case object Type extends TypeInstances {
   private def fail[A](expected: Type, actual: Type, message: Option[String]): ValidationNel[TypeError, A] =
     Validation.failure(NonEmptyList(TypeError(expected, actual, message)))
 
@@ -385,36 +385,36 @@ case object Type extends TypeInstances {
     loop(v)
   }
 
-  case object Top extends Type
-  case object Bottom extends Type
+  final case object Top extends Type
+  final case object Bottom extends Type
 
-  case class Const(value: Data) extends Type
+  final case class Const(value: Data) extends Type
 
   sealed trait PrimitiveType extends Type
-  case object Null extends PrimitiveType
-  case object Str extends PrimitiveType
-  case object Int extends PrimitiveType
-  case object Dec extends PrimitiveType
-  case object Bool extends PrimitiveType
-  case object Binary extends PrimitiveType
-  case object Timestamp extends PrimitiveType
-  case object Date extends PrimitiveType
-  case object Time extends PrimitiveType
-  case object Interval extends PrimitiveType
-  case object Id extends PrimitiveType
+  final case object Null extends PrimitiveType
+  final case object Str extends PrimitiveType
+  final case object Int extends PrimitiveType
+  final case object Dec extends PrimitiveType
+  final case object Bool extends PrimitiveType
+  final case object Binary extends PrimitiveType
+  final case object Timestamp extends PrimitiveType
+  final case object Date extends PrimitiveType
+  final case object Time extends PrimitiveType
+  final case object Interval extends PrimitiveType
+  final case object Id extends PrimitiveType
 
-  case class Set(value: Type) extends Type
+  final case class Set(value: Type) extends Type
 
-  case class Arr(value: List[Type]) extends Type
-  case class FlexArr(minSize: Int, maxSize: Option[Int], value: Type)
+  final case class Arr(value: List[Type]) extends Type
+  final case class FlexArr(minSize: Int, maxSize: Option[Int], value: Type)
       extends Type
 
   // NB: `unknowns` represents the type of any values where we don’t know the
   //      keys. None means the Obj is fully known.
-  case class Obj(value: Map[String, Type], unknowns: Option[Type])
+  final case class Obj(value: Map[String, Type], unknowns: Option[Type])
       extends Type
 
-  case class Product(left: Type, right: Type) extends Type {
+  final case class Product(left: Type, right: Type) extends Type {
     def flatten: Vector[Type] = {
       def flatten0(v: Type): Vector[Type] = v match {
         case Product(left, right) => flatten0(left) ++ flatten0(right)
@@ -440,7 +440,7 @@ case object Type extends TypeInstances {
     }
   }
 
-  case class Coproduct(left: Type, right: Type) extends Type {
+  final case class Coproduct(left: Type, right: Type) extends Type {
     def flatten: Vector[Type] = {
       def flatten0(v: Type): Vector[Type] = v match {
         case Coproduct(left, right) => flatten0(left) ++ flatten0(right)

--- a/core/src/main/scala/slamdata/engine/variables.scala
+++ b/core/src/main/scala/slamdata/engine/variables.scala
@@ -9,11 +9,11 @@ import argonaut._, Argonaut._
 import scalaz.{Node => _, Tree => _, _}
 import Scalaz._
 
-case class Variables(value: Map[VarName, VarValue])
-case class VarName(value: String) {
+final case class Variables(value: Map[VarName, VarValue])
+final case class VarName(value: String) {
   override def toString = ":" + value
 }
-case class VarValue(value: String)
+final case class VarValue(value: String)
 
 object Variables {
   def fromMap(value: Map[String, String]): Variables = Variables(value.map(t => VarName(t._1) -> VarValue(t._2)))

--- a/core/src/main/scala/slamdata/java/util.scala
+++ b/core/src/main/scala/slamdata/java/util.scala
@@ -9,10 +9,10 @@ object JavaUtil {
   }
 
   sealed trait TraceSegment
-  case class SavedFrame(elem: StackTraceElement) extends TraceSegment {
+  final case class SavedFrame(elem: StackTraceElement) extends TraceSegment {
     override def toString = elem.toString
   }
-  case class DroppedSegment(first: StackTraceElement, count: Int, last: StackTraceElement) extends TraceSegment {
+  final case class DroppedSegment(first: StackTraceElement, count: Int, last: StackTraceElement) extends TraceSegment {
     override def toString = s"  ... ($count)"
   }
   object TraceSegment {

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -53,7 +53,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
   val queryPlanner = MongoDbPlanner.queryPlanner(κ("Mongo" -> Cord.empty))
 
   def plan(query: String): Either[Error, Workflow] =
-    queryPlanner(QueryRequest(Query(query), None, basePath=Path("/db/")))._2.map(Workflow.finish).toEither
+    queryPlanner(QueryRequest(Query(query), None, Path.Root, Path("/db/"), Variables(Map())))._2.map(Workflow.finish).toEither
 
   def plan(logical: Term[LogicalPlan]): Either[Error, Workflow] =
     (for {

--- a/it/src/test/scala/slamdata/engine/regression.scala
+++ b/it/src/test/scala/slamdata/engine/regression.scala
@@ -183,9 +183,9 @@ object RegressionTest {
 
 sealed trait Disposition
 object Disposition {
-  case object Skip    extends Disposition
-  case object Pending extends Disposition
-  case object Verify  extends Disposition
+  final case object Skip    extends Disposition
+  final case object Pending extends Disposition
+  final case object Verify  extends Disposition
 
   import DecodeResult.{ok, fail}
 
@@ -231,7 +231,7 @@ object Predicate extends Specification {
   }
 
   // Must contain ALL the elements in some order.
-  case object ContainsAtLeast extends Predicate {
+  final case object ContainsAtLeast extends Predicate {
     def apply(expected: Vector[Json], actual: Process[Task, Json]): Task[Result] = {
       (for {
         expected <- actual.pipe(scan(expected.toSet) {
@@ -241,7 +241,7 @@ object Predicate extends Specification {
     }
   }
   // Must contain ALL and ONLY the elements in some order.
-  case object ContainsExactly extends Predicate {
+  final case object ContainsExactly extends Predicate {
     def apply(expected: Vector[Json], actual: Process[Task, Json]): Task[Result] = {
       (for {
         t <-  actual.pipe(scan((expected.toSet, Set.empty[Json])) {
@@ -255,7 +255,7 @@ object Predicate extends Specification {
     }
   }
   // Must EXACTLY match the elements, in order.
-  case object EqualsExactly extends Predicate {
+  final case object EqualsExactly extends Predicate {
     def apply(expected0: Vector[Json], actual0: Process[Task, Json]): Task[Result] = {
       val actual   = actual0.map(Some(_))
       val expected = Process.emitAll(expected0).map(Some(_))
@@ -268,7 +268,7 @@ object Predicate extends Specification {
     }
   }
   // Must START WITH the elements, in order.
-  case object EqualsInitial extends Predicate {
+  final case object EqualsInitial extends Predicate {
     def apply(expected0: Vector[Json], actual0: Process[Task, Json]): Task[Result] = {
       val actual   = actual0.map(Some(_))
       val expected = Process.emitAll(expected0).map(Some(_))
@@ -282,7 +282,7 @@ object Predicate extends Specification {
     }
   }
   // Must NOT contain ANY of the elements.
-  case object DoesNotContain extends Predicate {
+  final case object DoesNotContain extends Predicate {
     def apply(expected0: Vector[Json], actual: Process[Task, Json]): Task[Result] = {
       val expected = expected0.toSet
       (for {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,4 +25,4 @@ addSbtPlugin("org.scala-sbt.plugins" % "sbt-onejar" % "0.8")
 // sbt-release
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
 
-addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.12")
+addSbtPlugin("org.brianmckenna" % "sbt-wartremover" % "0.13")

--- a/web/src/main/scala/slamdata/engine/api/fs.scala
+++ b/web/src/main/scala/slamdata/engine/api/fs.scala
@@ -126,7 +126,7 @@ class FileSystemApi(fs: FSTable[Backend]) {
           b     <- backendFor(path)
           (backend, mountPath) = b
 
-          (phases, resultT) = backend.eval(QueryRequest(query, None, mountPath, path))
+          (phases, resultT) = backend.eval(QueryRequest(query, None, mountPath, path, Variables(Map())))
           result <- resultT.attemptRun.leftMap(e =>  errorResponse(BadRequest, e))
         } yield jsonStream(result)).fold(identity, identity)
 
@@ -162,7 +162,7 @@ class FileSystemApi(fs: FSTable[Backend]) {
         b     <- backendFor(path)
         (backend, mountPath) = b
 
-        (phases, resultT) = backend.eval(QueryRequest(query, None, mountPath, path))
+        (phases, resultT) = backend.eval(QueryRequest(query, None, mountPath, path, Variables(Map())))
 
         plan  <- phases.lastOption \/> InternalServerError("no plan")
       } yield plan match {


### PR DESCRIPTION
The two major changes here are:

1. case classes must be final (I made case objects final, too) and
2. we can use `@SuppressWarnings` to silence the one place we use `null`
   and turn the `Null` wart back on.

Re `final case object`, I partially did it just for consistency, but
apparently there are actually ways to override objects in a subclass, so
I guess it’s useful, too.