### PR TITLE
TO_TIMESTAMP function for converting epoch time to timestamp (fixes #703)

### DIFF
--- a/core/src/main/scala/slamdata/engine/debug.scala
+++ b/core/src/main/scala/slamdata/engine/debug.scala
@@ -24,9 +24,9 @@ final case class RenderedTree(nodeType: List[String], label: Option[String], chi
    Node types are not compared or necessarily preserved.
    */
   def diff(that: RenderedTree): RenderedTree = {
-    def prefixedType(t: RenderedTree, p: String): List[String] = t.nodeType.reverse match {
-      case last :: rest => ((p + " " + last) :: rest).reverse
-      case Nil          => p :: Nil
+    def prefixedType(t: RenderedTree, p: String): List[String] = t.nodeType match {
+      case first :: rest => (p + " " + first) :: rest
+      case Nil           => p :: Nil
     }
 
     def prefixType(t: RenderedTree, p: String): RenderedTree = t.copy(nodeType = prefixedType(t, p))

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/exprop.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/exprop.scala
@@ -131,6 +131,13 @@ object ExprOp {
     expr match {
       case Include               => -\/(NonRepresentableInJS(expr.toString))
       case dv @ DocVar(_, _)     => \/-(dv.toJs)
+
+      // NB: matches the pattern the planner generates for converting epoch time
+      // values to timestamps. Adding numbers to dates works in ExprOp, but not
+      // in Javacript.
+      case Add(Literal(Bson.Date(inst)), r) if inst.toEpochMilli == 0 =>
+        expr1(r)(x => JsCore.New("Date", List(x)).fix)
+
       case Add(l, r)             => binop(JsCore.Add, l, r)
       case Divide(l, r)          => binop(JsCore.Div, l, r)
       case Eq(l, r)              => binop(JsCore.Eq, l, r)

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -688,6 +688,8 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
                 pad3(JsCore.Call(JsCore.Select(JsCore.Ident("t").fix, "getUTCMilliseconds").fix, Nil).fix))).fix))))
         }
 
+        case `ToTimestamp` => expr1(ExprOp.Add(ExprOp.Literal(Bson.Date(Instant.ofEpochMilli(0))), _))
+
         case `ToId`         => lift(args match {
           case a1 :: Nil =>
             HasText(a1).flatMap(str => BsonCodec.fromData(Data.Id(str)).map(WorkflowBuilder.pure)) <+>

--- a/core/src/test/scala/slamdata/engine/debug.scala
+++ b/core/src/test/scala/slamdata/engine/debug.scala
@@ -96,6 +96,15 @@ class RenderedTreeSpec extends Specification {
                               Nil)
     }
 
+    "find different nodeType (compound type; no labels)" in {
+      val t1 = NonTerminal(List("root"), None, Terminal(List("red", "color"), None) :: Terminal(List("green", "color"), None) :: Nil)
+      val t2 = NonTerminal(List("root"), None, Terminal(List("red", "color"), None) :: Terminal(List("blue", "color"), None) :: Nil)
+      t1.diff(t2) must_== NonTerminal(List("root"), None,
+                            Terminal(List("red", "color"), None) ::
+                            Terminal(List(">>> green", "color"), None) ::
+                              Terminal(List("<<< blue", "color"), None) ::
+                              Nil)
+    }
   }
 
   "RenderedTreeEncodeJson" should {

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/exprop.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/exprop.scala
@@ -4,7 +4,10 @@ import collection.immutable.ListMap
 
 import org.specs2.mutable._
 
-class ExprOpSpec extends Specification {
+import slamdata.engine.{DisjunctionMatchers}
+import slamdata.engine.fp._
+
+class ExprOpSpec extends Specification with DisjunctionMatchers {
   import ExprOp._
 
   "ExprOp" should {
@@ -65,6 +68,16 @@ class ExprOpSpec extends Specification {
       Workflow.$Redact.PRUNE.bson.repr   must_== "$$PRUNE"
       Workflow.$Redact.KEEP.bson.repr    must_== "$$KEEP"
     }
+  }
 
+  "toJs" should {
+    import org.threeten.bp._
+    import slamdata.engine.javascript.JsFn
+    import slamdata.engine.javascript.JsCore._
+
+    "handle addition with epoch date literal" in {
+      toJs(ExprOp.Add(ExprOp.Literal(Bson.Date(Instant.ofEpochMilli(0))), DocField(BsonField.Name("epoch")))) must beRightDisj(
+        JsFn(JsFn.base, New("Date", List(Select(JsFn.base.fix, "epoch").fix)).fix))
+    }
   }
 }

--- a/it/src/test/resources/tests/convertTimestamp.test
+++ b/it/src/test/resources/tests/convertTimestamp.test
@@ -1,0 +1,13 @@
+{
+  "name": "convert epoch milliseconds value to timestamp",
+
+  "data": "days.data",
+
+  "query": "select \"day\", ts, to_timestamp(epoch) as converted from days where ts = to_timestamp(1408255200000) or to_timestamp(epoch) = timestamp '2014-08-18T07:00:00Z'",
+
+  "predicate": "equalsExactly",
+  "expected": [
+    { "ts": { "$timestamp": "2014-08-17T06:00:00Z" }, "day": "Sunday", "converted": { "$timestamp": "2014-08-17T06:00:00Z" } },
+    { "ts": { "$timestamp": "2014-08-18T07:00:00Z" }, "day": "Monday", "converted": { "$timestamp": "2014-08-18T07:00:00Z" } }
+  ]
+}

--- a/it/src/test/resources/tests/dateFilter.test
+++ b/it/src/test/resources/tests/dateFilter.test
@@ -3,7 +3,7 @@
 
   "data": "days.data",
 
-  "query": "select \"day\" from days where date_part('dow', \"date\") >= 3",
+  "query": "select \"day\" from days where date_part('dow', ts) >= 3",
 
   "predicate": "containsExactly",
 

--- a/it/src/test/resources/tests/days.data
+++ b/it/src/test/resources/tests/days.data
@@ -1,7 +1,7 @@
-{ "_id" : { "$oid" : "54b6f430d4c654959e963a62"}, "date" : { "$timestamp": "2014-08-17T06:00:00Z" }, "day" : "Sunday" }
-{ "_id" : { "$oid" : "54b6f444d4c654959e963a63"}, "date" : { "$timestamp": "2014-08-18T07:00:00Z" }, "day" : "Monday" }
-{ "_id" : { "$oid" : "54b6f4a3d4c654959e963a64"}, "date" : { "$timestamp": "2014-08-19T08:00:00Z" }, "day" : "Tuesday" }
-{ "_id" : { "$oid" : "54b6f4aad4c654959e963a65"}, "date" : { "$timestamp": "2014-08-20T09:00:00Z" }, "day" : "Wednesday" }
-{ "_id" : { "$oid" : "54b6f4b1d4c654959e963a66"}, "date" : { "$timestamp": "2014-08-21T10:00:00Z" }, "day" : "Thursday" }
-{ "_id" : { "$oid" : "54b6f4bad4c654959e963a67"}, "date" : { "$timestamp": "2014-08-22T11:00:00Z" }, "day" : "Friday" }
-{ "_id" : { "$oid" : "54b6f4c3d4c654959e963a68"}, "date" : { "$timestamp": "2014-08-23T12:00:00Z" }, "day" : "Saturday" }
+{ "_id" : { "$oid" : "54b6f430d4c654959e963a62"}, "ts" : { "$timestamp": "2014-08-17T06:00:00Z" }, "epoch": 1408255200000, "day" : "Sunday" }
+{ "_id" : { "$oid" : "54b6f444d4c654959e963a63"}, "ts" : { "$timestamp": "2014-08-18T07:00:00Z" }, "epoch": 1408345200000, "day" : "Monday" }
+{ "_id" : { "$oid" : "54b6f4a3d4c654959e963a64"}, "ts" : { "$timestamp": "2014-08-19T08:00:00Z" }, "epoch": 1408435200000, "day" : "Tuesday" }
+{ "_id" : { "$oid" : "54b6f4aad4c654959e963a65"}, "ts" : { "$timestamp": "2014-08-20T09:00:00Z" }, "epoch": 1408525200000, "day" : "Wednesday" }
+{ "_id" : { "$oid" : "54b6f4b1d4c654959e963a66"}, "ts" : { "$timestamp": "2014-08-21T10:00:00Z" }, "epoch": 1408615200000, "day" : "Thursday" }
+{ "_id" : { "$oid" : "54b6f4bad4c654959e963a67"}, "ts" : { "$timestamp": "2014-08-22T11:00:00Z" }, "epoch": 1408705200000, "day" : "Friday" }
+{ "_id" : { "$oid" : "54b6f4c3d4c654959e963a68"}, "ts" : { "$timestamp": "2014-08-23T12:00:00Z" }, "epoch": 1408795200000, "day" : "Saturday" }

--- a/it/src/test/resources/tests/days.test
+++ b/it/src/test/resources/tests/days.test
@@ -3,7 +3,7 @@
 
   "data": "days.data",
 
-  "query": "select \"day\", date_part('dow', \"date\") as dow, date_part('isodow', \"date\") as isodow from days",
+  "query": "select \"day\", date_part('dow', ts) as dow, date_part('isodow', ts) as isodow from days",
 
   "predicate": "containsExactly",
 

--- a/it/src/test/resources/tests/filterOnDate.test
+++ b/it/src/test/resources/tests/filterOnDate.test
@@ -4,8 +4,8 @@
   "data": "days.data",
 
   "query": "select \"day\" from days
-    where ((\"date\" > date '2014-08-17' and \"date\" <= date '2014-08-20') and \"date\" != date '2014-08-19')
-    or \"date\" = date '2014-08-22'",
+    where ((ts > date '2014-08-17' and ts <= date '2014-08-20') and ts != date '2014-08-19')
+    or ts = date '2014-08-22'",
 
   "predicate": "containsExactly",
   "expected": [

--- a/it/src/test/resources/tests/time.test
+++ b/it/src/test/resources/tests/time.test
@@ -3,8 +3,8 @@
 
   "data": "days.data",
 
-  "query": "select \"day\", time_of_day(\"date\") as tod, time_of_day(\"day\") as \"not a date\", time_of_day(missing) as missing from days
-    where time_of_day(\"date\") >= time '08:00' and time_of_day(\"date\") < time '10:20:30.400'",
+  "query": "select \"day\", time_of_day(ts) as tod, time_of_day(\"day\") as \"not a date\", time_of_day(missing) as missing from days
+    where time_of_day(ts) >= time '08:00' and time_of_day(ts) < time '10:20:30.400'",
 
   "predicate": "containsExactly",
   "expected": [

--- a/it/src/test/resources/tests/timestampsAndIntervals.test
+++ b/it/src/test/resources/tests/timestampsAndIntervals.test
@@ -3,10 +3,10 @@
 
   "data": "days.data",
 
-  "query": "select \"day\", (\"date\" - timestamp '2014-08-17T00:00:00.000Z') / interval 'PT1H0M0S' as hoursSinceSunday
+  "query": "select \"day\", (ts - timestamp '2014-08-17T00:00:00.000Z') / interval 'PT1H0M0S' as hoursSinceSunday
             from days
-            where \"date\" < timestamp '2014-08-17T12:00:00Z'
-              or \"date\" - interval 'PT12H' > timestamp '2014-08-22T00:00:00Z'",
+            where ts < timestamp '2014-08-17T12:00:00Z'
+              or ts - interval 'PT12H' > timestamp '2014-08-22T00:00:00Z'",
 
   "predicate": "containsExactly",
 


### PR DESCRIPTION
Compiles to an exprop adding the value to the constant 1970-01-01. However,
since that doesn't work in JavaScript, that pattern is detected and translated
to `new Date(_)` when it ends up being part of a map op.

Also fixed `RenderTree.diff` which was producing very confusing labels.