### PR TITLE
clean up the RenderedTree type

### DIFF
--- a/core/src/main/scala/slamdata/engine/analysis/AnnotatedTree.scala
+++ b/core/src/main/scala/slamdata/engine/analysis/AnnotatedTree.scala
@@ -21,10 +21,9 @@ trait AnnotatedTreeInstances {
     override def render(t: AnnotatedTree[N, A]) = {
       def renderNode(n: N): RenderedTree = {
         val r = RN.render(n)
-        NonTerminal(r.label,
-          RA.render(t.attr(n)).copy(label="", nodeType=List("Annotation")) ::
-            t.children(n).map(renderNode(_)),
-          r.nodeType)
+        NonTerminal(r.nodeType, r.label,
+          RA.render(t.attr(n)).copy(nodeType=List("Annotation"), label=None) ::
+            t.children(n).map(renderNode(_)))
       }
 
       renderNode(t.root)

--- a/core/src/main/scala/slamdata/engine/analysis/fixplate.scala
+++ b/core/src/main/scala/slamdata/engine/analysis/fixplate.scala
@@ -180,7 +180,7 @@ sealed trait term {
     implicit def TermRenderTree[F[_]](implicit F: Foldable[F], RF: RenderTree[F[_]]) = new RenderTree[Term[F]] {
       override def render(v: Term[F]) = {
         val t = RF.render(v.unFix)
-        NonTerminal(t.label, v.children.map(render(_)), t.nodeType)
+        NonTerminal(t.nodeType, t.label, v.children.map(render(_)))
       }
     }
 
@@ -376,10 +376,9 @@ sealed trait attr extends term with holes {
     override def render(attr: Cofree[F, A]) = {
       val term = RF.render(attr.tail)
       val ann = RA.render(attr.head)
-      NonTerminal(term.label,
-        (if (ann.children.isEmpty) NonTerminal("", ann :: Nil, List("Annotation")) else ann.copy(label="", nodeType=List("Annotation"))) ::
-          children(attr).map(render(_)),
-        term.nodeType)
+      NonTerminal(term.nodeType, term.label,
+        (if (ann.children.isEmpty) NonTerminal(List("Annotation"), None, ann :: Nil) else ann.copy(label=None, nodeType=List("Annotation"))) ::
+          children(attr).map(render(_)))
     }
   }
 

--- a/core/src/main/scala/slamdata/engine/debug.scala
+++ b/core/src/main/scala/slamdata/engine/debug.scala
@@ -8,7 +8,7 @@ import Argonaut._
 
 import slamdata.engine.fp._
 
-case class RenderedTree(nodeType: List[String], label: Option[String], children: List[RenderedTree]) {
+final case class RenderedTree(nodeType: List[String], label: Option[String], children: List[RenderedTree]) {
   def simpleType: Option[String] = nodeType.headOption
 
   /**

--- a/core/src/main/scala/slamdata/engine/errors.scala
+++ b/core/src/main/scala/slamdata/engine/errors.scala
@@ -18,9 +18,7 @@ object Error {
     override def show(v: A): Cord = Cord(v.fullMessage)
   }
 
-  implicit def ErrorRenderTree[A <: Error]= new RenderTree[A] {
-    def render(v: A) = Terminal(v.message, List("Error"))
-  }
+  implicit def ErrorRenderTree[A <: Error] = RenderTree.fromToString[A]("Error")
 }
 
 case class ManyErrors(errors: NonEmptyList[Error]) extends Error {
@@ -150,6 +148,6 @@ object PlannerError {
   }
 
   implicit val PlannerErrorRenderTree: RenderTree[PlannerError] = new RenderTree[PlannerError] {
-    def render(v: PlannerError) = Terminal(v.message, Nil)
+    def render(v: PlannerError) = Terminal(List("Error"), Some(v.message))
   }
 }

--- a/core/src/main/scala/slamdata/engine/fp/package.scala
+++ b/core/src/main/scala/slamdata/engine/fp/package.scala
@@ -11,10 +11,10 @@ sealed trait LowerPriorityTreeInstances {
   implicit def Tuple2RenderTree[A, B](implicit RA: RenderTree[A], RB: RenderTree[B]) =
     new RenderTree[(A, B)] {
       override def render(t: (A, B)) =
-        NonTerminal("", RA.render(t._1) ::
-                          RB.render(t._2) ::
-                          Nil,
-                    "tuple" :: Nil)
+        NonTerminal("tuple" :: Nil, None,
+          RA.render(t._1) ::
+            RB.render(t._2) ::
+            Nil)
     }
 }
 
@@ -22,11 +22,11 @@ sealed trait LowPriorityTreeInstances extends LowerPriorityTreeInstances {
   implicit def LeftTuple3RenderTree[A, B, C](implicit RA: RenderTree[A], RB: RenderTree[B], RC: RenderTree[C]) =
     new RenderTree[((A, B), C)] {
       override def render(t: ((A, B), C)) =
-        NonTerminal("", RA.render(t._1._1) ::
-                          RB.render(t._1._2) ::
-                          RC.render(t._2) ::
-                          Nil,
-                    "tuple" :: Nil)
+        NonTerminal("tuple" :: Nil, None,
+          RA.render(t._1._1) ::
+            RB.render(t._1._2) ::
+            RC.render(t._2) ::
+            Nil)
     }
 }
 
@@ -34,20 +34,20 @@ sealed trait TreeInstances extends LowPriorityTreeInstances {
   implicit def LeftTuple4RenderTree[A, B, C, D](implicit RA: RenderTree[A], RB: RenderTree[B], RC: RenderTree[C], RD: RenderTree[D]) =
     new RenderTree[(((A, B), C), D)] {
       override def render(t: (((A, B), C), D)) =
-        NonTerminal("", RA.render(t._1._1._1) ::
-                          RB.render(t._1._1._2) ::
-                          RC.render(t._1._2) ::
-                          RD.render(t._2) ::
-                          Nil,
-                    "tuple" :: Nil)
+        NonTerminal("tuple" :: Nil, None,
+           RA.render(t._1._1._1) ::
+            RB.render(t._1._1._2) ::
+            RC.render(t._1._2) ::
+            RD.render(t._2) ::
+            Nil)
     }
 
   implicit def EitherRenderTree[A, B](implicit RA: RenderTree[A], RB: RenderTree[B]) =
     new RenderTree[A \/ B] {
       override def render(v: A \/ B) =
         v match {
-          case -\/ (a) => NonTerminal("", RA.render(a) :: Nil, "-\\/" :: Nil)
-          case \/- (b) => NonTerminal("", RB.render(b) :: Nil, "\\/-" :: Nil)
+          case -\/ (a) => NonTerminal("-\\/" :: Nil, None, RA.render(a) :: Nil)
+          case \/- (b) => NonTerminal("\\/-" :: Nil, None, RB.render(b) :: Nil)
         }
     }
 
@@ -55,8 +55,8 @@ sealed trait TreeInstances extends LowPriorityTreeInstances {
     new RenderTree[Either[A, B]] {
       override def render(v: Either[A, B]) =
         v match {
-          case Left(a) => NonTerminal("", RA.render(a) :: Nil, List("Left"))
-          case Right(b) => NonTerminal("", RB.render(b) :: Nil, List("Right"))
+          case Left(a) => NonTerminal(List("Left"), None, RA.render(a) :: Nil)
+          case Right(b) => NonTerminal(List("Right"), None, RB.render(b) :: Nil)
         }
     }
 
@@ -64,22 +64,22 @@ sealed trait TreeInstances extends LowPriorityTreeInstances {
     new RenderTree[Option[A]] {
       override def render(o: Option[A]) = o match {
         case Some(a) => RA.render(a)
-        case None => Terminal("", "Option" :: "None" :: Nil)
+        case None => Terminal("None" :: "Option" :: Nil, None)
       }
     }
 
   implicit def ListRenderTree[A](implicit RA: RenderTree[A]) =
     new RenderTree[List[A]] {
-      def render(v: List[A]) = NonTerminal("", v.map(RA.render), List("List"))
+      def render(v: List[A]) = NonTerminal(List("List"), None, v.map(RA.render))
     }
 
   implicit def ListMapRenderTree[K, V](implicit RV: RenderTree[V]) =
     new RenderTree[ListMap[K, V]] {
       def render(v: ListMap[K, V]) =
-        NonTerminal("",
+        NonTerminal("Map" :: Nil, None,
           v.toList.map { case (k, v) =>
-            NonTerminal(k.toString, RV.render(v) :: Nil, Nil)},
-          "Map" :: Nil)
+            NonTerminal("Key" :: "Map" :: Nil, Some(k.toString), RV.render(v) :: Nil)
+          })
     }
 
   implicit def RenderTreeToShow[N: RenderTree] = new Show[N] {

--- a/core/src/main/scala/slamdata/engine/functions.scala
+++ b/core/src/main/scala/slamdata/engine/functions.scala
@@ -35,7 +35,7 @@ sealed trait Func {
 }
 trait FuncInstances {
   implicit val FuncRenderTree = new RenderTree[Func] {
-    override def render(v: Func) = Terminal(v.name, List("Func", v.mappingType.toString))
+    override def render(v: Func) = Terminal(v.mappingType.toString :: "Func" :: Nil, Some(v.name))
   }
 }
 object Func extends FuncInstances {

--- a/core/src/main/scala/slamdata/engine/javascript/javascript.scala
+++ b/core/src/main/scala/slamdata/engine/javascript/javascript.scala
@@ -124,7 +124,7 @@ object Js {
     }
 
   implicit val JSRenderTree = new RenderTree[Js] {
-    override def render(v: Js) = Terminal(v.render(2), "JavaScript" :: Nil)
+    override def render(v: Js) = Terminal("JavaScript" :: Nil, Some(v.render(2)))
   }
 }
 

--- a/core/src/main/scala/slamdata/engine/javascript/jscore.scala
+++ b/core/src/main/scala/slamdata/engine/javascript/jscore.scala
@@ -351,7 +351,5 @@ object JsFn {
 
   def const(x: Term[JsCore]) = JsFn(JsCore.Ident("__unused"), x)
 
-  implicit val JsFnRenderTree = new RenderTree[JsFn] {
-    def render(v: JsFn) = Terminal(v.toString, List("JsFn"))
-  }
+  implicit val JsFnRenderTree = RenderTree.fromToString[JsFn]("JsFn")
 }

--- a/core/src/main/scala/slamdata/engine/logicalplan.scala
+++ b/core/src/main/scala/slamdata/engine/logicalplan.scala
@@ -71,14 +71,16 @@ object LogicalPlan {
     }
   }
   implicit val RenderTreeLogicalPlan: RenderTree[LogicalPlan[_]] = new RenderTree[LogicalPlan[_]] {
+    val nodeType = "LogicalPlan" :: Nil
+
     // Note: these are all terminals; the wrapping Term or Cofree will use these to build nodes with children.
     override def render(v: LogicalPlan[_]) = v match {
-      case ReadF(name)                 => Terminal(name.pathname,             List("LogicalPlan", "Read"))
-      case ConstantF(data)             => Terminal(data.toString,             List("LogicalPlan", "Constant"))
-      case JoinF(_, _, tpe, rel, _, _) => Terminal(tpe.toString + ", " + rel, List("LogicalPlan", "Join"))
-      case InvokeF(func, _     )       => Terminal(func.name,                 List("LogicalPlan", "Invoke", func.mappingType.toString))
-      case FreeF(name)                 => Terminal(name.toString,             List("LogicalPlan", "Free"))
-      case LetF(ident, _, _)           => Terminal(ident.toString,            List("LogicalPlan", "Let"))
+      case ReadF(name)                 => Terminal("Read" :: nodeType, Some(name.pathname))
+      case ConstantF(data)             => Terminal("Constant" :: nodeType, Some(data.toString))
+      case JoinF(_, _, tpe, rel, _, _) => Terminal("Join" :: nodeType, Some(tpe.toString + ", " + rel))
+      case InvokeF(func, _     )       => Terminal(func.mappingType.toString :: "Invoke" :: nodeType, Some(func.name))
+      case FreeF(name)                 => Terminal("Free" :: nodeType, Some(name.toString))
+      case LetF(ident, _, _)           => Terminal("Let" :: nodeType, Some(ident.toString))
     }
   }
   implicit val EqualFLogicalPlan = new fp.EqualF[LogicalPlan] {

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/collection.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/collection.scala
@@ -66,6 +66,6 @@ object Collection {
   }
 
   implicit val CollectionRenderTree = new RenderTree[Collection] {
-    def render(v: Collection) = Terminal(v.databaseName + "; " + v.collectionName, List("Collection"))
+    def render(v: Collection) = Terminal(List("Collection"), Some(v.databaseName + "; " + v.collectionName))
   }
 }

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/exprop.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/exprop.scala
@@ -93,9 +93,7 @@ sealed trait ExprOp {
 }
 
 object ExprOp {
-  implicit object ExprOpRenderTree extends RenderTree[ExprOp] {
-    override def render(v: ExprOp) = Terminal(v.toString, List("ExprOp"))  // TODO
-  }
+  implicit val ExprOpRenderTree = RenderTree.fromToString[ExprOp]("ExprOp")
 
   def toJs(expr: ExprOp): Error \/ JsFn = {
     import slamdata.engine.PlannerError._
@@ -289,9 +287,7 @@ object ExprOp {
   case class Avg(value: ExprOp)      extends GroupOp { val op = "$avg" }
   case class Sum(value: ExprOp)      extends GroupOp { val op = "$sum" }
 
-  implicit object GroupOpRenderTree extends RenderTree[GroupOp] {
-    override def render(v: GroupOp) = Terminal(v.toString, List("GroupOp"))
-  }
+  implicit val GroupOpRenderTree = RenderTree.fromToString[GroupOp]("GroupOp")
 
   sealed trait BoolOp extends SimpleOp
   case class And(values: NonEmptyList[ExprOp]) extends BoolOp {

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/findquery.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/findquery.scala
@@ -70,18 +70,18 @@ object Selector {
     val SelectorNodeType = List("Selector")
 
     override def render(sel: Selector) = sel match {
-      case and: And     => NonTerminal("And", and.flatten.map(render), SelectorNodeType)
-      case or: Or       => NonTerminal("Or", or.flatten.map(render), SelectorNodeType)
-      case nor: Nor     => NonTerminal("Nor", nor.flatten.map(render), SelectorNodeType)
-      case where: Where => Terminal(where.bson.repr.toString, SelectorNodeType)
+      case and: And     => NonTerminal("And" :: SelectorNodeType, None, and.flatten.map(render))
+      case or: Or       => NonTerminal("Or" :: SelectorNodeType, None, or.flatten.map(render))
+      case nor: Nor     => NonTerminal("Nor" :: SelectorNodeType, None, nor.flatten.map(render))
+      case where: Where => Terminal("Where" :: SelectorNodeType, Some(where.bson.repr.toString))
       case Doc(pairs)   => {
         val children = pairs.map {
           case (field, Expr(expr)) =>
-            Terminal(field.toString + " -> " + expr, SelectorNodeType)
+            Terminal("Expr" :: SelectorNodeType, Some(field.toString + " -> " + expr))
           case (field, notExpr @ NotExpr(_)) =>
-            Terminal(field.toString + " -> " + notExpr, SelectorNodeType)
+            Terminal("NotExpr" :: SelectorNodeType, Some(field.toString + " -> " + notExpr))
         }
-        NonTerminal("Doc", children.toList, SelectorNodeType)
+        NonTerminal("Doc" :: SelectorNodeType, None, children.toList)
       }
     }
   }

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/reshape.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/reshape.scala
@@ -21,9 +21,8 @@ object Grouped {
   implicit def GroupedRenderTree = new RenderTree[Grouped] {
     val GroupedNodeType = List("Grouped")
 
-    def render(grouped: Grouped) = NonTerminal("",
-                                    (grouped.value.map { case (name, expr) => Terminal(name.bson.repr.toString + " -> " + expr.bson.repr.toString, GroupedNodeType :+ "Name") } ).toList,
-                                    GroupedNodeType)
+    def render(grouped: Grouped) = NonTerminal(GroupedNodeType, None,
+                                    (grouped.value.map { case (name, expr) => Terminal("Name" :: GroupedNodeType, Some(name.bson.repr.toString + " -> " + expr.bson.repr.toString)) } ).toList)
   }
 }
 
@@ -126,8 +125,8 @@ object Reshape {
         case _ => field.bson.repr.toString -> "Name"
       }
       value match {
-        case -\/  (exprOp) => Terminal(label + " -> " + exprOp.bson.repr.toString, ProjectNodeType :+ typ)
-        case  \/- (shape)  => NonTerminal(label, renderReshape(shape), ProjectNodeType :+ typ)
+        case -\/  (exprOp) => Terminal(typ :: ProjectNodeType, Some(label + " -> " + exprOp.bson.repr.toString))
+        case  \/- (shape)  => NonTerminal(typ :: ProjectNodeType, Some(label), renderReshape(shape))
       }
     }
 

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowop.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowop.scala
@@ -1111,83 +1111,86 @@ object Workflow {
   implicit def WorkflowFRenderTree(implicit RC: RenderTree[Collection], RS: RenderTree[Selector], RE: RenderTree[ExprOp], RG: RenderTree[Grouped], RJ: RenderTree[Js], RJM: RenderTree[JsFn]):
       RenderTree[WorkflowF[Unit]] =
     new RenderTree[WorkflowF[Unit]] {
-      def nodeType(subType: String) = "Workflow" :: subType :: Nil
+      val wfType = "Workflow" :: Nil
 
       def render(v: WorkflowF[Unit]) = v match {
-        case $Pure(value)       => Terminal(value.toString, nodeType("$Pure"))
-        case $Read(coll)        => RC.render(coll).copy(nodeType = nodeType("$Read"))
+        case $Pure(value)       => Terminal("$Pure" :: wfType, Some(value.toString))
+        case $Read(coll)        => RC.render(coll).copy(nodeType = "$Read" :: wfType)
         case $Match(_, sel)     =>
-          NonTerminal("", RS.render(sel) :: Nil, nodeType("$Match"))
+          NonTerminal("$Match" :: wfType, None, RS.render(sel) :: Nil)
         case $Project(_, shape, xId) =>
-          NonTerminal("",
+          NonTerminal("$Project" :: wfType, None,
             Reshape.renderReshape(shape) :+
-              Terminal("", nodeType(xId.toString)),
-            nodeType("$Project"))
-        case $Redact(_, value) => NonTerminal("",
+              Terminal(xId.toString :: "$Project" :: wfType, None))
+        case $Redact(_, value) => NonTerminal("$Redact" :: wfType, None,
           RE.render(value) ::
-            Nil,
-          nodeType("$Redact"))
-        case $Limit(_, count)  => Terminal(count.toString, nodeType("$Limit"))
-        case $Skip(_, count)   => Terminal(count.toString, nodeType("$Skip"))
-        case $Unwind(_, field) => Terminal(field.toString, nodeType("$Unwind"))
-        case $Group(_, grouped, -\/ (expr))
-            => NonTerminal("",
+            Nil)
+        case $Limit(_, count)  => Terminal("$Limit" :: wfType, Some(count.toString))
+        case $Skip(_, count)   => Terminal("$Skip" :: wfType, Some(count.toString))
+        case $Unwind(_, field) => Terminal("$Unwind" :: wfType, Some(field.toString))
+        case $Group(_, grouped, -\/ (expr)) =>
+          val nt = "$Group" :: wfType
+          NonTerminal(nt, None,
               RG.render(grouped) ::
-                Terminal(expr.toString, nodeType("By")) ::
-                Nil,
-              nodeType("$Group"))
-        case $Group(_, grouped, \/- (by))
-            => NonTerminal("",
+                Terminal("By" :: nt, Some(expr.toString)) ::
+                Nil)
+        case $Group(_, grouped, \/- (by)) =>
+          val nt = "$Group" :: wfType
+          NonTerminal(nt, None,
               RG.render(grouped) ::
-                NonTerminal("", Reshape.renderReshape(by), nodeType("By")) ::
-                Nil,
-              nodeType("$Group"))
-        case $Sort(_, value)   => NonTerminal("",
-          value.map { case (field, st) => Terminal(field.asText + " -> " + st, nodeType("SortKey")) }.toList,
-          nodeType("$Sort"))
-        case $GeoNear(_, near, distanceField, limit, maxDistance, query, spherical, distanceMultiplier, includeLocs, uniqueDocs)
-            => NonTerminal("",
-              Terminal(near.toString, nodeType("$GeoNear") :+ "Near") ::
-                Terminal(distanceField.toString, nodeType("$GeoNear") :+ "DistanceField") ::
-                Terminal(limit.toString, nodeType("$GeoNear") :+ "Limit") ::
-                Terminal(maxDistance.toString, nodeType("$GeoNear") :+ "MaxDistance") ::
-                Terminal(query.toString, nodeType("$GeoNear") :+ "Query") ::
-                Terminal(spherical.toString, nodeType("$GeoNear") :+ "Spherical") ::
-                Terminal(distanceMultiplier.toString, nodeType("$GeoNear") :+ "DistanceMultiplier") ::
-                Terminal(includeLocs.toString, nodeType("$GeoNear") :+ "IncludeLocs") ::
-                Terminal(uniqueDocs.toString, nodeType("$GeoNear") :+ "UniqueDocs") ::
-                Nil,
-              nodeType("$GeoNear"))
+                NonTerminal("By" :: nt, None, Reshape.renderReshape(by)) ::
+                Nil)
+        case $Sort(_, value)   =>
+          val nt = "$Sort" :: wfType
+          NonTerminal(nt, None,
+            value.map { case (field, st) => Terminal("SortKey" :: nt, Some(field.asText + " -> " + st)) }.toList)
+        case $GeoNear(_, near, distanceField, limit, maxDistance, query, spherical, distanceMultiplier, includeLocs, uniqueDocs) =>
+          val nt = "$GeoNear" :: wfType
+          NonTerminal(nt, None,
+            Terminal("Near" :: nt, Some(near.toString)) ::
+              Terminal("DistanceField" :: nt, Some(distanceField.toString)) ::
+              Terminal("Limit" :: nt, Some(limit.toString)) ::
+              Terminal("MaxDistance" :: nt, Some(maxDistance.toString)) ::
+              Terminal("Query" :: nt, Some(query.toString)) ::
+              Terminal("Spherical" :: nt, Some(spherical.toString)) ::
+              Terminal("DistanceMultiplier" :: nt, Some(distanceMultiplier.toString)) ::
+              Terminal("IncludeLocs" :: nt, Some(includeLocs.toString)) ::
+              Terminal("UniqueDocs" :: nt, Some(uniqueDocs.toString)) ::
+              Nil)
 
-        case $Map(_, fn, scope) => NonTerminal("",
-          RJ.render(fn) ::
-            Terminal((scope ∘ (_.toJs.render(2))).toString, nodeType("$Map") :+ "Scope") ::
-            Nil,
-          nodeType("$Map"))
-        case $FlatMap(_, fn, scope) => NonTerminal("",
-          RJ.render(fn) ::
-            Terminal((scope ∘ (_.toJs.render(2))).toString, nodeType("$Map") :+ "Scope") ::
-            Nil,
-          nodeType("$FlatMap"))
-        case $SimpleMap(_, expr, flatten, scope) => NonTerminal("",
-            Terminal(expr.toString, nodeType("$SimpleMap") :+ "Expr") ::
-              (flatten.map(RJM.render(_).copy(nodeType = nodeType("$SimpleMap") :+ "Flatten")) :+
-                Terminal((scope ∘ (_.toJs.render(2))).toString, nodeType("$SimpleMap") :+ "Scope")),
-            nodeType("$SimpleMap"))
-        case $Reduce(_, fn, scope) => NonTerminal("",
-          RJ.render(fn) ::
-            Terminal((scope ∘ (_.toJs.render(2))).toString, nodeType("$Map") :+ "Scope") ::
-            Nil,
-          nodeType("$Reduce"))
-        case $Out(_, coll) => RC.render(coll).copy(nodeType = nodeType("$Out"))
-        case $FoldLeft(_, _) => Terminal("", nodeType("$FoldLeft"))
+        case $Map(_, fn, scope) =>
+          val nt = "$Map" :: wfType
+          NonTerminal(nt, None,
+            RJ.render(fn) ::
+              Terminal("Scope" :: nt, Some((scope ∘ (_.toJs.render(2))).toString)) ::
+              Nil)
+        case $FlatMap(_, fn, scope) =>
+          val nt = "$FlatMap" :: wfType
+          NonTerminal(nt, None,
+            RJ.render(fn) ::
+              Terminal("Scope" :: nt, Some((scope ∘ (_.toJs.render(2))).toString)) ::
+              Nil)
+        case $SimpleMap(_, expr, flatten, scope) =>
+          val nt = "$SimpleMap" :: wfType
+          NonTerminal(nt, None,
+            Terminal("Expr" :: nt, Some(expr.toString)) ::
+              (flatten.map(RJM.render(_).copy(nodeType = "Flatten" :: nt)) :+
+                Terminal("Scope" :: nt, Some((scope ∘ (_.toJs.render(2))).toString))))
+        case $Reduce(_, fn, scope) =>
+          val nt = "$Reduce" :: wfType
+          NonTerminal(nt, None,
+            RJ.render(fn) ::
+              Terminal("Scope" :: nt, Some((scope ∘ (_.toJs.render(2))).toString)) ::
+              Nil)
+        case $Out(_, coll) => RC.render(coll).copy(nodeType = "$Out" :: wfType)
+        case $FoldLeft(_, _) => Terminal("$FoldLeft" :: wfType, None)
       }
     }
 
   implicit def WorkflowRenderTree(implicit RW: RenderTree[WorkflowF[Unit]]):
       RenderTree[Workflow] =
     new RenderTree[Workflow] {
-      def nodeType(subType: String) = "Workflow" :: subType :: Nil
+      val wfType = "Workflow" :: Nil
 
       def chain(op: Workflow): List[RenderedTree] = op.unFix match {
         case ss: SingleSourceF[Workflow] =>
@@ -1198,9 +1201,9 @@ object Workflow {
       def render(v: Workflow) = v.unFix match {
         case op: SourceOp    => RW.render(op.void)
         case _: SingleSourceF[Workflow] =>
-          NonTerminal("", chain(v), nodeType("Chain"))
+          NonTerminal("Chain" :: wfType, None, chain(v))
         case $FoldLeft(_, _) =>
-          NonTerminal("", v.children.map(render(_)), nodeType("$FoldLeft"))
+          NonTerminal("$FoldLeft" :: wfType, None, v.children.map(render(_)))
       }
     }
 }

--- a/core/src/main/scala/slamdata/engine/semantics.scala
+++ b/core/src/main/scala/slamdata/engine/semantics.scala
@@ -49,9 +49,7 @@ trait SemanticAnalysis {
     case object SortKey extends Synthetic
   }
 
-  implicit val SyntheticRenderTree = new RenderTree[Synthetic] {
-    def render(v: Synthetic) = Terminal(v.toString, List("Synthetic"))
-  }
+  implicit val SyntheticRenderTree = RenderTree.fromToString[Synthetic]("Synthetic")
 
   /**
    * Inserts synthetic fields into the projections of each `select` stmt to hold
@@ -208,15 +206,15 @@ trait SemanticAnalysis {
         val ProvenanceNodeType = List("Provenance")
 
         def nest(l: RenderedTree, r: RenderedTree, sep: String) = (l, r) match {
-          case (RenderedTree(ll, Nil, lt), RenderedTree(rl, Nil, rt)) =>
-                    Terminal("(" + ll + " " + sep + " " + rl + ")", ProvenanceNodeType)
-          case _ => NonTerminal(sep, l :: r :: Nil, ProvenanceNodeType)
+          case (RenderedTree(_, ll, Nil), RenderedTree(_, rl, Nil)) =>
+                    Terminal(ProvenanceNodeType, Some("(" + ll + " " + sep + " " + rl + ")"))
+          case _ => NonTerminal(ProvenanceNodeType, Some(sep), l :: r :: Nil)
         }
 
         v match {
-          case Empty               => Terminal("Empty", ProvenanceNodeType)
-          case Value               => Terminal("Value", ProvenanceNodeType)
-          case Relation(value)     => RenderTree[Node].render(value).copy(nodeType=ProvenanceNodeType)
+          case Empty               => Terminal(ProvenanceNodeType, Some("Empty"))
+          case Value               => Terminal(ProvenanceNodeType, Some("Value"))
+          case Relation(value)     => RenderTree[Node].render(value).copy(nodeType = ProvenanceNodeType)
           case Either(left, right) => nest(self.render(left), self.render(right), "|")
           case Both(left, right)   => nest(self.render(left), self.render(right), "&")
         }

--- a/core/src/main/scala/slamdata/engine/types.scala
+++ b/core/src/main/scala/slamdata/engine/types.scala
@@ -204,9 +204,7 @@ trait TypeInstances {
     def append(f1: Type, f2: => Type) = Type.lub(f1, f2)
   }
 
-  implicit val TypeRenderTree = new RenderTree[Type] {
-    override def render(v: Type) = Terminal(v.toString, List("Type"))  // TODO
-  }
+  implicit val TypeRenderTree = RenderTree.fromToString[Type]("Type")
 }
 
 case object Type extends TypeInstances {

--- a/core/src/test/scala/slamdata/engine/analysis/fixplate.scala
+++ b/core/src/test/scala/slamdata/engine/analysis/fixplate.scala
@@ -43,19 +43,16 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
   implicit val ExpRenderTree: RenderTree[Exp[_]] =
     new RenderTree[Exp[_]] {
       def render(v: Exp[_]) = v match {
-        case Num(value)       => Terminal(value.toString, List("Num"))
-        case Mul(_, _)        => Terminal("", List("Mul"))
-        case Var(sym)         => Terminal(sym.toString, List("Var"))
-        case Lambda(param, _) => Terminal(param.toString, List("Lambda"))
-        case Apply(_, _)      => Terminal("", List("Apply"))
-        case Let(name, _, _)  => Terminal(name.toString, List("Let"))
+        case Num(value)       => Terminal(List("Num"), Some(value.toString))
+        case Mul(_, _)        => Terminal(List("Mul"), None)
+        case Var(sym)         => Terminal(List("Var"), Some(sym.toString))
+        case Lambda(param, _) => Terminal(List("Lambda"), Some(param.toString))
+        case Apply(_, _)      => Terminal(List("Apply"), None)
+        case Let(name, _, _)  => Terminal(List("Let"), Some(name.toString))
       }
     }
 
-  implicit val IntRenderTree =
-    new RenderTree[Int] {
-      override def render(t: Int) = Terminal("", t.shows :: Nil)
-    }
+  implicit val IntRenderTree = RenderTree.fromToString[Int]("Int")
 
   // NB: an unusual definition of equality, in that only the first 3 characters
   //     of variable names are significant
@@ -602,7 +599,7 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
 
     "RenderTree" should {
       "render simple nested expr" in {
-        implicit def RU = new RenderTree[Unit] { def render(v: Unit) = Terminal("", List("()")) }
+        implicit def RU = new RenderTree[Unit] { def render(v: Unit) = Terminal(List("()"), None) }
         attrUnit(mul(num(0), num(1))).shows must_==
           """Mul
             |├─ Annotation

--- a/core/src/test/scala/slamdata/engine/debug.scala
+++ b/core/src/test/scala/slamdata/engine/debug.scala
@@ -11,97 +11,91 @@ class RenderedTreeSpec extends Specification {
   "RenderedTree.diff" should {
 
     "find no differences" in {
-      val t = NonTerminal("A", Terminal("B", Nil) :: Terminal("C", Nil) :: Nil, Nil)
+      val t = NonTerminal(Nil, Some("A"), Terminal(Nil, Some("B")) :: Terminal(Nil, Some("C")) :: Nil)
       t.diff(t) must_== t
     }
 
     "find simple difference" in {
-      val t1 = Terminal("A", Nil)
-      val t2 = Terminal("B", Nil)
+      val t1 = Terminal(Nil, Some("A"))
+      val t2 = Terminal(Nil, Some("B"))
       t1.diff(t2) must_==
-        NonTerminal("",
-          Terminal("A", List(">>>")) ::
-            Terminal("B", List("<<<")) ::
-            Nil,
-          "[Root differs]" :: Nil)
+        NonTerminal("[Root differs]" :: Nil, None,
+          Terminal(List(">>>"), Some("A")) ::
+            Terminal(List("<<<"), Some("B")) ::
+            Nil)
     }
 
     "find simple difference in parent" in {
-      val t1 = NonTerminal("A", Terminal("B", Nil) :: Nil, Nil)
-      val t2 = NonTerminal("C", Terminal("B", Nil) :: Nil, Nil)
+      val t1 = NonTerminal(Nil, Some("A"), Terminal(Nil, Some("B")) :: Nil)
+      val t2 = NonTerminal(Nil, Some("C"), Terminal(Nil, Some("B")) :: Nil)
       t1.diff(t2) must_==
-        NonTerminal("",
-          NonTerminal("A", Terminal("B", Nil) :: Nil, List(">>>")) ::
-            NonTerminal("C", Terminal("B", Nil) :: Nil, List("<<<")) ::
-            Nil,
-          "[Root differs]" :: Nil)
+        NonTerminal("[Root differs]" :: Nil, None,
+          NonTerminal(List(">>>"), Some("A"), Terminal(Nil, Some("B")) :: Nil) ::
+            NonTerminal(List("<<<"), Some("C"), Terminal(Nil, Some("B")) :: Nil) ::
+            Nil)
     }
 
     "find added child" in {
-      val t1 = NonTerminal("A", Terminal("B", Nil) :: Nil, Nil)
-      val t2 = NonTerminal("A", Terminal("B", Nil) :: Terminal("C", Nil) :: Nil, Nil)
-      t1.diff(t2) must_== NonTerminal("A", Terminal("B", Nil) :: Terminal("C", "<<<" :: Nil) :: Nil, Nil)
+      val t1 = NonTerminal(Nil, Some("A"), Terminal(Nil, Some("B")) :: Nil)
+      val t2 = NonTerminal(Nil, Some("A"), Terminal(Nil, Some("B")) :: Terminal(Nil, Some("C")) :: Nil)
+      t1.diff(t2) must_== NonTerminal(Nil, Some("A"), Terminal(Nil, Some("B")) :: Terminal("<<<" :: Nil, Some("C")) :: Nil)
     }
 
     "find deleted child" in {
-      val t1 = NonTerminal("A", Terminal("B", Nil) :: Terminal("C", Nil) :: Nil, Nil)
-      val t2 = NonTerminal("A", Terminal("B", Nil) :: Nil, Nil)
-      t1.diff(t2) must_== NonTerminal("A", Terminal("B", Nil) :: Terminal("C", ">>>" :: Nil) :: Nil, Nil)
+      val t1 = NonTerminal(Nil, Some("A"), Terminal(Nil, Some("B")) :: Terminal(Nil, Some("C")) :: Nil)
+      val t2 = NonTerminal(Nil, Some("A"), Terminal(Nil, Some("B")) :: Nil)
+      t1.diff(t2) must_== NonTerminal(Nil, Some("A"), Terminal(Nil, Some("B")) :: Terminal(">>>" :: Nil, Some("C")) :: Nil)
     }
 
     "find simple difference in child" in {
-      val t1 = NonTerminal("A", Terminal("B", Nil) :: Nil, Nil)
-      val t2 = NonTerminal("A", Terminal("C", Nil) :: Nil, Nil)
+      val t1 = NonTerminal(Nil, Some("A"), Terminal(Nil, Some("B")) :: Nil)
+      val t2 = NonTerminal(Nil, Some("A"), Terminal(Nil, Some("C")) :: Nil)
       t1.diff(t2) must_==
-        NonTerminal("A",
-          Terminal("B", ">>>" :: Nil) ::
-            Terminal("C", "<<<" :: Nil) ::
-            Nil,
-          Nil)
+        NonTerminal(Nil, Some("A"),
+          Terminal(">>>" :: Nil, Some("B")) ::
+            Terminal("<<<" :: Nil, Some("C")) ::
+            Nil)
     }
 
     "find multiple changed children" in {
-      val t1 = NonTerminal("A", Terminal("B", Nil) :: Terminal("C", Nil) :: Terminal("D", Nil) :: Nil, Nil)
-      val t2 = NonTerminal("A", Terminal("C", Nil) :: Terminal("C1", Nil) :: Terminal("D", Nil) :: Nil, Nil)
+      val t1 = NonTerminal(Nil, Some("A"), Terminal(Nil, Some("B")) :: Terminal(Nil, Some("C")) :: Terminal(Nil, Some("D")) :: Nil)
+      val t2 = NonTerminal(Nil, Some("A"), Terminal(Nil, Some("C")) :: Terminal(Nil, Some("C1")) :: Terminal(Nil, Some("D")) :: Nil)
       t1.diff(t2) must_==
-        NonTerminal("A",
-          Terminal("B", ">>>" :: Nil) ::
-            Terminal("C", Nil) ::
-            Terminal("C1", "<<<" :: Nil) ::
-            Terminal("D", Nil) :: Nil,
-        Nil)
+        NonTerminal(Nil, Some("A"),
+          Terminal(">>>" :: Nil, Some("B")) ::
+            Terminal(Nil, Some("C")) ::
+            Terminal("<<<" :: Nil, Some("C1")) ::
+            Terminal(Nil, Some("D")) :: Nil)
     }
 
     "find added grand-child" in {
-      val t1 = NonTerminal("A", NonTerminal("B", Nil, Nil) :: Nil, Nil)
-      val t2 = NonTerminal("A", NonTerminal("B", Terminal("C", Nil) :: Nil, Nil) :: Nil, Nil)
-      t1.diff(t2) must_== NonTerminal("A", NonTerminal("B", Terminal("C", "<<<" :: Nil) :: Nil, Nil) :: Nil, Nil)
+      val t1 = NonTerminal(Nil, Some("A"), NonTerminal(Nil, Some("B"), Nil) :: Nil)
+      val t2 = NonTerminal(Nil, Some("A"), NonTerminal(Nil, Some("B"), Terminal(Nil, Some("C")) :: Nil) :: Nil)
+      t1.diff(t2) must_== NonTerminal(Nil, Some("A"), NonTerminal(Nil, Some("B"), Terminal("<<<" :: Nil, Some("C")) :: Nil) :: Nil)
     }
 
     "find deleted grand-child" in {
-      val t1 = NonTerminal("A", NonTerminal("B", Terminal("C", Nil) :: Nil, Nil) :: Nil, Nil)
-      val t2 = NonTerminal("A", NonTerminal("B", Nil, Nil) :: Nil, Nil)
-      t1.diff(t2) must_== NonTerminal("A", NonTerminal("B", Terminal("C", ">>>" :: Nil) :: Nil, Nil) :: Nil, Nil)
+      val t1 = NonTerminal(Nil, Some("A"), NonTerminal(Nil, Some("B"), Terminal(Nil, Some("C")) :: Nil) :: Nil)
+      val t2 = NonTerminal(Nil, Some("A"), NonTerminal(Nil, Some("B"), Nil) :: Nil)
+      t1.diff(t2) must_== NonTerminal(Nil, Some("A"), NonTerminal(Nil, Some("B"), Terminal(">>>" :: Nil, Some("C")) :: Nil) :: Nil)
     }
 
     "find different nodeType at root" in {
-      val t1 = Terminal("A", List("green"))
-      val t2 = Terminal("A", List("blue"))
-      t1.diff(t2) must_== NonTerminal("",
-                            Terminal("A", List(">>> green")) ::
-                              Terminal("A", List("<<< blue")) ::
-                              Nil,
-                            List("[Root differs]"))
+      val t1 = Terminal(List("green"), Some("A"))
+      val t2 = Terminal(List("blue"), Some("A"))
+      t1.diff(t2) must_== NonTerminal(List("[Root differs]"), None,
+                            Terminal(List(">>> green"), Some("A")) ::
+                              Terminal(List("<<< blue"), Some("A")) ::
+                              Nil)
     }
 
     "find different nodeType" in {
-      val t1 = NonTerminal("", Terminal("A", List("green")) :: Nil, List("root"))
-      val t2 = NonTerminal("", Terminal("A", List("blue")) :: Nil, List("root"))
-      t1.diff(t2) must_== NonTerminal("",
-                            Terminal("A", List(">>> green")) ::
-                              Terminal("A", List("<<< blue")) ::
-                              Nil,
-                            List("root"))
+      val t1 = NonTerminal(List("root"), None, Terminal(List("green"), Some("A")) :: Nil)
+      val t2 = NonTerminal(List("root"), None, Terminal(List("blue"), Some("A")) :: Nil)
+      t1.diff(t2) must_== NonTerminal(List("root"), None,
+                            Terminal(List(">>> green"), Some("A")) ::
+                              Terminal(List("<<< blue"), Some("A")) ::
+                              Nil)
     }
 
   }
@@ -109,35 +103,38 @@ class RenderedTreeSpec extends Specification {
   "RenderedTreeEncodeJson" should {
 
     "encode Terminal" in {
-      Terminal("A", Nil).asJson must_== Json("label" := "A")
+      Terminal(Nil, Some("A")).asJson must_== Json("label" := "A")
     }
 
     "encode Terminal with type" in {
-      Terminal("A", List("green")).asJson must_== Json("type" := "green", "label" := "A")
+      Terminal("green" :: Nil, Some("A")).asJson must_== Json("type" := "green", "label" := "A")
+    }
+
+    "encode Terminal with complex type" in {
+      Terminal("inner" :: "outer" :: Nil, Some("A")).asJson must_== Json("type" := "outer/inner", "label" := "A")
     }
 
     "encode NonTerminal with no children" in {
-      NonTerminal("A", Nil, Nil).asJson must_== Json("label" := "A")
+      NonTerminal(Nil, Some("A"), Nil).asJson must_== Json("label" := "A")
     }
 
     "encode NonTerminal with type and no children" in {
-      NonTerminal("A", Nil, List("green")).asJson must_== Json("type" := "green", "label" := "A")
+      NonTerminal("green" :: Nil, Some("A"), Nil).asJson must_== Json("type" := "green", "label" := "A")
     }
 
     "encode NonTerminal with one child" in {
-      NonTerminal("A", Terminal("B", Nil) :: Nil, Nil).asJson must_==
+      NonTerminal(Nil, Some("A"), Terminal(Nil, Some("B")) :: Nil).asJson must_==
         Json(
           "label" := "A",
           "children" := Json("label" := "B") :: Nil)
     }
 
     "encode NonTerminal with one child and type" in {
-      NonTerminal("A", Terminal("B", Nil) :: Nil, List("green")).asJson must_==
+      NonTerminal("green" :: Nil, Some("A"), Terminal(Nil, Some("B")) :: Nil).asJson must_==
         Json(
           "type" := "green",
           "label" := "A",
           "children" := Json("label" := "B") :: Nil)
     }
-
   }
 }

--- a/web/src/test/scala/slamdata/engine/api/fs.scala
+++ b/web/src/test/scala/slamdata/engine/api/fs.scala
@@ -43,7 +43,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
   object Stub {
     case class Plan(description: String)
     implicit val PlanRenderTree = new RenderTree[Plan] {
-      def render(v: Plan) = Terminal("", List("Stub.Plan"))
+      def render(v: Plan) = Terminal(List("Stub.Plan"), None)
     }
 
     lazy val planner = new Planner[Plan] {


### PR DESCRIPTION
1. Make `nodeType` the first parameter, and
2. reverse the order of the list, so shared structure can be shared.
3. Make `label` optional, reflecting its
use.

This corrects the mistake of putting the nodeType at the end, simply because
it was added later, and makes it clearer that the label isn't required.
Actually, it would make sense for nodeType to be `NonEmptyList`, but that
would be painful, and it's easy enough to provide some default in case it's
empty, since it's just being turned into a label string.