### PR TITLE
Enable warnings for non-Unit-returning statements

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -18,16 +18,17 @@ ScoverageKeys.coverageFailOnMinimum := true
 
 ScoverageKeys.coverageHighlighting := true
 
-wartremoverErrors ++= Warts.allBut(
+wartremoverErrors in (Compile, compile) ++= Warts.allBut(
   // NB: violation counts are from running `compile`
   Wart.Any,               // 113
   Wart.AsInstanceOf,      //  75
   Wart.DefaultArguments,  //   6
   Wart.IsInstanceOf,      //  79
   Wart.NoNeedForMonad,    //  62
-  Wart.NonUnitStatements, //  24
   Wart.Nothing,           // 366
   Wart.Null,              //   1
   Wart.Product,           // 180  _ these two are highly correlated
   Wart.Serializable,      // 182  /
   Wart.Throw)             // 412
+
+scalacOptions += "-Ywarn-value-discard"

--- a/core/src/main/scala/slamdata/engine/analysis/Analysis.scala
+++ b/core/src/main/scala/slamdata/engine/analysis/Analysis.scala
@@ -12,6 +12,8 @@ import scalaz.std.iterable._
 
 import scala.collection.JavaConverters._
 
+import slamdata.engine.fp._
+
 object Analysis {
   def readTree[N, A, B, E](f: AnnotatedTree[N, A] => Analysis[N, A, B, E]): Analysis[N, A, B, E] = tree => {
     f(tree)(tree)
@@ -28,7 +30,7 @@ object Analysis {
     implicit val sg = Semigroup.firstSemigroup[B]
 
     tree.fork(new java.util.IdentityHashMap[N, B])({ (acc, node) =>
-      analyzer((k: N) => acc.get(k), node).map(b => { acc.put(node, b); acc })
+      analyzer((k: N) => acc.get(k), node).map(b => { ignore(acc.put(node, b)); acc })
     }).map { vector =>
       val collapsed = vector.foldLeft(new java.util.IdentityHashMap[N, B]) { (acc, map) => acc.putAll(map); acc }
       tree.annotate(n => collapsed.get(n))

--- a/core/src/main/scala/slamdata/engine/analysis/AnnotatedTree.scala
+++ b/core/src/main/scala/slamdata/engine/analysis/AnnotatedTree.scala
@@ -33,7 +33,7 @@ trait AnnotatedTreeInstances {
 }
 
 object AnnotatedTree extends AnnotatedTreeInstances {
-  def unit[N](root0: N, children0: N => List[N]): AnnotatedTree[N, Unit] = const(root0, children0, Unit)
+  def unit[N](root0: N, children0: N => List[N]): AnnotatedTree[N, Unit] = const(root0, children0, ())
 
   def const[N, A](root0: N, children0: N => List[N], const: A): AnnotatedTree[N, A] = new AnnotatedTree[N, A] {
     def root: N = root0

--- a/core/src/main/scala/slamdata/engine/analysis/Tree.scala
+++ b/core/src/main/scala/slamdata/engine/analysis/Tree.scala
@@ -12,6 +12,8 @@ import scalaz.syntax.foldable1._
 
 import scala.collection.JavaConverters._
 
+import slamdata.engine.fp._
+
 trait Tree[N] { self =>
   def root: N
 
@@ -90,7 +92,7 @@ trait Tree[N] { self =>
     case (parentMap, parentNode) =>
       self.children(parentNode).foldLeft(parentMap) {
         case (parentMap, childNode) =>
-          parentMap.put(childNode, parentNode)
+          ignore(parentMap.put(childNode, parentNode))
           parentMap
       }
   })
@@ -102,7 +104,7 @@ trait Tree[N] { self =>
 
       children.foldLeft(siblingMap) {
         case (siblingMap, childNode) =>
-          siblingMap.put(childNode, children.filter(_ != childNode))
+          ignore(siblingMap.put(childNode, children.filter(_ != childNode)))
           siblingMap
       }
   }

--- a/core/src/main/scala/slamdata/engine/compiler.scala
+++ b/core/src/main/scala/slamdata/engine/compiler.scala
@@ -160,7 +160,7 @@ trait Compiler[F[_]] {
 
   private def mod(f: CompilerState => CompilerState)(implicit m: Monad[F]):
       CompilerM[Unit] =
-    StateT[M, CompilerState, Unit](s => Applicative[M].point(f(s) -> Unit))
+    StateT[M, CompilerState, Unit](s => Applicative[M].point((f(s), ())))
 
   private def invoke(func: Func, args: List[Node])(implicit m: Monad[F]): StateT[M, CompilerState, Term[LogicalPlan]] =
     for {

--- a/core/src/main/scala/slamdata/engine/config/config.scala
+++ b/core/src/main/scala/slamdata/engine/config/config.scala
@@ -3,7 +3,9 @@ package slamdata.engine.config
 import argonaut._, Argonaut._
 
 import scalaz.concurrent.Task
+
 import slamdata.engine.Backend
+import slamdata.engine.fp._
 import slamdata.engine.fs.Path
 
 import scalaz._
@@ -125,8 +127,9 @@ object Config {
     val text = toString(config)
 
     val p = Paths.get(path)
-    Option(p.getParent).map(Files.createDirectories(_))
-    Files.write(p, text.getBytes(StandardCharsets.UTF_8))
+    ignore(Option(p.getParent).map(Files.createDirectories(_)))
+    ignore(Files.write(p, text.getBytes(StandardCharsets.UTF_8)))
+    ()
   }
 
   def write(config: Config, path: Option[String]): Task[Unit] =

--- a/core/src/main/scala/slamdata/engine/debug.scala
+++ b/core/src/main/scala/slamdata/engine/debug.scala
@@ -6,6 +6,8 @@ import Scalaz._
 import argonaut._
 import Argonaut._
 
+import slamdata.engine.fp._
+
 case class RenderedTree(label: String, children: List[RenderedTree], nodeType: List[String]) {
   def relabel(label: String): RenderedTree = relabel(_ => label)
 
@@ -299,8 +301,8 @@ object RenderTree {
 
     val sl = new JLabel("Search:")
     val sp = new JPanel()
-    sp.add(sl)
-    sp.add(s)
+    ignore(sp.add(sl))
+    ignore(sp.add(s))
 
     val f = new JFrame("RenderedTree - " + new java.text.SimpleDateFormat("HH:mm:ss.SSS").format(new java.util.Date()))
     f.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE)
@@ -309,7 +311,7 @@ object RenderTree {
     f.setLocation(count*20, count*20)
 
     f.getContentPane().add(sp, "North")
-    f.getContentPane().add(sc)
+    f.getContentPane().add(sc, "Center")
 
     java.awt.EventQueue.invokeLater(new Runnable { def run = {
       f.setVisible(true)

--- a/core/src/main/scala/slamdata/engine/fp/package.scala
+++ b/core/src/main/scala/slamdata/engine/fp/package.scala
@@ -290,4 +290,11 @@ package object fp extends TreeInstances with ListMapInstances with ToTaskOps wit
       case ((as, bs), -\/ (a)) => (a :: as, bs)
       case ((as, bs),  \/-(b)) => (as, b :: bs)
     }
+
+  /**
+   Accept a value (forcing the argument expression to be evaluated for its effects),
+   and then discard it, returning Unit. Makes it explicit that you're discarding the
+   result, and effectively suppresses the "NonUnitStatement" warning from wartremover.
+   */
+  def ignore[A](a: A): Unit = ()
 }

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/evaluator.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/evaluator.scala
@@ -262,7 +262,10 @@ class MongoDbExecutor[S](client: MongoClient, nameGen: NameGenerator[({type Î»[Î
       x => Task.now((s, x)))))
 
   private def runMongoCommand(db: String, cmd: Bson.Doc): M[Unit] =
-    liftMongo(client.getDatabase(db).runCommand(cmd.repr))
+    liftMongo {
+      ignore(client.getDatabase(db).runCommand(cmd.repr))
+      ()
+    }
 }
 
 // Convenient partially-applied type: LoggerT[X]#Rec

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/filesystem.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/filesystem.scala
@@ -31,7 +31,7 @@ sealed trait MongoDbFileSystem extends FileSystem {
           cursor => Task.delay {
             if (cursor.hasNext) {
               val obj = cursor.next
-              obj.remove("_id")
+              ignore(obj.remove("_id"))
               BsonCodec.toData(Bson.fromRepr(obj))
             }
             else throw Cause.End.asThrowable

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowop.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowop.scala
@@ -397,7 +397,7 @@ object Workflow {
   final def refs[A <: WorkflowF[_]](op: A): List[DocVar] = {
     // FIXME: Sorry world
     val vf = new scala.collection.mutable.ListBuffer[DocVar]
-    rewriteRefs(op, { case v => vf += v; v })
+    ignore(rewriteRefs(op, { case v => ignore(vf += v); v }))
     vf.toList
   }
 

--- a/core/src/main/scala/slamdata/engine/semantics.scala
+++ b/core/src/main/scala/slamdata/engine/semantics.scala
@@ -493,7 +493,7 @@ trait SemanticAnalysis {
           } else {
             (expected.zip(actual).map {
               case (expected, actual) => Type.typecheck(expected, actual)
-            }).sequenceU.map(κ(Unit))
+            }).sequenceU.map(κ(()))
           }
         }
 

--- a/core/src/main/scala/slamdata/engine/sql/parser.scala
+++ b/core/src/main/scala/slamdata/engine/sql/parser.scala
@@ -68,17 +68,17 @@ class SQLParser extends StandardTokenParsers {
 
   def floatLit: Parser[String] = elem("decimal", _.isInstanceOf[lexical.FloatLit]) ^^ (_.chars)
 
-  lexical.reserved += (
+  ignore(lexical.reserved += (
     "and", "as", "asc", "between", "by", "case", "cross", "date", "desc", "distinct",
     "else", "end", "escape", "exists", "false", "for", "from", "full", "group", "having", "in",
     "inner", "interval", "is", "join", "left", "like", "limit", "not", "null",
     "offset", "oid", "on", "or", "order", "outer", "right", "select", "then", "time",
     "timestamp", "true", "when", "where"
-  )
+  ))
 
-  lexical.delimiters += (
+  ignore(lexical.delimiters += (
     "*", "+", "-", "%", "~", "||", "<", "=", "<>", "!=", "<=", ">=", ">", "/", "(", ")", ",", ".", ";", "[", "]", "{", "}"
-  )
+  ))
 
   override def keyword(name: String): Parser[String] =
     if (lexical.reserved.contains(name))

--- a/core/src/main/scala/slamdata/engine/types.scala
+++ b/core/src/main/scala/slamdata/engine/types.scala
@@ -253,10 +253,10 @@ case object Type extends TypeInstances {
   def typecheck(superType: Type, subType: Type):
       ValidationNel[TypeError, Unit] =
     (superType, subType) match {
-      case (superType, subType) if (superType == subType) => succeed(Unit)
+      case (superType, subType) if (superType == subType) => succeed(())
 
-      case (Top, _)    => succeed(Unit)
-      case (_, Bottom) => succeed(Unit)
+      case (Top, _)    => succeed(())
+      case (_, Bottom) => succeed(())
 
       case (superType, Const(subType)) => typecheck(superType, subType.dataType)
 
@@ -292,7 +292,7 @@ case object Type extends TypeInstances {
         } +++
           supUk.fold(
             subUk.fold[ValidationNel[TypeError, Unit]](
-              if ((subMap -- supMap.keySet).isEmpty) succeed(Unit) else fail(superType, subType))(
+              if ((subMap -- supMap.keySet).isEmpty) succeed(()) else fail(superType, subType))(
               κ(fail(superType, subType))))(
             p => subUk.fold[ValidationNel[TypeError, Unit]](
               // if (subMap -- supMap.keySet) is empty, fail(superType, subType)
@@ -473,7 +473,7 @@ case object Type extends TypeInstances {
   private def forall(expected: Type, actuals: Seq[Type]): ValidationNel[TypeError, Unit] = {
     actuals.headOption match {
       case Some(head) => typecheck(expected, head) +++ forall(expected, actuals.tail)
-      case None => Validation.success(Top)
+      case None => Validation.success(())
     }
   }
 
@@ -487,7 +487,7 @@ case object Type extends TypeInstances {
 
   private def typecheck(combine: (ValidationNel[TypeError, Unit], ValidationNel[TypeError, Unit]) => ValidationNel[TypeError, Unit],
                         check: (Type, Seq[Type]) => ValidationNel[TypeError, Unit]) = (expecteds: Seq[Type], actuals: Seq[Type]) => {
-    expecteds.foldLeft[ValidationNel[TypeError, Unit]](Validation.success(Unit)) {
+    expecteds.foldLeft[ValidationNel[TypeError, Unit]](Validation.success(())) {
       case (acc, expected) => {
         combine(acc, check(expected, actuals))
       }

--- a/core/src/main/scala/slamdata/engine/variables.scala
+++ b/core/src/main/scala/slamdata/engine/variables.scala
@@ -1,6 +1,7 @@
 package slamdata.engine
 
 import slamdata.engine.analysis._
+import slamdata.engine.fp._
 import slamdata.engine.sql._
 import slamdata.engine.SemanticError._
 
@@ -75,7 +76,7 @@ object Variables {
     ).run(Nil).run.run.map {
       case (tuples, root) =>
         val map1 = tuples.foldLeft(new java.util.IdentityHashMap[Node, A]) { // TODO: Use ordinary map when AnnotatedTree has been off'd
-          case (map, (k, v)) => map.put(k, v); map
+          case (map, (k, v)) => ignore(map.put(k, v)); map
         }
 
         Tree[Node](root, _.children).annotate(map1.get(_))

--- a/it/src/test/scala/slamdata/engine/backendtest.scala
+++ b/it/src/test/scala/slamdata/engine/backendtest.scala
@@ -62,7 +62,7 @@ trait BackendTest extends Specification {
       (backends.map {
         case (name, backend) => Task.delay(f(name, backend))
       }).sequenceU
-    }).run
+    }).map(_ => ()).run
   }
 
   def deleteTempFiles(fs: FileSystem, dir: Path) = {

--- a/it/src/test/scala/slamdata/engine/fs/filesystem.scala
+++ b/it/src/test/scala/slamdata/engine/fs/filesystem.scala
@@ -214,7 +214,7 @@ class FileSystemSpecs extends BackendTest with slamdata.engine.DisjunctionMatche
       }
     }
 
-    step {
+    val cleanup = step {
       deleteTempFiles(fs, TestDir)
     }
   }

--- a/it/src/test/scala/slamdata/engine/regression.scala
+++ b/it/src/test/scala/slamdata/engine/regression.scala
@@ -109,7 +109,7 @@ class RegressionSpec extends BackendTest {
       ()
     }
 
-    step {
+    val cleanup = step {
       deleteTempFiles(fs, tmpDir)
     }
   }


### PR DESCRIPTION
Enable wartremover's check for non-Unit-returning expressions used in statement position. Add a function `ignore` to make the discarding of values explicit when we need to do it.

Also enabled scalac's warning for discarded values, which catches where you produce any value at all but `Unit` is expected, so scalac says, "great", and just tosses the value.

Both of those only in the `core` project, and wartremover only in `compile` (not `test`), because specs2.mutable and swing both break these rules by their nature.