### PR TITLE
Decode the JAR path so we handle paths with spaces.

### DIFF
--- a/web/src/main/scala/slamdata/engine/api/server.scala
+++ b/web/src/main/scala/slamdata/engine/api/server.scala
@@ -19,9 +19,11 @@ object Server {
       val uri = Server.getClass.getProtectionDomain.getCodeSource.getLocation.toURI
       val path0 = uri.getPath
       val path =
-        if (path0 == null)
-          uri.toURL.openConnection.asInstanceOf[java.net.JarURLConnection].getJarFileURL.getPath
-        else path0
+        java.net.URLDecoder.decode(
+          if (path0 == null)
+            uri.toURL.openConnection.asInstanceOf[java.net.JarURLConnection].getJarFileURL.getPath
+          else path0,
+          "UTF-8")
       (new File(path)).getParentFile().getPath() + "/docroot"
     }
 


### PR DESCRIPTION
This was breaking starting the app on Macs with a name like “SlamData 2.0.0”.