### PR TITLE
Produce CSV output with "Accept: text/csv" header (first part of #645)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The server provides a simple JSON API.
 
 Executes a SQL query, contained in the single, required query parameter, on the backend responsible for the request path.
 
-The result is returned in the response body, formatted as one JSON object per line. By default, the “readable” JSON format (described below) is returned, but the “precise” format can be requested by including a header like `Accept: application/ldjson;mode=precise`.
+The result is returned in the response body, formatted as one JSON object per line. By default, the “readable” JSON format (described below) is returned, but an `Accept` header may be specified: `Accept: application/ldjson;mode=precise` for “precise” JSON or `Accept: text/csv` for comma-separated.
 
 SQL `limit` syntax may be used to keep the result size reasonable.
 
@@ -322,7 +322,7 @@ Retrieves metadata about the files, directories, and mounts at the specified pat
 
 ### GET /data/fs/[path]?offset=[offset]&limit=[limit]
 
-Retrieves data from the specified path, formatted as one JSON object per line. The `offset` and `limit` parameters are optional, and may be used to page through results.
+Retrieves data from the specified path, formatted as one object per line in JSON or CSV format. The `offset` and `limit` parameters are optional, and may be used to page through results.
 
 ```json
 {"id":0,"guid":"03929dcb-80f6-44f3-a64c-09fc1d810c61","isActive":true,"balance":"$3,244.51","picture":"http://placehold.it/32x32","age":38,"eyeColor":"green","latitude":87.709281,"longitude":-20.549375}

--- a/admin/src/main/scala/slamdata/engine/admin/admin.scala
+++ b/admin/src/main/scala/slamdata/engine/admin/admin.scala
@@ -266,7 +266,7 @@ class AdminUI(configPath: Option[String]) {
       dialog.setVisible(true)
         ignore((Option(dialog.getDirectory) |@| Option(dialog.getFile)){ (dir, file) =>
           val w = fileWriter(dir + "/" + file)
-            w.write(planArea.text)
+          w.write(planArea.text)
           w.close()
         })
     }

--- a/core/src/main/scala/slamdata/engine/repl/prettify.scala
+++ b/core/src/main/scala/slamdata/engine/repl/prettify.scala
@@ -39,6 +39,7 @@ object Prettify {
         }
       data match {
         case Data.Arr(value) =>  \/-(value.zipWithIndex.flatMap { case (c, i) => prepend(IndexSeg(i), c) })
+        case Data.Set(value) =>  \/-(value.zipWithIndex.flatMap { case (c, i) => prepend(IndexSeg(i), c) })
         case Data.Obj(value) =>  \/-(value.toList.flatMap { case (f, c) => prepend(FieldSeg(f), c) })
         case _               => -\/ (data)
       }
@@ -81,7 +82,10 @@ object Prettify {
 
       case Data.NA              => "n/a"
 
-      case _ => "unexpected: " + data  // NB: the non-atomic types never appear here because the Data has been flattened
+      // NB: the non-atomic types never appear here because the Data has been
+      // flattened. Str is handled above.
+      case Data.Arr(_) | Data.Set(_) | Data.Obj(_) | Data.Str(_)
+                                => "unexpected: " + data
     })
   }
 
@@ -95,7 +99,8 @@ object Prettify {
     if (rows.isEmpty) Nil
     else {
       val flat = rows.map(flatten)
-      val columnNames = flat.map(_.keys.toList).foldLeft[List[Path]](Nil)(mergePaths)
+      val columnNames0 = flat.map(_.keys.toList).foldLeft[List[Path]](Nil)(mergePaths)
+      val columnNames = if (columnNames0.isEmpty) List(Path(FieldSeg("<empty>"))) else columnNames0
 
       val columns: List[(Path, List[Aligned[String]])] =
         columnNames.map(n => n -> flat.map(m => m.get(n).fold[Aligned[String]](Aligned.Left(""))(render)))
@@ -112,4 +117,51 @@ object Prettify {
           }}.mkString
         }.toList
     }
+
+  import scalaz.concurrent.Task
+  import scalaz.stream._
+
+  /**
+   Render an unbounded series of values to a series of rows, all with the same
+   columns, which are discovered by pre-processing the first `n (>= 1)` values.
+   That means we never have more than `n` values in memory, and for the common
+   case where all values have the same fields, a small value of `n` (even 1)
+   is sufficient. However, if elements contain variable-length arrays/sets and/or
+   objects with varying fields, then values are more likely to be omitted.
+   - The first row is the names of the columns, based on the first `n` values.
+   - Each row contains the "pretty" String values for each of the corresponding
+       fields, if present.
+   - If new fields appear after the first `n` rows, they're ignored.
+   */
+  def renderStream(src: Process[Task, Data], n: Int): Process[Task, List[String]] = {
+    // Combinator that handles sampling the stream, computing some value from the sample,
+    // and emiting a single "header" value, followed by each transformed value. The types
+    // make this look generic, but it's not clear what else this would be useful for.
+    def sampleMap[A, B, C](src: Process[Task, A], n: Int, sample: IndexedSeq[A] => B, prefix: B => C, f: (A, B) => C): Process[Task, C] = {
+      (src.chunk(n) ++ Process.emit(Vector.empty) ++ Process.emit(Vector.empty)).zipWithState[Option[B]](None) { case (as, optB) =>
+        optB.orElse(Some(sample(as)))
+      }.zipWithNext.flatMap {
+        case ((as, b0), Some((_, Some(b)))) =>
+          b0.fold[Process[Task, C]](Process.emit(prefix(b)))(κ(Process.halt)) ++
+            Process.emitAll(as.map(a => f(a, b)))
+        case ((as, _), None) =>
+          if (as.nonEmpty) sys.error("!")
+          Process.halt
+        case (_, Some((_, None))) => sys.error("!")
+      }
+    }
+
+    sampleMap[Data, List[Path], List[String]](
+      src,
+      n max 1,
+      { rows =>
+        val cols = rows.map(flatten(_).keys.toList).foldLeft[List[Path]](Nil)(mergePaths)
+        if (cols.isEmpty) List(Path(FieldSeg("<empty>"))) else cols
+      },
+      _.map(_.label),
+      { (row, cols) =>
+        val flat = flatten(row)
+        cols.map(n => flat.get(n).fold("")(render(_).value))
+      })
+  }
 }

--- a/web/build.sbt
+++ b/web/build.sbt
@@ -1,3 +1,7 @@
 name := "Web"
 
 mainClass in Compile := Some("slamdata.engine.api.Server")
+
+libraryDependencies ++= Seq(
+  "com.github.tototoshi"    %% "scala-csv"         % "1.1.2"
+)

--- a/web/src/main/scala/slamdata/engine/api/fs.scala
+++ b/web/src/main/scala/slamdata/engine/api/fs.scala
@@ -23,32 +23,50 @@ import Scalaz._
 import scalaz.concurrent._
 import scalaz.stream._
 
-class FileSystemApi(fs: FSTable[Backend]) {
-  import Method.{MOVE, OPTIONS}
+sealed trait ResponseFormat {
+  def mediaType: MediaType
+}
+object ResponseFormat {
+  val JsonMediaType = new MediaType("application", "ldjson")
+  val CsvMediaType = new MediaType("text", "csv")
 
-  private def responseCodec(accept: Option[Accept]): (DataCodec, MediaType) = {
-    val jsonTypes = NonEmptyList(
-      new MediaType("application", "ldjson"),
+  final case class Json private[ResponseFormat] (codec: DataCodec, mediaType: MediaType) extends ResponseFormat
+  private def jsonType(mode: String) = JsonMediaType.withExtensions(Map("mode" -> mode))
+  val Precise = Json(DataCodec.Precise, jsonType("precise"))
+  val Readable = Json(DataCodec.Readable, jsonType("readable"))
+
+  case object Csv extends ResponseFormat {
+    val mediaType = CsvMediaType
+  }
+
+  def fromAccept(accept: Option[Accept]): ResponseFormat = {
+    val mediaTypes = NonEmptyList(
+      JsonMediaType,
       new MediaType("application", "x-ldjson"),
       new MediaType("application", "json",
-        extensions = Map("boundary" -> "NL")))
-
-    def responseType(mode: String) =
-      jsonTypes.head.withExtensions(jsonTypes.head.extensions ++ Map("mode" -> mode))
+        extensions = Map("boundary" -> "NL")),
+      CsvMediaType)
 
     (for {
       acc       <- accept
       // TODO: MediaRange needs an Order instance – combining QValue ordering
       //       with specificity (EG, application/json sorts before
       //       application/* if they have the same q-value).
-      mediaType <- acc.values.toList.sortBy(_.qValue).find(a => jsonTypes.toList.exists(a.satisfies(_)))
-      mode      <- mediaType.extensions.get("mode")
-      codec     <- mode match {
-        case "precise" => Some((DataCodec.Precise, responseType("precise")))
-        case _         => None
-      }
-    } yield codec).getOrElse((DataCodec.Readable, responseType("readable")))
+      mediaType <- acc.values.toList.sortBy(_.qValue).find(a => mediaTypes.toList.exists(a.satisfies(_)))
+      format    <-
+        if (mediaType satisfies CsvMediaType) Some(Csv)
+        else for {
+          mode <- mediaType.extensions.get("mode")
+          fmt  <- if (mode == "precise") Some(ResponseFormat.Precise) else None
+        } yield fmt
+    } yield format).getOrElse(ResponseFormat.Readable)
   }
+}
+
+class FileSystemApi(fs: FSTable[Backend]) {
+  import Method.{MOVE, OPTIONS}
+
+  val CsvColumnsFromInitialRowsCount = 1000
 
   private def jsonStream(codec: DataCodec, v: Process[Task, Data])(implicit EE: EncodeJson[DataEncodingError]): Task[Response] = {
     Ok(v.map { data =>
@@ -56,10 +74,27 @@ class FileSystemApi(fs: FSTable[Backend]) {
     })
   }
 
+  private def csvStream(v: Process[Task, Data]): Task[Response] = {
+    import slamdata.engine.repl.Prettify
+
+    Ok(Prettify.renderStream(v, CsvColumnsFromInitialRowsCount).map { v =>
+      import com.github.tototoshi.csv._
+      val w = new java.io.StringWriter
+      val cw = CSVWriter.open(w)
+      cw.writeRow(v)
+      cw.close
+      w.toString
+    })
+  }
+
   private def responseStream(accept: Option[Accept], v: Process[Task, Data]):
       Task[Response] = {
-    val (codec, mediaType) = responseCodec(accept)
-    jsonStream(codec, v).map(_.putHeaders(`Content-Type`(mediaType, Some(Charset.`UTF-8`))))
+    ResponseFormat.fromAccept(accept) match {
+      case ResponseFormat.Json(codec, mediaType) =>
+        jsonStream(codec, v).map(_.putHeaders(`Content-Type`(mediaType, Some(Charset.`UTF-8`))))
+      case ResponseFormat.Csv =>
+        csvStream(v).map(_.putHeaders(`Content-Type`(ResponseFormat.Csv.mediaType, Some(Charset.`UTF-8`))))
+    }
   }
 
   private def lookupBackend(path: Path): Task[Response] \/ (Backend, Path, Path) =

--- a/web/src/test/scala/slamdata/engine/api/fs.scala
+++ b/web/src/test/scala/slamdata/engine/api/fs.scala
@@ -339,7 +339,6 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
           val path = root / "foo" / "bar"
           val meta = Http(path.setHeader("Accept", csvContentType) OK asLines)
 
-          println("meta: " + meta()._2.map("[" + _ + "]").mkString("\n"))
           meta() must_==
             csvContentType ->
             List("a,b,c[0]", "1,,", ",2,", ",,3")


### PR DESCRIPTION
Uses the first `n` results (currently 1000) to identify columns, so that the
entire data set is never loaded into memory at once. Uses the same formatting
of values as the REPL and the Admin tool's CSV output.

Because the wrangling of Process was the only tricky bit here, I included a
test that effects are properly sequenced (and executed only once!)

Also fixed a couple of bugs:
- the REPL would give an error if every result object was `{}`
- `Data.Set` was not formatted properly in tabular output.