### PR TITLE
test against multiple mongodb versions in travis (currently 2.6.9 and 3.0.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ scala:
   - 2.11.4
 sudo: false
 before_install:
-  - "./scripts/installMongo"
-  - "export PATH=$HOME/mongo:$PATH"
+  - "./scripts/installMongo mongodb-linux-x86_64-2.6.9 mongo2.6 27018"
+  - "./scripts/installMongo mongodb-linux-x86_64-3.0.3 mongo3.0 27019"
 script:         "./scripts/build"
 after_success:  "./scripts/buildSuccess"
 after_failure:  "./scripts/buildFailure"
@@ -14,6 +14,6 @@ notifications:
       - "chat.freenode.net#slamdata"
     template:
       - "%{result}: %{repository_slug}#%{build_number} (%{branch}@%{commit}: %{author}) %{build_url}"
-env: 
+env:
   global:
     - LOCAL_MONGODB=true

--- a/it/src/test/resources/tests/LocationCount.test
+++ b/it/src/test/resources/tests/LocationCount.test
@@ -1,6 +1,6 @@
 {
     "name": "job postings by city ",
-    "backends": { "mongodb": "pending" },
+    "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending" },
     "data": "jobs_jobinfo.data",
     "query": "select count(PositionHeader.PositionLocation.LocationCity) as counter,
               PositionHeader.PositionLocation.LocationCity as location

--- a/it/src/test/resources/tests/filterOnOid.test
+++ b/it/src/test/resources/tests/filterOnOid.test
@@ -1,10 +1,6 @@
 {
   "name": "match on ObjectId",
 
-  "backends": {
-    "mongodb": "verify"
-  },
-
   "data": "days.data",
 
   "query": "select \"day\" from days where _id = oid '54b6f430d4c654959e963a62'",

--- a/it/src/test/resources/tests/idNotAliased.test
+++ b/it/src/test/resources/tests/idNotAliased.test
@@ -1,6 +1,6 @@
 {
     "name": "select _id explicitly",
-    "backends": { "mongodb": "pending" },
+    "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending" },
     "data": "zips.data",
     "query": "select _id from zips where city = 'BOULDER' and state = 'CO'",
     "predicate": "containsExactly",

--- a/it/src/test/resources/tests/null/nullTestExprsWithMissing.test
+++ b/it/src/test/resources/tests/null/nullTestExprsWithMissing.test
@@ -1,6 +1,6 @@
 {
     "name": "expressions with `= null` and `is null`, with missing fields (pending #465)",
-    "backends": { "mongodb": "pending" },
+    "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending" },
     "data": "nullsWithMissing.data",
     "query": "select name,
                      val, val = null, val is null, val is not null,

--- a/it/src/test/resources/tests/servlet.test
+++ b/it/src/test/resources/tests/servlet.test
@@ -1,6 +1,6 @@
 {
     "name": "servlets with and without init-param (pending #465, #467)",
-    "backends": { "mongodb": "pending" },
+    "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending" },
     "data": "webapp.data",
     "query": "select \"servlet-name\", \"init-param\" is not null from webapp where \"init-param\" is null or \"init-param\".\"betaServer\"",
     "predicate": "containsExactly",

--- a/it/src/test/resources/tests/simpleProjectWithOneRenamed.test
+++ b/it/src/test/resources/tests/simpleProjectWithOneRenamed.test
@@ -1,9 +1,7 @@
 {
   "name": "simple $project with one renamed field and one unchanged (see #598)",
 
-  "backends": {
-    "mongodb": "pending"
-  },
+  "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending" },
 
   "data": "zips.data",
 

--- a/it/src/test/resources/tests/tripleFlatten.test
+++ b/it/src/test/resources/tests/tripleFlatten.test
@@ -1,6 +1,6 @@
 {
     "name": "triple flatten with mixed content",
-    "backends": { "mongodb": "pending" },
+    "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending" },
     "note": "We should end up with just the most-deeply-nested object fields,
              but because flattening in JS is ignorant of array/object
              distinction, we end up including the results of topObj[*]{*}{*},

--- a/scripts/build
+++ b/scripts/build
@@ -38,12 +38,14 @@ cp "$SLAM_WEB_JAR_PATH" "$SLAM_TEMP_JAR"
 if [[ ${LOCAL_MONGODB:-} == "true" ]] ; then
   echo "Using local MongoDB config"
 
-  export SLAMDATA_MONGODB='{"mongodb": {"connectionUri": "mongodb://localhost/test"}}'
+  export SLAMDATA_MONGODB_2_6='{"mongodb": {"connectionUri": "mongodb://localhost:27018/test"}}'
+  export SLAMDATA_MONGODB_3_0='{"mongodb": {"connectionUri": "mongodb://localhost:27019/test"}}'
 
   # TODO: Move to code
   echo "Importing zips data set for integration tests"
 
-  mongoimport -h localhost --db test --collection zips --file "$WS_DIR/it/src/test/resources/tests/zips.data"
+  mongo2.6/bin/mongoimport -h localhost:27018 --db test --collection zips --file "$WS_DIR/it/src/test/resources/tests/zips.data"
+  mongo3.0/bin/mongoimport -h localhost:27019 --db test --collection zips --file "$WS_DIR/it/src/test/resources/tests/zips.data"
 fi
 
 # Build and run all tests everywhere (including integration)

--- a/scripts/installMongo
+++ b/scripts/installMongo
@@ -6,7 +6,10 @@ IFS=$'\n\t'       # http://redsymbol.net/articles/unofficial-bash-strict-mode/
 # is not available on Travis' new Docker-based platform.
 # TODO: This won't be necessary when travis switches to 2.6 by default - see https://github.com/travis-ci/travis-ci/issues/2246
 
-MONGO_VERSION=mongodb-linux-x86_64-2.6.6
+MONGO_VERSION=$1
+MONGO_DIR=$2
+MONGO_PORT=$3
+
 CACHE_DIR=cache
 
 mkdir -p $CACHE_DIR
@@ -17,9 +20,9 @@ then
 fi
 
 tar -zxf $CACHE_DIR/$MONGO_VERSION.tgz
-mv $MONGO_VERSION mongo
+mv $MONGO_VERSION $MONGO_DIR
 
-mkdir -p mongodata
-mongo/bin/mongod --dbpath mongodata > /dev/null &
+mkdir -p $MONGO_DIR-data
+$MONGO_DIR/bin/mongod --dbpath $MONGO_DIR-data --port $MONGO_PORT > /dev/null &
 
 sleep 5s


### PR DESCRIPTION
There are now two backends configured for the regression tests. By default,
mongodb_2_6 points to the mongolab instance, and mongodb_3_0 is disabled. When
running in Travis, each version is downloaded and installed locally, running
on separate ports.

If you've been running against a local instance, just update your env variable
from `SLAMDATA_MONGODB` to `SLAMDATA_MONGODB_2_6`.