### PR TITLE
better communication about INTERVAL formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ set       | `[1, 2, 3]`     | `{ "$set": [1, 2, 3] }` |
 timestamp | `"2015-01-31T10:30:00Z"` | `{ "$timestamp": "2015-01-31T10:30:00Z" }` |
 date      | `"2015-01-31"`  | `{ "$date": "2015-01-31" }` |
 time      | `"10:30:05"`    | `{ "$time": "10:30:05" }` | HH:MM[:SS[:.SSS]]
-interval  | `"PT12H34M"`    | `{ "$interval": "PT12H34M" }` |
+interval  | `"PT12H34M"`    | `{ "$interval": "P7DT12H34M" }` | Note: year/month not currently supported.
 binary    | `"TE1OTw=="`    | `{ "$binary": "TE1OTw==" }` | BASE64-encoded.
 object id | `"abc"`         | `{ "$oid": "abc" }` |
 

--- a/core/src/main/scala/slamdata/engine/errors.scala
+++ b/core/src/main/scala/slamdata/engine/errors.scala
@@ -111,8 +111,8 @@ object SemanticError {
   final case class CompiledSubtableMissing(name: String) extends SemanticError {
     def message = "Expected to find a compiled subtable with name \"" + name + "\""
   }
-  final case class DateFormatError(func: Func, str: String) extends SemanticError {
-    def message = "Date/time string could not be parsed as " + func.name + ": " + str
+  final case class DateFormatError(func: Func, str: String, hint: Option[String]) extends SemanticError {
+    def message = "Date/time string could not be parsed as " + func.name + ": " + str + hint.map(" (" + _ + ")").getOrElse("")
   }
 }
 

--- a/core/src/main/scala/slamdata/engine/std/date.scala
+++ b/core/src/main/scala/slamdata/engine/std/date.scala
@@ -13,23 +13,24 @@ import SemanticError._
 trait DateLib extends Library {
   def parseTimestamp(str: String): SemanticError \/ Data.Timestamp =
     \/.fromTryCatchNonFatal(Instant.parse(str)).bimap(
-      κ(DateFormatError(Timestamp, str)),
+      κ(DateFormatError(Timestamp, str, None)),
       Data.Timestamp.apply)
 
   def parseDate(str: String): SemanticError \/ Data.Date =
     \/.fromTryCatchNonFatal(LocalDate.parse(str)).bimap(
-      κ(DateFormatError(Date, str)),
+      κ(DateFormatError(Date, str, None)),
       Data.Date.apply)
 
   def parseTime(str: String): SemanticError \/ Data.Time =
     \/.fromTryCatchNonFatal(LocalTime.parse(str)).bimap(
-      κ(DateFormatError(Time, str)),
+      κ(DateFormatError(Time, str, None)),
       Data.Time.apply)
 
-  def parseInterval(str: String): SemanticError \/ Data.Interval =
+  def parseInterval(str: String): SemanticError \/ Data.Interval = {
     \/.fromTryCatchNonFatal(Duration.parse(str)).bimap(
-      κ(DateFormatError(Interval, str)),
+      κ(DateFormatError(Interval, str, Some("expected, e.g. P3DT12H30M15.0S; note: year/month not currently supported"))),
       Data.Interval.apply)
+  }
 
   private def startOfDayInstant(date: LocalDate): Instant =
     date.atStartOfDay.atZone(ZoneOffset.UTC).toInstant
@@ -85,7 +86,7 @@ trait DateLib extends Library {
 
   val Interval = Mapping(
     "interval",
-    "Converts a string literal (ISO 8601, e.g. P1Y6M3DT12H30M15.0S) to an interval constant.",
+    "Converts a string literal (ISO 8601, e.g. P3DT12H30M15.0S) to an interval constant. Note: year/month not currently supported.",
     Type.Str :: Nil,
     partialTyperV {
       case Type.Const(Data.Str(str)) :: Nil => parseInterval(str).map(Type.Const(_)).validation.toValidationNel

--- a/core/src/test/scala/slamdata/engine/std/date.scala
+++ b/core/src/test/scala/slamdata/engine/std/date.scala
@@ -1,0 +1,45 @@
+package slamdata.engine.std
+
+import org.specs2.mutable._
+
+import org.threeten.bp._
+import scalaz._
+
+import slamdata.engine._, SemanticError._
+
+class DateSpecs extends Specification with DisjunctionMatchers {
+  import DateLib._
+
+  "parseInterval" should {
+    def fromMillis(millis: Long) = \/-(Data.Interval(Duration.ofMillis(millis)))
+
+    def hms(hours: Int, minutes: Int, seconds: Int, millis: Int) =
+      fromMillis((((hours.toLong*60) + minutes)*60 + seconds)*1000 + millis)
+
+    "parse millis" in {
+      parseInterval("PT0.001S") must_== fromMillis(1)
+    }
+
+    "parse negative parts" in {
+      parseInterval("PT-1H-1M-1S") must_== hms(-1, -1, -1, 0)
+    }
+
+    "parse fractional parts" in {
+      // The spec says "the smallest value may have a decimal fraction"
+      parseInterval("PT1.5H") must_== hms(1, 30, 0, 0)
+      parseInterval("PT5H1.5M") must_== hms(5, 1, 30, 0)
+    }.pendingUntilFixed("#718")
+
+    "parse days" in {
+      parseInterval("P1D") must_== hms(24, 0, 0, 0)
+    }
+
+    "parse ymd" in {
+      val msg = parseInterval("P1Y1M1D") match {
+        case -\/(DateFormatError(_, _, hint)) => hint
+        case _ => None
+      }
+      msg must beSome.which(_ contains "year/month not currently supported")
+    }
+  }
+}


### PR DESCRIPTION
Year/month don't work, so:
- correct the documentation for the conversion Func
- improve the resulting error's message
- add a note to README.md
- some tests for the current state of things

See #717 and #718.