### PR TITLE
Add an API to manage the engine config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,6 @@ Type `help` for information on other commands.
 
 The server provides a simple JSON API.
 
-
 ### GET /query/fs/[path]?q=[query]
 
 Executes a SQL query, contained in the single, required query parameter, on the backend responsible for the request path.
@@ -356,6 +355,35 @@ Removes all data at the specified path. Single files are deleted atomically.
 Moves data from one path to another within the same backend. The new path must
 be provided in the "Destination" request header. Single files are deleted atomically.
 
+### GET /mount/fs/[path]
+
+Retrieves the configuration for the mount point at the provided path. In the case of MongoDB, the response will look like
+
+```
+{ "mongodb": { "connectionUri": "mongodb://localhost/test" } }
+```
+
+The outer key is the backend in use, and the value is a backend-specific configuration structure.
+
+### POST /mount/fs/[path]
+
+Adds a new mount point using the JSON contained in the body. This will return a 405 Method Not Allowed if the mount point already exists.
+
+### PUT /mount/fs/[path]
+
+Replaces an existing mount point using the JSON contained in the body. This will return 404 Not Found if the mount point doesn’t exist.
+
+### DELETE /mount/fs/[path]
+
+Deletes an existing mount point. This will return 404 Not Found if the mount point doesn’t exist.
+
+### PUT /server/port
+
+Takes a port number in the body, and restarts the server on that port, shutting down the running instance.
+
+### DELETE /server/port
+
+Removes any configured port, reverting to the default (20223) and restarting, as with `POST`.
 
 ## Data Formats
 

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -12,7 +12,7 @@ import ScoverageSbtPlugin._
 
 ScoverageKeys.coverageExcludedPackages := "slamdata.engine.repl;.*RenderTree"
 
-ScoverageKeys.coverageMinimum := 75
+ScoverageKeys.coverageMinimum := 78
 
 ScoverageKeys.coverageFailOnMinimum := true
 

--- a/core/src/main/scala/slamdata/engine/config/config.scala
+++ b/core/src/main/scala/slamdata/engine/config/config.scala
@@ -67,11 +67,9 @@ object MongoDbConfig {
 object BackendConfig {
   implicit def BackendConfig = CodecJson[BackendConfig](
     encoder = _ match {
-      case x : MongoDbConfig => ("mongodb", MongoDbConfig.Codec.encode(x)) ->: jEmptyObject
+      case x @ MongoDbConfig(_) => ("mongodb", MongoDbConfig.Codec.encode(x)) ->: jEmptyObject
     },
-    decoder = { cursor =>
-      cursor.get[MongoDbConfig]("mongodb").map(v => v : BackendConfig)
-    })
+    decoder = _.get[MongoDbConfig]("mongodb").map(v => v: BackendConfig))
 }
 
 final case class Config(
@@ -85,7 +83,7 @@ object Config {
     encoder = map => map.map(t => t._1.pathname -> t._2).asJson,
     decoder = cursor => implicitly[DecodeJson[Map[String, BackendConfig]]].decode(cursor).map(_.map(t => Path(t._1) -> t._2)))
 
-  private def defaultPath: Task[String] = Task.delay {
+  def defaultPath: Task[String] = Task.delay {
     import scala.util.Properties._
 
     val commonPath = "SlamData/slamengine-config.json"

--- a/web/src/main/scala/slamdata/engine/api/fs.scala
+++ b/web/src/main/scala/slamdata/engine/api/fs.scala
@@ -3,6 +3,7 @@ package slamdata.engine.api
 import scala.collection.immutable.{TreeSet}
 
 import slamdata.engine._
+import slamdata.engine.config._
 import slamdata.engine.sql.Query
 import slamdata.engine.fs._
 import slamdata.engine.fp._
@@ -50,11 +51,9 @@ class FileSystemApi(fs: FSTable[Backend]) {
     } yield codec).getOrElse((DataCodec.Readable, responseType("readable")))
   }
 
-  private def jsonStream(codec: DataCodec, v: Process[Task, Data])(implicit EE: EncodeJson[DataEncodingError]): Task[Response] = {
-    Ok(v.map { data =>
-      DataCodec.render(data)(codec).fold(err => EE.encode(err).toString, identity) + "\r\n"
-    })
-  }
+  private def jsonStream(codec: DataCodec, v: Process[Task, Data])(implicit EE: EncodeJson[DataEncodingError]): Task[Response] =
+    Ok(v.map(
+      DataCodec.render(_)(codec).fold(EE.encode(_).toString, identity) + "\r\n"))
 
   private def responseStream(accept: Option[Accept], v: Process[Task, Data]):
       Task[Response] = {
@@ -208,6 +207,69 @@ class FileSystemApi(fs: FSTable[Backend]) {
         query <- EntityDecoder.decodeString(req)
         resp  <- if (query != "") go(path, Query(query)) else POSTContentMustContainQuery
       } yield resp
+    }
+  }
+
+  def serverService(config: Config, reloader: Config => Task[Unit]) = {
+    corsService {
+      case req @ PUT -> Root / "port" => for {
+        body <- EntityDecoder.decodeString(req)
+        r    <- body.parseInt.fold(
+          e => NotFound(e.getMessage),
+          i => for {
+            _    <- reloader(config.copy(server = SDServerConfig(Some(i))))
+            resp <- Ok("changed port to " + i)
+          } yield resp)
+      } yield r
+      case DELETE -> Root / "port" => for {
+        _    <- reloader(config.copy(server = SDServerConfig(None)))
+        resp <- Ok("reverted to default port")
+      } yield resp
+    }
+  }
+
+  def mountService(config: Config, reloader: Config => Task[Unit]) = {
+    def addPath(path: Path, req: Request): Task[Unit] = for {
+      body <- EntityDecoder.decodeString(req)
+      conf <- Parse.decodeEither[BackendConfig](body).fold(
+        e => Task.fail(new RuntimeException(e)),
+        Task.now)
+      _    <- reloader(config.copy(mountings = config.mountings + (path -> conf)))
+    } yield ()
+
+    corsService {
+      case GET -> AsPath(path) =>
+        config.mountings.find { case (k, _) => k.equals(path) }.fold(
+          NotFound("There is no mount point at " + path))(
+          v => Ok(BackendConfig.BackendConfig.encode(v._2).pretty(slamdata.engine.fp.multiline)))
+      case req @ POST -> AsPath(path) =>
+        def addMount = for {
+          _    <- addPath(path, req)
+          resp <- Ok("added " + path)
+        } yield resp
+        config.mountings.find { case (k, _) => k.contains(path) }.fold(
+          addMount) {
+          case (k, v) =>
+            // TODO: make sure path+resource doesn’t conflict, too
+            if (k.equals(path))
+              MethodNotAllowed("There’s already a mount point at " + path)
+            else
+              addMount
+        }
+      case req @ PUT -> AsPath(path) =>
+        if (config.mountings.contains(path))
+          NotFound("There is no mount point at " + path)
+        else for {
+          _    <- addPath(path, req)
+          resp <- Ok("updated " + path)
+        } yield resp
+      case DELETE -> AsPath(path) =>
+        if (config.mountings.contains(path))
+          NotFound("There is no mount point at " + path)
+        else for {
+          _    <- reloader(config.copy(mountings = config.mountings - path))
+          resp <- Ok("deleted " + path)
+        } yield resp
     }
   }
 

--- a/web/src/test/scala/slamdata/engine/api/fs.scala
+++ b/web/src/test/scala/slamdata/engine/api/fs.scala
@@ -2,6 +2,7 @@ package slamdata.engine.api
 
 import slamdata.engine._
 import slamdata.engine.analysis.fixplate.{Term}
+import slamdata.engine.config._
 import slamdata.engine.fp._
 import slamdata.engine.fs._
 
@@ -30,7 +31,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
   down the server.
   */
   def withServer[A](fs: Map[Path, Backend])(body: => A): A = {
-    val srv = Server.run(port, FSTable(fs), ".").run
+    val srv = Server.run(port, FSTable(fs), ".", Config.empty, None).run
 
     try {
       body


### PR DESCRIPTION
Adds two new services – one for configuring mount points, and one for
the port.

Fixes #182.

There is some … non-FP code in server.scala. I’m happy if anyone can push it toward more FP.