### PR TITLE
validate MongoDB connection URI before updating config

### DIFF
--- a/core/src/main/scala/slamdata/engine/config/config.scala
+++ b/core/src/main/scala/slamdata/engine/config/config.scala
@@ -27,9 +27,12 @@ object Credentials {
   implicit def Codec = casecodec2(Credentials.apply, Credentials.unapply)("username", "password")
 }
 
-sealed trait BackendConfig
+sealed trait BackendConfig {
+  def validate: String \/ Unit
+}
 final case class MongoDbConfig(connectionUri: String) extends BackendConfig {
-
+  def validate =
+    MongoDbConfig.ParsedUri.unapply(connectionUri).map(κ(())) \/> ("invalid connection URI: " + connectionUri)
 }
 object MongoDbConfig {
   implicit def Codec = casecodec1(MongoDbConfig.apply, MongoDbConfig.unapply)("connectionUri")
@@ -46,7 +49,7 @@ object MongoDbConfig {
       "(?::([0-9]+))?" +     // 3: (primary) port
       "((?:,[^,/]+)*)" +     // 4: additional hosts
       "(?:/" +
-        "([^?]+)?" +         // 5: database
+        "([^/?]+)?" +        // 5: database
         "(?:\\?(.+))?" +     // 6: options
       ")?$").r
 


### PR DESCRIPTION
Fixes #758.

Static validation for MongoDbConfig that just attempts to parse the connection
URI.

Fix our parser to reject URIs with extra slashes, to match MongoDBs behavior.
Note: we may want two parsers at some point; one to decipher user-entered
URIs, which is lenient, and another to validate URIs from the API, which is
strict. We would regularize user-entered URIs so that they pass the strict
parser before saving them.

Small-scale conversion in the API to `EitherT[Task, RequestError, A]` to deal
with this one case.

Expose the raw services and separately a mapping from paths to the same
services wrapped in our common middleware.

New middleware to deal with failure in `Task`, returning a 500 with the
description wrapped in Json. This fixes the annoying default behavior of
http4s, which is to hang for 30 seconds and then return an empty 200.