### PR TITLE
Fix some `fs.move` cases.

### DIFF
--- a/core/src/main/scala/slamdata/engine/physical/mongodb/filesystem.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/filesystem.scala
@@ -142,12 +142,13 @@ sealed trait MongoWrapper {
   def get(col: Collection): Task[MongoCollection[Document]] =
     Task.delay(db(col.databaseName).getCollection(col.collectionName))
 
-  def rename(src: Collection, dst: Collection): Task[Unit] = for {
-    s <- get(src)
-    _ = s.renameCollection(
-      new MongoNamespace(dst.databaseName, dst.collectionName),
-      new RenameCollectionOptions().dropTarget(true))
-  } yield ()
+  def rename(src: Collection, dst: Collection): Task[Unit] =
+    if (src.equals(dst)) Task.now(())
+    else
+      for {
+        s <- get(src)
+        _ <- Task.delay(s.renameCollection(new MongoNamespace(dst.databaseName, dst.collectionName)))
+      } yield ()
 
   def drop(col: Collection): Task[Unit] = for {
     c <- get(col)

--- a/it/src/test/scala/slamdata/engine/fs/filesystem.scala
+++ b/it/src/test/scala/slamdata/engine/fs/filesystem.scala
@@ -145,6 +145,27 @@ class FileSystemSpecs extends BackendTest with slamdata.engine.DisjunctionMatche
           }).run
         }
 
+        "move file to itself (NOP)" in {
+          (for {
+            tmp1  <- genTempFile(fs)
+            _     <- fs.save(TestDir ++ tmp1, oneDoc)
+            _     <- fs.move(TestDir ++ tmp1, TestDir ++ tmp1)
+            after <- fs.ls(TestDir)
+          } yield {
+            after must contain(tmp1)
+          }).run
+        }
+
+        "fail to move file over existing" in {
+          (for {
+            tmp1  <- genTempFile(fs)
+            tmp2  <- genTempFile(fs)
+            _     <- fs.save(TestDir ++ tmp1, oneDoc)
+            _     <- fs.save(TestDir ++ tmp2, oneDoc)
+            _     <- fs.move(TestDir ++ tmp1, TestDir ++ tmp2)
+          } yield ()).attemptRun must beAnyLeftDisj
+        }
+
         "move dir" in {
           (for {
             tmpDir1  <- genTempDir(fs)

--- a/it/src/test/scala/slamdata/engine/regression.scala
+++ b/it/src/test/scala/slamdata/engine/regression.scala
@@ -60,7 +60,7 @@ class RegressionSpec extends BackendTest {
           t    <- backend.run {
                     QueryRequest(
                       query     = Query(query),
-                      out       = Some(tmpDir ++ Path("out")),
+                      out       = Some(tmpDir ++ Path("out") ++ genTempDir(fs).run),
                       basePath  = Path("/") ++ tmpDir,
                       mountPath = Path("/"),
                       variables = Variables.fromMap(vars))


### PR DESCRIPTION
Fixes #693.

* If src and dst are the same, it’s a NOP;
* if dst exists (and isn’t the same as src), fail; and
* modify regression tests so they don’t all try to write to the same
  output collection (since it would now require adding a deletion step).