### PR TITLE
regularize and validate of paths in the /mount API

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Removes all data at the specified path. Single files are deleted atomically.
 ### MOVE /data/fs/[path]
 
 Moves data from one path to another within the same backend. The new path must
-be provided in the "Destination" request header. Single files are deleted atomically.
+be provided in the "Destination" request header. Single files are moved atomically.
 
 ### GET /mount/fs/[path]
 
@@ -367,7 +367,7 @@ The outer key is the backend in use, and the value is a backend-specific configu
 
 ### POST /mount/fs/[path]
 
-Adds a new mount point using the JSON contained in the body. This will return a 405 Method Not Allowed if the mount point already exists.
+Adds a new mount point using the JSON contained in the body. The path is the containing directory, and an `X-File-Name` header should contain the name of the mount. This will return a 405 Method Not Allowed if the mount point already exists.
 
 ### PUT /mount/fs/[path]
 
@@ -375,7 +375,7 @@ Creates a new mount point or replaces an existing mount point using the JSON con
 
 ### DELETE /mount/fs/[path]
 
-Deletes an existing mount point. This will return 404 Not Found if the mount point doesn’t exist.
+Deletes an existing mount point, if any exists at the given path. If no such mount exists, the request succeeds but the response has no content.
 
 ### PUT /server/port
 
@@ -383,7 +383,8 @@ Takes a port number in the body, and restarts the server on that port, shutting 
 
 ### DELETE /server/port
 
-Removes any configured port, reverting to the default (20223) and restarting, as with `POST`.
+Removes any configured port, reverting to the default (20223) and restarting, as with `PUT`.
+
 
 ## Data Formats
 

--- a/admin/src/main/scala/slamdata/engine/admin/config.scala
+++ b/admin/src/main/scala/slamdata/engine/admin/config.scala
@@ -27,7 +27,7 @@ class ConfigDialog(parent: Window, configPath: Option[String]) extends Dialog(pa
   private lazy val plusAction = Action("+") {
     val otherPaths = mountTM.validMounts.map(_._1.pathname)
     MountEditDialog.show(this, MongoDbConfig(""), Some("/"), otherPaths).foreach { case (cfg, path) =>
-      mountTM.add(Path(path) -> cfg)
+      mountTM.add(path -> cfg)
       syncColumns
     }
   }
@@ -44,7 +44,7 @@ class ConfigDialog(parent: Window, configPath: Option[String]) extends Dialog(pa
           case m @ MongoDbConfig(_) =>
             val otherPaths = mountTM.validMounts.filterNot(_._2 == cfg).map(_._1.pathname)
             MountEditDialog.show(this, m, Some(path.pathname), otherPaths).foreach { case (cfg, path) =>
-              mountTM.update(index, Path(path) -> cfg)
+              mountTM.update(index, path -> cfg)
             }
           case _ => errorAlert(mountTable, "Unrecognized backend: " + cfg)
         }

--- a/admin/src/main/scala/slamdata/engine/admin/edit.scala
+++ b/admin/src/main/scala/slamdata/engine/admin/edit.scala
@@ -150,7 +150,7 @@ class MountEditDialog private (parent: Window, startConfig: MongoDbConfig, start
             errorAlert(contents(0), interpretError(err))
             \/-(())
           case Backend.TestResult.Success(_) =>
-            result = Some(MongoDbConfig(testUri) -> path.text)
+            result = Some(MongoDbConfig(testUri) -> Path(path.text).asDir)
             dispose
             \/-(())
         })
@@ -196,7 +196,7 @@ class MountEditDialog private (parent: Window, startConfig: MongoDbConfig, start
     }
   }
 
-  var result: Option[(MongoDbConfig, String)] = None
+  var result: Option[(MongoDbConfig, Path)] = None
 
   modal = true
 
@@ -277,7 +277,7 @@ class MountEditDialog private (parent: Window, startConfig: MongoDbConfig, start
   }
 }
 object MountEditDialog {
-  def show(parent: Window, startConfig: MongoDbConfig, startPath: Option[String], otherPaths: List[String]): Option[(MongoDbConfig, String)] = {
+  def show(parent: Window, startConfig: MongoDbConfig, startPath: Option[String], otherPaths: List[String]): Option[(MongoDbConfig, Path)] = {
     val dialog = new MountEditDialog(parent, startConfig, startPath, otherPaths)
     dialog.open
     dialog.result

--- a/web/src/main/scala/slamdata/engine/api/package.scala
+++ b/web/src/main/scala/slamdata/engine/api/package.scala
@@ -20,4 +20,13 @@ package object api {
       else None
     }
   }
+
+  object FileName extends HeaderKey.Singleton {
+    type HeaderT = Header
+    val name = CaseInsensitiveString("X-File-Name")
+    override def matchHeader(header: Header): Option[HeaderT] = {
+      if (header.name == name) Some(header)
+      else None
+    }
+  }
 }

--- a/web/src/test/scala/slamdata/engine/api/fs.scala
+++ b/web/src/test/scala/slamdata/engine/api/fs.scala
@@ -24,6 +24,7 @@ sealed trait Action
 object Action {
   final case class Save(path: Path, rows: List[Data]) extends Action
   final case class Append(path: Path, rows: List[Data]) extends Action
+  final case class Reload(cfg: Config) extends Action
 }
 
 class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAccurateCoverage {
@@ -39,8 +40,11 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
   Start a server, with the given backends, execute something, and then tear
   down the server.
   */
-  def withServer[A](fs: Map[Path, Backend])(body: => A): A = {
-    val srv = Server.run(port, FSTable(fs), ".", Config.empty, None).run
+  def withServer[A](fs: Map[Path, Backend], config: Config)(body: => A): A = {
+    val srv = Server.run(port, FileSystemApi(FSTable(fs), ".", config, cfg => Task.delay {
+      historyBuff += Action.Reload(cfg)
+      ()
+    })).run
 
     try {
       body
@@ -148,6 +152,9 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     Path("badPath1/") -> Stub.backend(FileSystem.Null),
     Path("/badPath2") -> Stub.backend(FileSystem.Null))
 
+  val config1 = Config(SDServerConfig(Some(port)), ListMap(
+    Path("/foo/") -> MongoDbConfig("mongodb://localhost/foo")))
+
   "OPTIONS" should {
     val optionsRoot = svc.OPTIONS
 
@@ -155,7 +162,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     val corsHeaders = header("Access-Control-Allow-Headers") andThen commaSep
 
     "advertise GET and POST for /query path" in {
-      withServer(Map()) {
+      withServer(Map(), config1) {
         val methods = Http(optionsRoot / "query" / "fs" / "" > corsMethods)
 
         methods() must contain(allOf("GET", "POST"))
@@ -163,7 +170,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     }
 
     "advertise Destination header for /query path and method POST" in {
-      withServer(Map()) {
+      withServer(Map(), config1) {
         val headers = Http((optionsRoot / "query" / "fs" / "").setHeader("Access-Control-Request-Method", "POST") > corsHeaders)
 
         headers() must contain(allOf("Destination"))
@@ -171,7 +178,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     }
 
     "advertise GET, PUT, POST, DELETE, and MOVE for /data path" in {
-      withServer(Map()) {
+      withServer(Map(), config1) {
         val methods = Http(optionsRoot / "data" / "fs" / "" > corsMethods)
 
         methods() must contain(allOf("GET", "PUT", "POST", "DELETE", "MOVE"))
@@ -179,7 +186,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     }
 
     "advertise Destination header for /data path and method MOVE" in {
-      withServer(Map()) {
+      withServer(Map(), config1) {
         val headers = Http((optionsRoot / "data" / "fs" / "").setHeader("Access-Control-Request-Method", "MOVE") > corsHeaders)
 
         headers() must contain(allOf("Destination"))
@@ -196,7 +203,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     val root = svc / "metadata" / "fs" / ""  // Note: trailing slash required
 
     "return no filesystems" in {
-      withServer(Map()) {
+      withServer(Map(), config1) {
         val meta = Http(root OK asJson)
 
         meta() must beRightDisj((jsonContentType, List(Json("children" := List[Json]()))))
@@ -204,7 +211,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     }
 
     "be 404 with missing backend" in {
-      withServer(Map()) {
+      withServer(Map(), config1) {
         val path = root / "missing"
         val meta = Http(path > code)
 
@@ -213,7 +220,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     }
 
     "return empty for null fs" in {
-      withServer(backends1) {
+      withServer(backends1, config1) {
         val path = root / "empty" / ""
         val meta = Http(path OK asJson)
 
@@ -222,7 +229,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     }
 
     "be 404 with missing path" in {
-      withServer(backends1) {
+      withServer(backends1, config1) {
         val path = root / "foo" / "baz" / ""
         val meta = Http(path > code)
 
@@ -231,7 +238,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     }
 
     "find stubbed filesystems" in {
-      withServer(backends1) {
+      withServer(backends1, config1) {
         val meta = Http(root OK asJson)
 
         // Note: four backends will come in the right order and compare equal, but not 5 or more.
@@ -247,7 +254,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     }
 
     "find stubbed files" in {
-      withServer(backends1) {
+      withServer(backends1, config1) {
         val path = root / "foo" / ""
         val meta = Http(path OK asJson)
 
@@ -264,7 +271,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     }
 
     "be 404 for file with same name as existing directory (minus the trailing slash)" in {
-      withServer(backends1) {
+      withServer(backends1, config1) {
         val path = root / "foo"
         val meta = Http(path > code)
 
@@ -273,7 +280,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     }
 
     "be empty for file" in {
-      withServer(backends1) {
+      withServer(backends1, config1) {
         val path = root / "foo" / "bar"
         val meta = Http(path OK asJson)
 
@@ -291,7 +298,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
 
     "GET" should {
       "be 404 for missing backend" in {
-        withServer(Map()) {
+        withServer(Map(), config1) {
           val path = root / "missing"
           val meta = Http(path > code)
 
@@ -300,7 +307,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 404 for missing file" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "empty" / "anything"
           val meta = Http(path > code)
 
@@ -309,7 +316,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }.pendingUntilFixed  // FIXME: ResponseStreamer does not detect failure
 
       "read entire file readably by default" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "bar"
           val meta = Http(path OK asJson)
 
@@ -320,7 +327,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "read entire file precisely when specified" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "bar"
           val meta = Http(path.setHeader("Accept", "application/ldjson;mode=precise") OK asJson)
 
@@ -331,7 +338,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "read entire file precisely with complicated Accept" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "bar"
           val meta = Http(path.setHeader("Accept", "application/ldjson;q=0.9;mode=readable,application/json;boundary=NL;mode=precise") OK asJson)
 
@@ -342,7 +349,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "read entire file (with space)" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "a file"
           val meta = Http(path OK asJson)
 
@@ -351,7 +358,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "read entire file as CSV" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "bar"
           val meta = Http(path.setHeader("Accept", csvContentType) OK asLines)
 
@@ -362,7 +369,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "read entire file as CSV with quoting" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "quoting"
           val meta = Http(path.setHeader("Accept", csvContentType) OK asLines)
 
@@ -373,7 +380,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "read partial file with offset and limit" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "bar" <<? Map("offset" -> "1", "limit" -> "1")
           val meta = Http(path OK asJson)
 
@@ -384,7 +391,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 with negative offset" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "bar" <<? Map("offset" -> "-10", "limit" -> "10")
           val meta = Http(path > code)
 
@@ -393,7 +400,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 with negative limit" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "bar" <<? Map("offset" -> "10", "limit" -> "-10")
           val meta = Http(path > code)
 
@@ -404,7 +411,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
 
     "PUT" should {
       "be 404 for missing backend" in {
-        withServer(Map()) {
+        withServer(Map(), config1) {
           val path = root / "missing"
           val meta = Http(path.PUT > code)
 
@@ -413,7 +420,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 with no body" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "bar"
           val meta = Http(path.PUT > code)
 
@@ -422,7 +429,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 with invalid JSON" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "bar"
           val meta = Http(path.PUT.setBody("{") > code)
 
@@ -431,7 +438,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "accept valid (Precise) JSON" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "bar"
           val meta = Http(path.PUT.setBody("{\"a\": 1}\n{\"b\": \"12:34:56\"}") OK as.String)
 
@@ -446,7 +453,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "accept valid (Readable) JSON" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = (root / "foo" / "bar").setHeader("Content-Type", readableContentType)
           val meta = Http(path.PUT.setBody("{\"a\": 1}\n{\"b\": \"12:34:56\"}") OK as.String)
 
@@ -461,7 +468,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "accept valid (standard) CSV" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (root / "foo" / "bar").PUT
             .setHeader("Content-Type", csvContentType)
             .setBody("a,b\n1,\n,12:34:56")
@@ -478,7 +485,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "accept valid (weird) CSV" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (root / "foo" / "bar").PUT
             .setHeader("Content-Type", csvContentType)
             .setBody("a|b\n1|\n|'[1|2|3]'\n")
@@ -495,7 +502,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 with empty CSV (no headers)" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (root / "foo" / "bar").PUT
             .setHeader("Content-Type", csvContentType)
             .setBody("")
@@ -507,7 +514,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 with broken CSV (after the tenth data line)" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (root / "foo" / "bar").PUT
             .setHeader("Content-Type", csvContentType)
             .setBody("\"a\",\"b\"\n1,2\n3,4\n5,6\n7,8\n9,10\n11,12\n13,14\n15,16\n17,18\n19,20\n\",\n") // NB: missing quote char _after_ the tenth data row
@@ -519,7 +526,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 with simulated path error" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "pathError"
           val meta = Http(path.PUT.setBody("{\"a\": 1}") > code)
 
@@ -528,7 +535,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 500 with simulated error on a particular value" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "valueError"
           val meta = Http(path.PUT.setBody("{\"a\": 1}") > code)
 
@@ -539,7 +546,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
 
     "POST" should {
       "be 404 for missing backend" in {
-        withServer(Map()) {
+        withServer(Map(), config1) {
           val path = root / "missing"
           val meta = Http(path.POST > code)
 
@@ -548,7 +555,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 with no body" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "bar"
           val meta = Http(path.POST > code)
 
@@ -557,7 +564,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 with invalid JSON" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "bar"
           val meta = Http(path.POST.setBody("{") > code)
 
@@ -566,7 +573,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "produce two errors with partially invalid JSON" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (root / "foo" / "bar").POST.setBody(
             """{"a": 1}
               |"unmatched
@@ -588,7 +595,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "accept valid (Precise) JSON" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (root / "foo" / "bar").POST
             .setBody("{\"a\": 1}\n{\"b\": \"12:34:56\"}")
           val meta = Http(req OK as.String)
@@ -604,7 +611,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "accept valid (Readable) JSON" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (root / "foo" / "bar").POST
             .setHeader("Content-Type", readableContentType)
             .setBody("{\"a\": 1}\n{\"b\": \"12:34:56\"}")
@@ -621,7 +628,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "accept valid (standard) CSV" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (root / "foo" / "bar").POST
             .setHeader("Content-Type", csvContentType)
             .setBody("a,b\n1,\n,12:34:56")
@@ -638,7 +645,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "accept valid (weird) CSV" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (root / "foo" / "bar").POST
             .setHeader("Content-Type", csvContentType)
             .setBody("a|b\n1|\n|'[1|2|3]'")
@@ -655,7 +662,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 with empty CSV (no headers)" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (root / "foo" / "bar").POST
             .setHeader("Content-Type", csvContentType)
             .setBody("")
@@ -667,7 +674,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 with broken CSV (after the tenth data line)" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (root / "foo" / "bar").POST
             .setHeader("Content-Type", csvContentType)
             .setBody("\"a\",\"b\"\n1,2\n3,4\n5,6\n7,8\n9,10\n11,12\n13,14\n15,16\n17,18\n19,20\n\",\n") // NB: missing quote char _after_ the tenth data row
@@ -679,7 +686,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 with simulated path error" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "pathError"
           val meta = Http(path.POST.setBody("{\"a\": 1}") > code)
 
@@ -688,7 +695,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 500 with simulated error on a particular value" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "valueError"
           val meta = Http(path.POST.setBody("{\"a\": 1}") > code)
 
@@ -701,7 +708,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       val moveRoot = root.setMethod("MOVE")
 
       "be 400 for missing src backend" in {
-        withServer(Map()) {
+        withServer(Map(), config1) {
           val req = moveRoot / "foo"
           val meta = Http(req > code)
 
@@ -710,7 +717,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 404 for missing source file" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (moveRoot / "missing" / "a" ).setHeader("Destination", "/foo/bar")
           val meta = Http(req > code)
 
@@ -719,7 +726,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 404 for missing dst backend" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (moveRoot / "foo" / "bar").setHeader("Destination", "/missing/a")
           val meta = Http(req > code)
 
@@ -728,7 +735,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 201 for file" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (moveRoot / "foo" / "bar").setHeader("Destination", "/foo/baz")
           val meta = Http(req > code)
 
@@ -737,7 +744,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 201 for dir" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (moveRoot / "foo" / "dir" / "").setHeader("Destination", "/foo/dir2/")
           val meta = Http(req > code)
 
@@ -746,7 +753,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 500 for src and dst not in same backend" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (moveRoot / "foo" / "bar").setHeader("Destination", "/empty/a")
           val meta = Http(req > code)
 
@@ -758,7 +765,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
 
     "DELETE" should {
       "be 404 for missing backend" in {
-        withServer(Map()) {
+        withServer(Map(), config1) {
           val path = root / "missing"
           val meta = Http(path.DELETE > code)
 
@@ -767,7 +774,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 200 with existing file" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "bar"
           val meta = Http(path.DELETE > code)
 
@@ -776,7 +783,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 200 with existing dir" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "dir" / ""
           val meta = Http(path.DELETE > code)
 
@@ -785,7 +792,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 200 with missing file (idempotency)" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "missing"
           val meta = Http(path.DELETE > code)
 
@@ -794,7 +801,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 200 with missing dir (idempotency)" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "missingDir" / ""
           val meta = Http(path.DELETE > code)
 
@@ -809,7 +816,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
 
     "GET" should {
       "be 404 for missing backend" in {
-        withServer(Map()) {
+        withServer(Map(), config1) {
           val path = root / "missing" <<? Map("q" -> "select * from bar")
           val meta = Http(path > code)
 
@@ -818,7 +825,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 for missing query" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / ""
           val result = Http(path > code)
 
@@ -827,7 +834,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "execute simple query" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "" <<? Map("q" -> "select * from bar")
           val result = Http(path OK asJson)
 
@@ -838,7 +845,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 for query error" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "" <<? Map("q" -> "error")
           val result = Http(path > code)
 
@@ -849,7 +856,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
 
     "POST" should {
       "be 404 with missing backend" in {
-        withServer(Map()) {
+        withServer(Map(), config1) {
           val req = (root / "missing" / "").POST.setBody("select * from bar").setHeader("Destination", "/tmp/gen0")
 
           val result = Http(req > code)
@@ -859,7 +866,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 with missing query" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (root / "foo" / "").POST.setHeader("Destination", "/foo/tmp/gen0")
 
           val result = Http(req > code)
@@ -869,7 +876,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 with missing Destination header" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (root / "foo" / "").POST.setBody("select * from bar")
 
           val result = Http(req > code)
@@ -879,7 +886,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "execute simple query" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (root / "foo" / "").POST.setBody("select * from bar").setHeader("Destination", "/foo/tmp/gen0")
 
           val result = Http(req > code)
@@ -895,7 +902,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
 
     "GET" should {
       "be 404 with missing backend" in {
-        withServer(Map()) {
+        withServer(Map(), config1) {
           val req = root / "missing" / "" <<? Map("q" -> "select * from bar")
           val result = Http(req > code)
 
@@ -904,7 +911,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 with missing query" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = root / "foo" / ""
 
           val result = Http(req > code)
@@ -914,7 +921,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "plan simple query" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "" <<? Map("q" -> "select * from bar")
           val result = Http(path OK as.String)
 
@@ -923,7 +930,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 for query error" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = root / "foo" / "" <<? Map("q" -> "error")
           val result = Http(path > code)
 
@@ -934,7 +941,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
 
     "POST" should {
       "be 404 with missing backend" in {
-        withServer(Map()) {
+        withServer(Map(), config1) {
           val req = (root / "missing" / "").POST.setBody("select * from bar")
           val result = Http(req > code)
 
@@ -943,7 +950,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 with missing query" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val req = (root / "foo" / "").POST
 
           val result = Http(req > code)
@@ -953,7 +960,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "plan simple query" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = (root / "foo" / "").POST.setBody("select * from bar")
           val result = Http(path OK as.String)
 
@@ -962,11 +969,265 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
       }
 
       "be 400 for query error" in {
-        withServer(backends1) {
+        withServer(backends1, config1) {
           val path = (root / "foo" / "").POST.setBody("error")
           val result = Http(path > code)
 
           result() must_== 400
+        }
+      }
+    }
+  }
+
+  "/mount/fs" should {
+    val root = svc / "mount" / "fs" / ""
+
+    "GET" should {
+      "be 404 with missing mount" in {
+        withServer(Map(), config1) {
+          val req = root / "missing" / ""
+          val result = Http(req > code)
+
+          result() must_== 404
+        }
+      }
+
+      "succeed with correct path" in {
+        withServer(Map(), config1) {
+          val req = root / "foo" / ""
+          val result = Http(req OK asJson)
+
+          result() must beRightDisj((
+            jsonContentType,
+            List(Json("mongodb" := Json("connectionUri" := "mongodb://localhost/foo")))))
+        }
+      }
+
+      "be 404 with missing trailing slash" in {
+        withServer(Map(), config1) {
+          val req = root / "foo"
+          val result = Http(req > code)
+
+          result() must_== 404
+        }
+      }
+    }
+
+    "MOVE" should {
+      "succeed with valid paths" in {
+        withServer(Map(), config1) {
+          val req = (root / "foo" / "")
+                    .setMethod("MOVE")
+                    .setHeader("Destination", "/foo2/")
+          val result = Http(req OK as.String)
+
+          result() must_== "moved /foo/ to /foo2/"
+          history must_== List(Action.Reload(Config(SDServerConfig(Some(port)), Map(
+            Path("/foo2/") -> MongoDbConfig("mongodb://localhost/foo")))))
+        }
+      }
+
+      "be 404 with missing source" in {
+        withServer(Map(), config1) {
+          val req = (root / "missing" / "")
+                    .setMethod("MOVE")
+                    .setHeader("Destination", "/foo/")
+          val result = Http(req > code)
+
+          result() must_== 404
+          history must_== Nil
+        }
+      }
+
+      "be 400 with missing destination" in {
+        withServer(Map(), config1) {
+          val req = (root / "foo" / "")
+                    .setMethod("MOVE")
+          val result = Http(req > code)
+
+          result() must_== 400
+          history must_== Nil
+        }
+      }
+
+      "be 400 with relative path" in {
+        withServer(Map(), config1) {
+          val req = (root / "foo" / "")
+                    .setMethod("MOVE")
+                    .setHeader("Destination", "foo2/")
+          val result = Http(req > code)
+
+          result() must_== 400
+          history must_== Nil
+        }
+      }
+
+      "be 400 with non-directory path for MongoDB mount" in {
+        withServer(Map(), config1) {
+          val req = (root / "foo" / "")
+                    .setMethod("MOVE")
+                    .setHeader("Destination", "/foo2")
+          val result = Http(req > code)
+
+          result() must_== 400
+          history must_== Nil
+        }
+      }
+    }
+
+    "POST" should {
+      "succeed with valid MongoDB config" in {
+        withServer(Map(), config1) {
+          val req = root.POST
+                    .setHeader("X-File-Name", "local/")
+                    .setBody("""{ "mongodb": { "connectionUri": "mongodb://localhost/test" } }""")
+          val result = Http(req OK as.String)
+
+          result() must_== "added /local/"
+          history must_== List(Action.Reload(Config(SDServerConfig(Some(port)), Map(
+            Path("/foo/") -> MongoDbConfig("mongodb://localhost/foo"),
+            Path("/local/") -> MongoDbConfig("mongodb://localhost/test")))))
+        }
+      }
+
+      "be 405 with existing path" in {
+        withServer(Map(), config1) {
+          val req = root.POST
+                    .setHeader("X-File-Name", "foo/")
+                    .setBody("""{ "mongodb": { "connectionUri": "mongodb://localhost/foo2" } }""")
+          val result = Http(req > code)
+
+          result() must_== 405
+          history must_== Nil
+        }
+      }
+
+      "be 400 with missing file-name" in {
+        withServer(Map(), config1) {
+          val req = root.POST
+                    .setBody("""{ "mongodb": { "connectionUri": "mongodb://localhost/test" } }""")
+          val result = Http(req > code)
+
+          result() must_== 400
+          history must_== Nil
+        }
+      }
+
+      "be 400 with invalid MongoDB path (no trailing slash)" in {
+        withServer(Map(), config1) {
+          val req = root.POST
+                    .setHeader("X-File-Name", "local")
+                    .setBody("""{ "mongodb": { "connectionUri": "mongodb://localhost/test" } }""")
+          val result = Http(req > code)
+
+          result() must_== 400
+          history must_== Nil
+        }
+      }
+
+      "be 400 with invalid JSON" in {
+        withServer(Map(), config1) {
+          val req = root.POST
+                    .setHeader("X-File-Name", "local/")
+                    .setBody("""{ "mongodb":""")
+          val result = Http(req > code)
+
+          result() must_== 400
+          history must_== Nil
+        }
+      }
+
+      "be 400 with invalid MongoDB URI (extra slash)" in {
+        withServer(Map(), config1) {
+          val req = root.POST
+                    .setHeader("X-File-Name", "local/")
+                    .setBody("""{ "mongodb": { "connectionUri": "mongodb://localhost:8080//test" } }""")
+          val result = Http(req > code)
+
+          result() must_== 400
+          history must_== Nil
+        }
+      }
+    }
+
+    "PUT" should {
+      "succeed with valid MongoDB config" in {
+        withServer(Map(), config1) {
+          val req = (root / "local" / "").PUT
+                    .setBody("""{ "mongodb": { "connectionUri": "mongodb://localhost/test" } }""")
+          val result = Http(req OK as.String)
+
+          result() must_== "added /local/"
+          history must_== List(Action.Reload(Config(SDServerConfig(Some(port)), Map(
+            Path("/foo/") -> MongoDbConfig("mongodb://localhost/foo"),
+            Path("/local/") -> MongoDbConfig("mongodb://localhost/test")))))
+        }
+      }
+
+      "succeed with valid, overwritten MongoDB config" in {
+        withServer(Map(), config1) {
+          val req = (root / "foo" / "").PUT
+                    .setBody("""{ "mongodb": { "connectionUri": "mongodb://localhost/foo2" } }""")
+          val result = Http(req OK as.String)
+
+          result() must_== "updated /foo/"
+          history must_== List(Action.Reload(Config(SDServerConfig(Some(port)), Map(
+            Path("/foo/") -> MongoDbConfig("mongodb://localhost/foo2")))))
+        }
+      }
+
+      "be 400 with invalid MongoDB path (no trailing slash)" in {
+        withServer(Map(), config1) {
+          val req = (root / "local").PUT
+                    .setBody("""{ "mongodb": { "connectionUri": "mongodb://localhost/test" } }""")
+          val result = Http(req > code)
+
+          result() must_== 400
+          history must_== Nil
+        }
+      }
+
+      "be 400 with invalid JSON" in {
+        withServer(Map(), config1) {
+          val req = (root / "local" / "").PUT
+                    .setBody("""{ "mongodb":""")
+          val result = Http(req > code)
+
+          result() must_== 400
+          history must_== Nil
+        }
+      }
+
+      "be 400 with invalid MongoDB URI (extra slash)" in {
+        withServer(Map(), config1) {
+          val req = (root / "local" / "").PUT
+                    .setBody("""{ "mongodb": { "connectionUri": "mongodb://localhost:8080//test" } }""")
+          val result = Http(req > code)
+
+          result() must_== 400
+          history must_== Nil
+        }
+      }
+    }
+
+    "DELETE" should {
+      "succeed with correct path" in {
+        withServer(Map(), config1) {
+          val req = (root / "foo" / "").DELETE
+          val result = Http(req OK as.String)
+
+          result() must_== "deleted /foo/"
+          history must_== List(Action.Reload(Config(SDServerConfig(Some(port)), Map())))
+        }
+      }
+
+      "succeed with missing path (no action)" in {
+        withServer(Map(), config1) {
+          val req = (root / "missing" / "").DELETE
+          val result = Http(req OK as.String)
+
+          result() must_== ""
+          history must_== Nil
         }
       }
     }


### PR DESCRIPTION
Fixes #739.

Enforce a consistent interpretation of paths for mounts. MongoDB mounts should
always use a directory path, and in the API those paths always have a trailing
slash.

Test coverage for all requests to /mount, and several small fixes:
- make DELETE idempotent
- use X-File-Name in POST
- use application/json Content-Type
- fix response text in a couple of cases

In the admin UI, always add the trailing slash.