### PR TITLE
In the API and the MongoDB Filesystem, validate that offset >= 0 and limit > 0

### DIFF
--- a/core/src/main/scala/slamdata/engine/fs/filesystem.scala
+++ b/core/src/main/scala/slamdata/engine/fs/filesystem.scala
@@ -18,6 +18,13 @@ object WriteError {
          "detail" := e.hint.getOrElse("")))
 }
 
+final case class InvalidOffsetError(value: Long) extends slamdata.engine.Error {
+  def message = "invalid offset: " + value + " (must be >= 0)"
+}
+final case class InvalidLimitError(value: Long) extends slamdata.engine.Error {
+  def message = "invalid limit: " + value + " (must be >= 1)"
+}
+
 trait FileSystem {
   def scan(path: Path, offset: Option[Long], limit: Option[Long]): Process[Task, Data]
 

--- a/it/src/test/scala/slamdata/engine/fs/filesystem.scala
+++ b/it/src/test/scala/slamdata/engine/fs/filesystem.scala
@@ -38,6 +38,17 @@ class FileSystemSpecs extends BackendTest with slamdata.engine.DisjunctionMatche
           fs.count(fs.defaultPath ++ Path("zips")).run must_== 29353
         }
 
+        "read zips with skip and limit" in {
+          val cursor = fs.scan(fs.defaultPath ++ Path("zips"), Some(100), Some(5)).runLog.run
+          val process = fs.scan(fs.defaultPath ++ Path("zips"), None, None).drop(100).take(5).runLog.run
+          cursor must_== process
+        }
+
+        "fail when reading zips with negative skip and zero limit" in {
+          fs.scan(fs.defaultPath ++ Path("zips"), Some(-1), None).run.attemptRun must beAnyLeftDisj
+          fs.scan(fs.defaultPath ++ Path("zips"), None, Some(0)).run.attemptRun must beAnyLeftDisj
+        }
+
         "save one" in {
           (for {
             tmp    <- genTempFile(fs)


### PR DESCRIPTION
Fixes #751.

Note: offset can be zero (indeed, that's a common offset), but limit cannot
(because there's no point in requesting zero results, and because MongoDB
wants to interpret that value as "no limit", naturally).

Check in the API so we can show a nice error message, and check in the
filesystem because the MongoDB driver doesn't handle this gracefully.

Always use a negative limit value, which gives the driver a hint that we won't
request additional results.

Also added an integration test for proper skip/limit behavior of the MongoDB
cursor.