### PR TITLE
accept uploaded (standard) CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ be provided in the "Destination" request header. Single files are deleted atomic
 
 ## Data Formats
 
-SlamEngine produces and accepts data in two JSON-based formats. Each format is valid JSON, and can
+SlamEngine produces and accepts data in two JSON-based formats or CSV. Each JSON-based format can
 represent all the types of data that SlamEngine supports. The two formats are appropriate for
 different purposes.
 
@@ -375,7 +375,7 @@ extra information that can make it harder to read.
 This format is easy to read and use with other tools, and contains minimal extra information.
 It does not always convey the precise type of the source data, and does not allow all values
 to be specified. For example, it's not possible to tell the difference between the string
-`"12:34"` and the time value equal to 34 minutes after noon.
+`"12:34:56"` and the time value equal to 34 minutes and 56 seconds after noon.
 
 
 ### Examples
@@ -397,6 +397,20 @@ time      | `"10:30:05"`    | `{ "$time": "10:30:05" }` | HH:MM[:SS[:.SSS]]
 interval  | `"PT12H34M"`    | `{ "$interval": "P7DT12H34M" }` | Note: year/month not currently supported.
 binary    | `"TE1OTw=="`    | `{ "$binary": "TE1OTw==" }` | BASE64-encoded.
 object id | `"abc"`         | `{ "$oid": "abc" }` |
+
+
+### CSV
+
+When SlamData produces CSV, all fields and array elements are "flattened" so that each column in the output contains the data for a single location in the source document. For example, the document `{ "foo": { "bar": 1, "baz": 2 } }` becomes
+
+```
+foo.bar,foo.baz
+1,2
+```
+
+Data is formatted the same way as the "Readable" JSON format, except that all values including `null`, `true`, `false`, and numbers are indistinguishable from their string representations.
+
+When data is uploaded in CSV format, the headers are interpreted as field names in the same way. As with the Readable JSON format, any string that can be interpreted as another kind of value will be, so for example there's no way to specify the string `"null"`.
 
 
 ## Troubleshooting

--- a/admin/src/main/scala/slamdata/engine/admin/config.scala
+++ b/admin/src/main/scala/slamdata/engine/admin/config.scala
@@ -56,7 +56,7 @@ class ConfigDialog(parent: Window, configPath: Option[String]) extends Dialog(pa
   private lazy val cancelAction = Action("Cancel") { dispose }
   private lazy val saveAction = Action("Save") {
     config = for {
-      port <- \/.fromTryCatchNonFatal(portField.text.toInt).toOption
+      port <- parseInt(portField.text)
       mountings = mountTM.validMounts
     } yield Config(SDServerConfig(Some(port)), Map(mountings: _*))
     config.foreach(cfg => async(Config.write(cfg, configPath))(_.fold(

--- a/admin/src/main/scala/slamdata/engine/admin/config.scala
+++ b/admin/src/main/scala/slamdata/engine/admin/config.scala
@@ -5,9 +5,10 @@ import scala.swing.event._
 import Swing._
 
 import scalaz._
-import Scalaz._
+import Scalaz.{parseInt => _, _}
 
 import slamdata.engine.{Backend, Mounter}
+import slamdata.engine.fp._
 import slamdata.engine.fs.Path
 import slamdata.engine.config._
 

--- a/core/src/main/scala/slamdata/engine/fp/package.scala
+++ b/core/src/main/scala/slamdata/engine/fp/package.scala
@@ -285,11 +285,25 @@ package object fp extends TreeInstances with ListMapInstances with ToTaskOps wit
     def tailOption = c.headOption map κ(c.drop(1))
   }
 
-  def unzipDisj[A, B](ds: List[A \/ B]): (List[A], List[B]) =
-    ds.foldLeft((List[A](), List[B]())) {
+  def unzipDisj[A, B](ds: List[A \/ B]): (List[A], List[B]) = {
+    val (as, bs) = ds.foldLeft((List[A](), List[B]())) {
       case ((as, bs), -\/ (a)) => (a :: as, bs)
       case ((as, bs),  \/-(b)) => (as, b :: bs)
     }
+    (as.reverse, bs.reverse)
+  }
+
+  def parseInt(str: String): Option[Int] =
+    \/.fromTryCatchNonFatal(str.toInt).toOption
+
+  def parseBigInt(str: String): Option[BigInt] =
+    \/.fromTryCatchNonFatal(BigInt(str)).toOption
+
+  def parseDouble(str: String): Option[Double] =
+    \/.fromTryCatchNonFatal(str.toDouble).toOption
+
+  def parseBigDecimal(str: String): Option[BigDecimal] =
+    \/.fromTryCatchNonFatal(BigDecimal(str)).toOption
 
   /**
    Accept a value (forcing the argument expression to be evaluated for its effects),

--- a/core/src/test/scala/slamdata/engine/codec.scala
+++ b/core/src/test/scala/slamdata/engine/codec.scala
@@ -208,7 +208,7 @@ class DataCodecSpecs extends Specification with ScalaCheck with DisjunctionMatch
       Data.Date(LocalDate.now),
       Data.Time(LocalTime.now),
       Data.Binary(Array[Byte](0, 1, 2, 3)),
-      Data.Id("012345678901234567890123"),  // NB: a (nominally) valid MongoDB id, because we use this generator to test BSON conversion, too
+      Data.Id("123456789012345678901234"),  // NB: a (nominally) valid MongoDB id, because we use this generator to test BSON conversion, too
       Data.NA,
 
       // Tricky cases:

--- a/core/src/test/scala/slamdata/engine/repl/prettify.scala
+++ b/core/src/test/scala/slamdata/engine/repl/prettify.scala
@@ -2,7 +2,6 @@ package slamdata.engine.repl
 
 import org.specs2.mutable._
 import org.specs2.ScalaCheck
-import org.scalacheck._
 
 import scala.collection.immutable.ListMap
 import org.threeten.bp._

--- a/core/src/test/scala/slamdata/engine/repl/prettify.scala
+++ b/core/src/test/scala/slamdata/engine/repl/prettify.scala
@@ -1,13 +1,17 @@
 package slamdata.engine.repl
 
 import org.specs2.mutable._
+import org.specs2.ScalaCheck
+import org.scalacheck._
 
 import scala.collection.immutable.ListMap
 import org.threeten.bp._
 
+import scalaz._
+
 import slamdata.engine._
 
-class PrettifySpecs extends Specification {
+class PrettifySpecs extends Specification with ScalaCheck with DisjunctionMatchers  {
   import Prettify._
 
   "flatten" should {
@@ -60,9 +64,123 @@ class PrettifySpecs extends Specification {
     }
   }
 
-  "render" should {
-    implicit val codec = DataCodec.Readable
+  "unflatten" should {
+    "construct flat fields" in {
+      val flat = ListMap(
+        Path(FieldSeg("a")) -> Data.Int(1),
+        Path(FieldSeg("b")) -> Data.Int(2))
+      unflatten(flat) must_== Data.Obj(ListMap(
+        "a" -> Data.Int(1),
+        "b" -> Data.Int(2)))
+    }
 
+    "construct single nested field" in {
+      val flat = ListMap(
+        Path(FieldSeg("foo"), FieldSeg("bar")) -> Data.Int(1))
+      unflatten(flat) must_== Data.Obj(ListMap(
+        "foo" -> Data.Obj(ListMap(
+          "bar" -> Data.Int(1)))))
+    }
+
+    "construct array with missing elements" in {
+      val flat = ListMap(
+        Path(FieldSeg("a"), IndexSeg(0)) -> Data.Int(1),
+        Path(FieldSeg("a"), IndexSeg(2)) -> Data.Int(3))
+      unflatten(flat) must_==
+        Data.Obj(ListMap(
+          "a" -> Data.Arr(List(
+            Data.Int(1), Data.Null, Data.Int(3)))))
+    }
+
+    "construct array with nested fields" in {
+      val flat = ListMap(
+        Path(FieldSeg("a"), IndexSeg(0), FieldSeg("foo"), FieldSeg("bar")) -> Data.Int(1),
+        Path(FieldSeg("a"), IndexSeg(2), FieldSeg("foo"), FieldSeg("bar")) -> Data.Int(3),
+        Path(FieldSeg("a"), IndexSeg(2), FieldSeg("foo"), FieldSeg("baz")) -> Data.Int(4))
+      unflatten(flat) must_==
+        Data.Obj(ListMap(
+          "a" -> Data.Arr(List(
+            Data.Obj(ListMap(
+              "foo" -> Data.Obj(ListMap(
+                "bar" -> Data.Int(1))))),
+            Data.Null,
+            Data.Obj(ListMap(
+              "foo" -> Data.Obj(ListMap(
+                "bar" -> Data.Int(3),
+                "baz" -> Data.Int(4)))))))))
+    }
+
+    "construct obj with populated contradictory paths" in {
+      val flat = ListMap(
+        Path(FieldSeg("foo"), IndexSeg(0)) -> Data.Int(1),
+        Path(FieldSeg("foo"), FieldSeg("bar")) -> Data.Int(2))
+      unflatten(flat) must_==
+        Data.Obj(ListMap(
+          "foo" -> Data.Arr(List(
+            Data.Int(1)))))
+    }
+  }
+
+  "Path.label" should {
+    "nested fields" in {
+      Path(FieldSeg("foo"), FieldSeg("bar")).label must_== "foo.bar"
+    }
+
+    "index at root" in {
+      Path(IndexSeg(0)).label must_== "[0]"
+    }
+
+    "index in the middle" in {
+      Path(FieldSeg("foo"), IndexSeg(0), FieldSeg("bar")).label must_== "foo[0].bar"
+    }
+
+    "nested indices" in {
+      Path(FieldSeg("matrix"), IndexSeg(0), IndexSeg(1)).label must_== "matrix[0][1]"
+    }
+
+    "escape special chars" in {
+      Path(FieldSeg("foo1.2"), FieldSeg("1"), FieldSeg("[alt]")).label must_== ???
+    }.pendingUntilFixed("it's not clear what we need here, if anything")
+  }
+
+  "Path.parse" should {
+    "nested fields" in {
+      Path.parse("foo.bar") must_== \/-(Path(FieldSeg("foo"), FieldSeg("bar")))
+    }
+
+    "index at root" in {
+      Path.parse("[0]") must_== \/-(Path(IndexSeg(0)))
+    }
+
+    "index in the middle" in {
+      Path.parse("foo[0].bar") must_== \/-(Path(FieldSeg("foo"), IndexSeg(0), FieldSeg("bar")))
+    }
+
+    "field-style index" in {
+      Path.parse("foo.0.bar") must_== \/-(Path(FieldSeg("foo"), IndexSeg(0), FieldSeg("bar")))
+    }
+
+    "nested indices" in {
+      Path.parse("matrix[0][1]") must_== \/-(Path(FieldSeg("matrix"), IndexSeg(0), IndexSeg(1)))
+    }
+
+    "fail with unmatched brackets" in {
+      Path.parse("foo[0") must beAnyLeftDisj
+      Path.parse("foo]") must beAnyLeftDisj
+    }
+
+    "fail with bad index" in {
+      Path.parse("foo[]") must beAnyLeftDisj
+      Path.parse("foo[abc]") must beAnyLeftDisj
+      Path.parse("foo[-1]") must beAnyLeftDisj
+    }
+
+    "fail with bad field" in {
+      Path.parse("foo..bar") must beAnyLeftDisj
+    }
+  }
+
+  "render" should {
     "render Str without quotes" in {
       render(Data.Str("abc")) must_== Aligned.Left("abc")
     }
@@ -74,6 +192,50 @@ class PrettifySpecs extends Specification {
     "render Timestamp" in {
       val now = Instant.now
       render(Data.Timestamp(now)) must_== Aligned.Right(now.toString)
+    }
+  }
+
+  "parse" should {
+    "parse \"\"" in {
+      parse("") must beNone
+    }
+
+    "parse int" in {
+      parse("1") must beSome(Data.Int(1))
+    }
+
+    import DataGen._
+
+    def representable(data: Data) = data match {
+      case Data.Int(x)    => x.isValidLong
+      case Data.Obj(_)    => false
+      case Data.Arr(_)    => false
+      case Data.Set(_)    => false
+      case Data.Binary(_) => false
+      case Data.Id(_)     => false
+      case Data.NA        => false
+      case _              => true
+    }
+
+    "round-trip all representable values" ! prop { (data: Data) =>
+      representable(data) ==> {
+        val r = render(data).value
+        parse(r) must beSome(data)
+      }
+    }
+
+    def isFlat(data: Data) = data match {
+      case Data.Obj(_) => false
+      case Data.Arr(_) => false
+      case Data.Set(_) => false
+      case _ => true
+    }
+
+    "round-trip all rendered values" ! prop { (data: Data) =>
+      isFlat(data) ==> {
+        val r = render(data).value
+        parse(r).map(render(_).value) must beSome(r)
+      }
     }
   }
 

--- a/web/src/main/scala/slamdata/engine/api/csv.scala
+++ b/web/src/main/scala/slamdata/engine/api/csv.scala
@@ -1,0 +1,90 @@
+package slamdata.engine.api
+
+import scalaz.{Ordering => ZOrdering, _}
+import Scalaz._
+
+final case class Record(fields: List[String]) {
+  def size = fields.length
+}
+
+trait CsvParser {
+  def parse(text: String): Stream[String \/ Record]
+}
+
+object CsvParser {
+  import com.github.tototoshi.csv._
+
+  final case class TototoshiCsvParser(format: CSVFormat) extends CsvParser {
+    def parse(text: String) = {
+      val reader = CSVReader.open(new java.io.StringReader(text))(format)
+      // NB: CSVReader's `toStream` does not allow the exceptions to be captured,
+      // so here I re-implement it.
+      Stream.continually(
+        \/.fromTryCatchNonFatal(reader.readNext).fold(
+            err => Some(-\/(err.getMessage)),
+            _.map(v => \/-(Record(v)))))
+        .takeWhile(_.isDefined).map(_.get)
+    }
+  }
+
+  final case class Format(delimiter: Char, quoteChar: Char, escapeChar: Char, lineTerminator: String) extends CSVFormat {
+    val quoting = QUOTE_MINIMAL
+    val treatEmptyLineAsNil = false
+  }
+
+  // Parsers with all plausible formats, roughly in decreasing order of likeliness.
+  val AllParsers = for {
+    del  <- List(',', '\t', '|', ':', ';', '\r')
+    quot <- List('"', '\'')
+    esc  <- List(quot, '\\')
+    term <- List("\r\n", "\n", ";")
+  } yield TototoshiCsvParser(Format(del, quot, esc, term))
+}
+
+
+object CsvDetect {
+  // NB: to avoid parsing a very large text many times, just impose a limit on the
+  // number of records that are inspected for format detection. And since a mis-matched
+  // format could miss record boundaries, also impose a character limit.
+  val TestRecords = 10
+  val TestChars = (TestRecords+1)*500
+
+  final case class TestResult(header: Int, rows: List[Int])
+
+  def testParse(parser: CsvParser, text: String): Option[TestResult] = {
+    val subtext = text.take(TestChars)
+    (parser.parse(subtext) ++ Stream.continually(\/-(Record(Nil)))).take(TestRecords + 1) match {
+      case header #:: rows =>
+        ((header |@| rows.toList.sequenceU) { (header, rows) =>
+          TestResult(header.size, rows.map(_.size))
+        }).toOption
+
+      case _ => None
+    }
+  }
+
+  /**
+    Assign a numeric score to the result of `testParse`. 0.0 is the best score, meaning
+    no deviation from the expected shape, which is
+    - at least two columns and two rows
+    - no rows with more fields than the header (large penalty)
+    - few rows with less fields than the header (small penalty)
+   */
+  def score(result: TestResult): Double =
+    ((2 - result.header) max 0)*100.0 +
+      ((2 - result.rows.size) max 0)*100.0 +
+      result.rows.map(n => (n - result.header) max 0).sum*10.0 +
+      result.rows.map(n => (result.header - n) max 0).sum*1.0
+
+  def rank[P <: CsvParser](parsers: List[P])(text: String): List[(Double, P)] = {
+    parsers.map(p => testParse(p, text).map(score(_) -> p)).flatten.sorted(Ordering.by[(Double, P), Double](_._1))
+  }
+
+  def bestParse(parsers: List[CsvParser])(text: String): String \/ Stream[String \/ Record] =
+    rank(parsers)(text).headOption match {
+      case None              => -\/ ("no successful parse")
+      case Some((_, parser)) =>  \/-(parser.parse(text))
+    }
+
+  val parse = bestParse(CsvParser.AllParsers) _
+}

--- a/web/src/main/scala/slamdata/engine/api/csv.scala
+++ b/web/src/main/scala/slamdata/engine/api/csv.scala
@@ -23,7 +23,7 @@ object CsvParser {
         \/.fromTryCatchNonFatal(reader.readNext).fold(
             err => Some(-\/(err.getMessage)),
             _.map(v => \/-(Record(v)))))
-        .takeWhile(_.isDefined).map(_.get)
+        .takeWhile(_.isDefined).collect { case Some(v) => v }
     }
   }
 

--- a/web/src/main/scala/slamdata/engine/api/fs.scala
+++ b/web/src/main/scala/slamdata/engine/api/fs.scala
@@ -1,13 +1,13 @@
 package slamdata.engine.api
 
-import scala.collection.immutable.{TreeSet}
+import scala.collection.immutable.{ListMap, TreeSet}
 
 import slamdata.engine._
 import slamdata.engine.sql.Query
 import slamdata.engine.fs._
 import slamdata.engine.fp._
 
-import argonaut._
+import argonaut.{DecodeResult => _, _ }
 import Argonaut._
 
 import org.http4s.{Query => HQuery, _}
@@ -122,12 +122,7 @@ class FileSystemApi(fs: FSTable[Backend]) {
   private val POSTContentMustContainQuery    = BadRequest("The body of the POST must contain a query")
   private val DestinationHeaderMustExist     = BadRequest("The 'Destination' header must be specified")
 
-  private def upload[A](body: String, path: Path, f: (FileSystem, Path, Process[Task, Data]) => List[Throwable] \/ Unit) = {
-    val codec = DataCodec.Precise
-    def parseJsonLines(str: String): (List[WriteError], List[Data]) =
-      unzipDisj(str.split("\n").map(line => DataCodec.parse(line)(codec).leftMap(
-        e => WriteError(Data.Str("parse error: " + line), Some(e.message)))).toList)
-
+  private def upload[A](errors: List[WriteError], path: Path, f: (FileSystem, Path) => List[Throwable] \/ Unit) = {
     def errorBody(status: org.http4s.dsl.impl.EntityResponseGenerator, errs: List[Throwable])(implicit EJ: EncodeJson[WriteError]) =
       status(Json(
         "errors" := errs.map {
@@ -137,13 +132,12 @@ class FileSystemApi(fs: FSTable[Backend]) {
         }))
 
     (for {
-      t1   <- dataSourceFor(path)
+      t1 <- dataSourceFor(path)
       (dataSource, relPath) = t1
 
-      (errs, json) = parseJsonLines(body)
-      _    <- if (!errs.isEmpty) -\/ (errorBody(BadRequest, errs)) else \/- (())
+      _  <- if (!errors.isEmpty) -\/ (errorBody(BadRequest, errors)) else \/- (())
 
-      _    <- f(dataSource, relPath, Process.emitAll(json)).leftMap {
+      _  <- f(dataSource, relPath).leftMap {
         case (pe @ PathError(_)) :: Nil => errorBody(BadRequest, pe :: Nil)
         case es                         => errorBody(InternalServerError, es)
       }
@@ -285,6 +279,46 @@ class FileSystemApi(fs: FSTable[Backend]) {
       // TODO: Use typesafe data structure and just serialize that.
   }
 
+  // NB: EntityDecoders handle media types but not streaming, so the entire body is
+  // parsed at once.
+  implicit val dataDecoder: EntityDecoder[(List[WriteError], List[Data])] = {
+    import ResponseFormat._
+
+    val csv: EntityDecoder[(List[WriteError], List[Data])] = EntityDecoder.decodeBy(CsvMediaType) { msg =>
+      val t = EntityDecoder.decodeString(msg).map { body =>
+        import scalaz.std.option._
+        import slamdata.engine.repl.Prettify
+
+        // NB: all the CSV parsing happens here. Tototoshi can handle multiple
+        // formats, but does not infer the format so here we assume the "standard".
+        import com.github.tototoshi.csv._
+        val lines: Stream[List[String]] = CSVReader.open(new java.io.StringReader(body)).toStream
+
+        lines.headOption.map { header =>
+          val paths = header.map(Prettify.Path.parse(_).toOption)
+          val rows = lines.drop(1).map { strs =>
+            val pairs = (paths zip strs.map(Prettify.parse))
+            val good = pairs.map { case (p, s) => (p |@| s).tupled }.flatten
+            Prettify.unflatten(good.toListMap)
+          }.toList
+
+          Nil -> rows
+        }.getOrElse(Nil -> Nil)  // TODO: fail
+      }
+      DecodeResult.success(t)
+    }
+    def json(mt: MediaRange)(implicit codec: DataCodec): EntityDecoder[(List[WriteError], List[Data])] = EntityDecoder.decodeBy(mt) { msg =>
+      val t = EntityDecoder.decodeString(msg).map { body =>
+        unzipDisj(body.split("\n").map(line => DataCodec.parse(line).leftMap(
+          e => WriteError(Data.Str("parse error: " + line), Some(e.message)))).toList)
+      }
+      DecodeResult.success(t)
+    }
+    csv orElse
+      json(ResponseFormat.Readable.mediaType)(DataCodec.Readable) orElse
+      json(MediaRange.`*/*`)(DataCodec.Precise)
+  }
+
   def dataService = corsService {
     case req @ GET -> AsPath(path) :? Offset(offset) +& Limit(limit) =>
       (for {
@@ -292,18 +326,18 @@ class FileSystemApi(fs: FSTable[Backend]) {
         (dataSource, relPath) = t
       } yield responseStream(req.headers.get(Accept), dataSource.scan(relPath, offset, limit))).getOrElse(NotFound())
 
-    case req @ PUT -> AsPath(path) => for {
-      body <- EntityDecoder.decodeString(req)
-      resp <- upload(body, path, (ds, p, json) => ds.save(p, json).attemptRun.leftMap(_ :: Nil))
-    } yield resp
+    case req @ PUT -> AsPath(path) =>
+      req.decode[(List[WriteError], List[Data])] { case (errors, rows) =>
+        upload(errors, path, (ds, p) => ds.save(p, Process.emitAll(rows)).attemptRun.leftMap(_ :: Nil))
+      }
 
-    case req @ POST -> AsPath(path) => for {
-      body <- EntityDecoder.decodeString(req)
-      resp <- upload(body, path, (ds, p, json) => {
-        val errors = ds.append(p, json).runLog
-        errors.attemptRun.fold(err => -\/ (err :: Nil), errs => if (!errs.isEmpty) -\/ (errs.toList) else \/- (()))
-      })
-    } yield resp
+    case req @ POST -> AsPath(path) =>
+      req.decode[(List[WriteError], List[Data])] { case (errors, rows) =>
+        upload(errors, path, (ds, p) => {
+          val errors0 = ds.append(p, Process.emitAll(rows)).runLog
+          errors0.attemptRun.fold(err => -\/(err :: Nil), errs => if (!errs.isEmpty) -\/(errs.toList) else \/-(()))
+        })
+      }
 
     case req @ MOVE -> AsPath(path) =>
       (for {

--- a/web/src/main/scala/slamdata/engine/api/fs.scala
+++ b/web/src/main/scala/slamdata/engine/api/fs.scala
@@ -365,7 +365,7 @@ class FileSystemApi(fs: FSTable[Backend]) {
           }.toList
 
           Nil -> rows
-        }.getOrElse(Nil -> Nil)  // TODO: fail
+        }.getOrElse(List(WriteError(Data.Obj(ListMap()), Some("no CSV header in body"))) -> Nil)
       }
       DecodeResult.success(t)
     }

--- a/web/src/test/scala/slamdata/engine/api/csv.scala
+++ b/web/src/test/scala/slamdata/engine/api/csv.scala
@@ -1,0 +1,72 @@
+package slamdata.engine.api
+
+import org.specs2.mutable._
+
+import scalaz._, Scalaz._
+
+class CsvSpec extends Specification {
+  import CsvDetect._
+
+  val Standard =
+    """a,b,c
+      |1,2,3
+      |4,5,6
+      |"1,000","1 000","This is ""standard"" CSV."""".stripMargin
+  val TSV =
+    "a\tb\tc\n" +
+    "1\t2\t3\n" +
+    "4\t5\t6\n" +
+    "1,000\t\"1 000\"\t\"This is \"\"TSV\"\", so-called.\""
+
+  "testParse" should {
+    "standard" in {
+      val p = CsvParser.AllParsers(0)
+
+      testParse(p, Standard) must beSome(TestResult(3, List(3, 3, 3, 0, 0, 0, 0, 0, 0, 0)))
+    }
+  }
+
+  "bestParse" should {
+    def parse(text: String) = bestParse(CsvParser.AllParsers)(text).map(_.toList.sequenceU).join
+
+    "parse standard format" in {
+      parse(Standard) must_==
+        \/-(List(
+          Record(List("a", "b", "c")),
+          Record(List("1", "2", "3")),
+          Record(List("4", "5", "6")),
+          Record(List("1,000", "1 000", "This is \"standard\" CSV."))))
+    }
+
+    "parse TSV format" in {
+      parse(TSV) must_==
+        \/-(List(
+          Record(List("a", "b", "c")),
+          Record(List("1", "2", "3")),
+          Record(List("4", "5", "6")),
+          Record(List("1,000", "1 000", "This is \"TSV\", so-called."))))
+    }
+
+    "parse more standard format" in {
+      // From https://en.wikipedia.org/wiki/Comma-separated_values
+      parse("""Year,Make,Model,Length
+              |1997,Ford,E350,2.34
+              |2000,Mercury,Cougar,2.38""".stripMargin) must_==
+        \/-(List(
+          Record(List("Year", "Make", "Model", "Length")),
+          Record(List("1997", "Ford", "E350", "2.34")),
+          Record(List("2000", "Mercury", "Cougar", "2.38"))))
+    }
+
+    "parse semi-colons and decimal commas" in {
+      // From https://en.wikipedia.org/wiki/Comma-separated_values
+      parse("""Year;Make;Model;Length
+              |1997;Ford;E350;2,34
+              |2000;Mercury;Cougar;2,38""".stripMargin) must_==
+        \/-(List(
+          Record(List("Year", "Make", "Model", "Length")),
+          Record(List("1997", "Ford", "E350", "2,34")),
+          Record(List("2000", "Mercury", "Cougar", "2,38"))))
+    }
+  }
+}

--- a/web/src/test/scala/slamdata/engine/api/fs.scala
+++ b/web/src/test/scala/slamdata/engine/api/fs.scala
@@ -433,8 +433,10 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
 
       "accept valid (standard) CSV" in {
         withServer(backends1) {
-          val path = (root / "foo" / "bar").setHeader("Content-Type", csvContentType)
-          val meta = Http(path.PUT.setBody("a,b\n1,\n,12:34:56") OK as.String)
+          val req = (root / "foo" / "bar").PUT
+            .setHeader("Content-Type", csvContentType)
+            .setBody("a,b\n1,\n,12:34:56")
+          val meta = Http(req OK as.String)
 
           meta() must_== ""
           history must_== List(
@@ -443,6 +445,18 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
               List(
                 Data.Obj(ListMap("a" -> Data.Int(1))),
                 Data.Obj(ListMap("b" -> Data.Time(org.threeten.bp.LocalTime.parse("12:34:56")))))))
+        }
+      }
+
+      "be 400 with empty CSV (no headers)" in {
+        withServer(backends1) {
+          val req = (root / "foo" / "bar").PUT
+            .setHeader("Content-Type", csvContentType)
+            .setBody("")
+          val meta = Http(req > code)
+
+          meta() must_== 400
+          history must_== Nil
         }
       }
 
@@ -548,7 +562,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
         }
       }
 
-      "accept valid (standarn) CSV" in {
+      "accept valid (standard) CSV" in {
         withServer(backends1) {
           val req = (root / "foo" / "bar").POST
             .setHeader("Content-Type", csvContentType)
@@ -562,6 +576,18 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
               List(
                 Data.Obj(ListMap("a" -> Data.Int(1))),
                 Data.Obj(ListMap("b" -> Data.Time(org.threeten.bp.LocalTime.parse("12:34:56")))))))
+        }
+      }
+
+      "be 400 with empty CSV (no headers)" in {
+        withServer(backends1) {
+          val req = (root / "foo" / "bar").POST
+            .setHeader("Content-Type", csvContentType)
+            .setBody("")
+          val meta = Http(req > code)
+
+          meta() must_== 400
+          history must_== Nil
         }
       }
 


### PR DESCRIPTION
See #645, which this fixes except for the requirement to handle crazy "CSV"-like formats.

Regularized REPL/CSV output to match the Readable encoding (by actually using it), with all JSON values turned into strings.

Handle `Content-Type: text/csv` on PUT/POST to `/data/fs`. Parse headers and reconstruct document structure from them, such that exported and re-imported CSV should reproduce the original documents. Mal-formed headers and empty cells are mostly just ignored.

Fix `unzipDisj` to *not* reverse the lists.

In the API tests, keep track of actions performed, effectfully :-(, so it's now possible to verify parsing of uploaded data.