### PR TITLE
various fixes related to MOVE (fixes #711)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,8 @@ import sbt._
 import Keys._
 
 val scalazVersion     = "7.1.0"
-val monocleVersion    = "0.5.0"
+val monocleVersion    = "1.1.1"
+val http4sVersion     = "0.7.0"
 val unfilteredVersion = "0.8.1"
 
 lazy val standardSettings = Defaults.defaultSettings ++ Seq(
@@ -45,17 +46,17 @@ lazy val standardSettings = Defaults.defaultSettings ++ Seq(
   libraryDependencies ++= Seq(
     "org.scalaz"        %% "scalaz-core"               % scalazVersion     % "compile, test",
     "org.scalaz"        %% "scalaz-concurrent"         % scalazVersion     % "compile, test",
-    "org.scalaz.stream" %% "scalaz-stream"             % "0.6a"            % "compile, test",
+    "org.scalaz.stream" %% "scalaz-stream"             % "0.7a"            % "compile, test",
     "org.spire-math"    %% "spire"                     % "0.8.2"           % "compile, test",
     "com.github.julien-truffaut" %% "monocle-core"     % monocleVersion    % "compile, test",
     "com.github.julien-truffaut" %% "monocle-generic"  % monocleVersion    % "compile, test",
     "com.github.julien-truffaut" %% "monocle-macro"    % monocleVersion    % "compile, test",
     "org.threeten"      %  "threetenbp"                % "1.2"             % "compile, test",
     "org.mongodb"       %  "mongo-java-driver"         % "3.0.0-rc0"       % "compile, test",
-    "org.http4s"        %% "http4s-dsl"                % "0.6.5"           % "compile, test",
-    "org.http4s"        %% "http4s-argonaut"           % "0.6.5"           % "compile, test",
-    "org.http4s"        %% "http4s-jetty"              % "0.6.5"           % "compile, test",
-    "io.argonaut"       %% "argonaut"                  % "6.1-M5"          % "compile, test",
+    "org.http4s"        %% "http4s-dsl"                % http4sVersion     % "compile, test",
+    "org.http4s"        %% "http4s-argonaut"           % http4sVersion     % "compile, test",
+    "org.http4s"        %% "http4s-jetty"              % http4sVersion     % "compile, test",
+    "io.argonaut"       %% "argonaut"                  % "6.1-M6"          % "compile, test",
     "org.jboss.aesh"    %  "aesh"                      % "0.55"            % "compile, test",
     "org.scalaz"        %% "scalaz-scalacheck-binding" % scalazVersion     % "compile, test",
     "com.github.julien-truffaut" %% "monocle-law"      % monocleVersion    % "compile, test",

--- a/core/src/main/scala/slamdata/engine/fs/path.scala
+++ b/core/src/main/scala/slamdata/engine/fs/path.scala
@@ -24,7 +24,7 @@ final case class Path private (dir: List[DirNode], file: Option[FileNode]) {
 
   def dirOf: Path = copy(file = None)
 
-  def fileOf: Path = copy(dir = Nil)
+  def fileOf: Path = copy(dir = List(DirNode.Current))
 
   def parent: Path = if (pureDir) Path(dir.dropRight(1), None) else dirOf
 

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/mapreduce.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/mapreduce.scala
@@ -3,7 +3,7 @@ package slamdata.engine.physical.mongodb
 import collection.immutable.ListMap
 
 import scalaz._
-import monocle.Macro._
+import monocle.macros.{GenLens}
 import com.mongodb._
 
 import slamdata.engine.javascript._
@@ -78,14 +78,14 @@ object MapReduce {
     def bson(dst: Collection) = Bson.Doc(ListMap("inline" -> Bson.Int64(1)))
   }
 
-  val _map       = mkLens[MapReduce, Js.Expr]("map")
-  val _reduce    = mkLens[MapReduce, Js.Expr]("reduce")
-  val _out       = mkLens[MapReduce, Option[Output]]("out")
-  val _selection = mkLens[MapReduce, Option[Selector]]("selection")
-  val _inputSort = mkLens[MapReduce, Option[NonEmptyList[(BsonField, SortType)]]]("inputSort")
-  val _limit     = mkLens[MapReduce, Option[Long]]("limit")
-  val _finalizer = mkLens[MapReduce, Option[Js.Expr]]("finalizer")
-  val _scope     = mkLens[MapReduce, Scope]("scope")
-  val _jsMode    = mkLens[MapReduce, Option[Boolean]]("jsMode")
-  val _verbose   = mkLens[MapReduce, Option[Boolean]]("verbose")
+  val _map       = GenLens[MapReduce](_.map)
+  val _reduce    = GenLens[MapReduce](_.reduce)
+  val _out       = GenLens[MapReduce](_.out)
+  val _selection = GenLens[MapReduce](_.selection)
+  val _inputSort = GenLens[MapReduce](_.inputSort)
+  val _limit     = GenLens[MapReduce](_.limit)
+  val _finalizer = GenLens[MapReduce](_.finalizer)
+  val _scope     = GenLens[MapReduce](_.scope)
+  val _jsMode    = GenLens[MapReduce](_.jsMode)
+  val _verbose   = GenLens[MapReduce](_.verbose)
 }

--- a/web/src/test/scala/slamdata/engine/api/fs.scala
+++ b/web/src/test/scala/slamdata/engine/api/fs.scala
@@ -236,6 +236,27 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
     }
 
+    "be 404 for file with same name as existing directory (minus the trailing slash)" in {
+      withServer(backends1) {
+        val path = root / "foo"
+        val meta = Http(path > code)
+
+        meta() must_== 404
+      }
+    }
+
+    "be empty for file" in {
+      withServer(backends1) {
+        val path = root / "foo" / "bar"
+        val meta = Http(path OK asJson)
+
+        meta() must beRightDisj((
+          jsonContentType,
+          List(
+            Json())))
+      }
+    }
+
   }
 
   "/data/fs" should {


### PR DESCRIPTION
Update http4s dependency to 0.7, and update lens construction for Monocle 1.1.0.

Pass paths through as is, now that http4s preserves trailing slashes.

Treat the destination for MOVE as a directory path if the source is a
directory path.

Fix `Path.fileOf`, which was always producing a non-relative path (like
`/foo`), which makes no sense. Of course, no one was calling it.

Do something reasonable in GET /metadata with non-dir path (return 200 with
an empty object in the body).

Add a test for the error that occurs when you try to move a file on top of
an existing file.

Note: it would be great to have unit tests for the API doing the right
effects, but that's challenging given that those effects are hidden inside
Task[Unit]. I don't want to mock the filesystem statefully, so I'm settling
for testing around those effects. Perhaps we need a free algebra for
actions on the (generic) filesystem, the same way we need a free algebra
for actions on MongoDB specifically.