### PR TITLE
Add a static file service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The path of the JAR will be `./core/target/scala-2.11/core_2.11-[version]-SNAPSH
 To run the JAR, execute the following command:
 
 ```bash
-java -jar [path to jar] [config file]
+java -jar [<path to jar>] [<config file>]
 ```
 
 #### Web JAR
@@ -69,7 +69,7 @@ The path of the JAR will be `./web/target/scala-2.11/web_2.11-[version]-SNAPSHOT
 To run the JAR, execute the following command:
 
 ```bash
-java -jar [path to jar] [config file]
+java -jar [<path to jar>] [-c <config file>]
 ```
 
 #### Admin JAR
@@ -85,7 +85,7 @@ The path of the JAR will be `./admin/target/scala-2.11/admin_2.11-[version]-SNAP
 To run the JAR, execute the following command:
 
 ```bash
-java -jar [path to jar] [config file]
+java -jar [<path to jar>] [<config file>]
 ```
 
 ### Configure

--- a/admin/src/main/scala/slamdata/engine/admin/config.scala
+++ b/admin/src/main/scala/slamdata/engine/admin/config.scala
@@ -17,10 +17,10 @@ class ConfigDialog(parent: Window, configPath: Option[String]) extends Dialog(pa
 
   var config: Option[Config] = None
 
-  private val startConfig = Config.load(configPath).attemptRun.fold(
+  private val startConfig = Config.loadOrEmpty(configPath).attemptRun.fold(
     err => {
-      if (!err.isInstanceOf[java.nio.file.NoSuchFileException]) errorAlert(mountTable, err.toString)
-      Config(SDServerConfig(Some(SDServerConfig.DefaultPort)), Map())
+      errorAlert(mountTable, err.toString)
+      Config.empty
     },
     identity)
 
@@ -144,7 +144,7 @@ class ConfigDialog(parent: Window, configPath: Option[String]) extends Dialog(pa
   }
   lazy val portField = new TextField {
     columns = 10
-    text = startConfig.server.port.foldMap(_.toString)
+    text = startConfig.server.port.toString
     this.bindEditActions
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ lazy val standardSettings = Defaults.defaultSettings ++ Seq(
     "com.github.julien-truffaut" %% "monocle-core"     % monocleVersion    % "compile, test",
     "com.github.julien-truffaut" %% "monocle-generic"  % monocleVersion    % "compile, test",
     "com.github.julien-truffaut" %% "monocle-macro"    % monocleVersion    % "compile, test",
+    "com.github.scopt"  %% "scopt"                     % "3.3.0"           % "compile, test",
     "org.threeten"      %  "threetenbp"                % "1.2"             % "compile, test",
     "org.mongodb"       %  "mongo-java-driver"         % "3.0.0-rc0"       % "compile, test",
     "org.http4s"        %% "http4s-dsl"                % "0.6.5"           % "compile, test",

--- a/core/src/main/scala/slamdata/engine/repl/repl.scala
+++ b/core/src/main/scala/slamdata/engine/repl/repl.scala
@@ -263,7 +263,7 @@ object Repl {
     Process.eval(for {
       tuple   <- commandInput
       (printer, commands) = tuple
-      mounted <- Config.load(args.headOption).flatMap(Mounter.mount(_))
+      mounted <- Config.loadOrEmpty(args.headOption).flatMap(Mounter.mount(_))
     } yield
       commands.scan(RunState(printer, mounted, Path.Root, None, DebugLevel.Normal, 10, Map())) { (state, input) =>
         input match {

--- a/scripts/autoPublish
+++ b/scripts/autoPublish
@@ -14,12 +14,12 @@ if [[ ! -v GITHUB_TOKEN ]] ; then
     exit 0
 fi
 
-# only auto-publish on slamdata/slamengine#main
+# only auto-publish on slamdata/slamengine#master
 if [[ "$TRAVIS" == "true" && "$TRAVIS_BRANCH" == "master" && "$TRAVIS_REPO_SLUG" == "slamdata/slamengine" ]] ; then
   "$SBT" 'project web'    githubRelease
   "$SBT" 'project admin'  githubRelease
 
   echo "See https://github.com/$REPO/releases/tag/$TAG_NAME"
 else 
-  echo "GITHUB_TOKEN defined, but Travis not running in slamdata/slamengine#master, so skipping auto-publish"  
+  echo "GITHUB_TOKEN defined, but Travis not running in slamdata/slamengine#master, so skipping auto-publish"
 fi

--- a/web/src/main/scala/slamdata/engine/api/fs.scala
+++ b/web/src/main/scala/slamdata/engine/api/fs.scala
@@ -293,23 +293,21 @@ class FileSystemApi(fs: FSTable[Backend]) {
   def fileMediaType(file: String): Option[MediaType] =
     MediaType.forExtension(file.split('.').last)
 
-  def appService = corsService {
+  def staticFileService(basePath: String) = corsService {
     case GET -> AsPath(path) =>
       // NB: http4s/http4s#265 should give us a simple way to handle this stuff.
-      basePath.flatMap { bp =>
-        val filePath = bp + "/docroot/slamdata" + path.toString
-        StaticFile.fromString(filePath).fold(
-          StaticFile.fromString(filePath + "/index.html").fold(
-            NotFound("Couldn’t find page " + path.toString))(
-            Task.now))(
-          resp => path.file.flatMap(f => fileMediaType(f.value)).fold(
-            Task.now(resp))(
-            mt => Task.delay(resp.withContentType(Some(`Content-Type`(mt))))))
-      }
+      val filePath = basePath + path.toString
+      StaticFile.fromString(filePath).fold(
+        StaticFile.fromString(filePath + "/index.html").fold(
+          NotFound("Couldn’t find page " + path.toString))(
+          Task.now))(
+        resp => path.file.flatMap(f => fileMediaType(f.value)).fold(
+          Task.now(resp))(
+          mt => Task.delay(resp.withContentType(Some(`Content-Type`(mt))))))
   }
 
-  def rootService = corsService {
+  def redirectService(basePath: String) = corsService {
     case GET -> AsPath(path) =>
-      TemporaryRedirect(Uri(path = "/slamdata" + path.toString))
+      TemporaryRedirect(Uri(path = basePath + path.toString))
   }
 }

--- a/web/src/main/scala/slamdata/engine/api/server.scala
+++ b/web/src/main/scala/slamdata/engine/api/server.scala
@@ -52,13 +52,13 @@ object Server {
 
   def main(args: Array[String]) = {
     optionParser.parse(args, Options(None, false, None)) match {
-      case Some(conf) =>
+      case Some(options) =>
         val serve = for {
-          config  <- Config.load(conf.config)
+          config  <- Config.loadOrEmpty(options.config)
           mounted <- Mounter.mount(config)
-          port = conf.port.getOrElse(config.server.port.getOrElse(8080))
+          port = options.port.getOrElse(config.server.port)
           server  <- run(port, mounted)
-          _       <- if (conf.openClient) openBrowser(port) else Task.now(())
+          _       <- if (options.openClient) openBrowser(port) else Task.now(())
           _       <- Task.delay { println("Embedded server listening at port " + port) }
           _       <- Task.delay { println("Press Enter to stop.") }
           _       <- waitForInput

--- a/web/src/test/scala/slamdata/engine/api/fs.scala
+++ b/web/src/test/scala/slamdata/engine/api/fs.scala
@@ -30,7 +30,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
   down the server.
   */
   def withServer[A](fs: Map[Path, Backend])(body: => A): A = {
-    val srv = Server.run(port, FSTable(fs)).run
+    val srv = Server.run(port, FSTable(fs), ".").run
 
     try {
       body


### PR DESCRIPTION
This serves up URIs under /slamdata relative to the location of the jar. It
also redirects / to /slamdata (assuming no other service matches
the path).

This also adds command-line options to the server (primarily to be able
to choose whether or not starting the server opens a client in the
browser). This meant changing the config file from being the first
argument to being passed with `--config`. I also add a `--port` option
just for convenience.