### PR TITLE
consume first chunk of scan, handle errors, then stream the rest

### DIFF
--- a/core/src/main/scala/slamdata/engine/fp/package.scala
+++ b/core/src/main/scala/slamdata/engine/fp/package.scala
@@ -198,11 +198,33 @@ trait JsonOps {
 }
 
 trait ProcessOps {
-  import scalaz.stream.Process
+  import scalaz.stream.{Process, Cause}
 
   class PrOps[F[_], O](self: Process[F, O]) {
     def cleanUpWith(t: F[Unit]): Process[F, O] =
       self.onComplete(Process.eval(t).drain)
+
+    // NB: backported from scalaz-stream master
+    import Process._
+    import Cause._
+    final def unconsOption[F2[x] >: F[x], O2 >: O](implicit F: Monad[F2], C: Catchable[F2]): F2[Option[(O2, Process[F2, O2])]] = {
+      def evaluate[F2[x] >: F[x], O2 >: O, A](await: Await[F2, A, O2])(implicit F: Monad[F2], C: Catchable[F2]): F2[Process[F2,O2]] =
+        C.attempt(await.req).map { e =>
+          await.rcv(EarlyCause.fromTaskResult(e)).run
+        }
+
+      self.step match {
+        case Step(head, next) => head match {
+          case Emit(as) => as.headOption.map(x => F.point[Option[(O2, Process[F2, O2])]](Some((x, Process.emitAll[O2](as drop 1) +: next)))) getOrElse
+              new PrOps(next.continue).unconsOption
+          case await: Await[F2, _, O2] => evaluate(await).flatMap(p => new PrOps(p +: next).unconsOption(F,C))
+        }
+        case Halt(cause) => cause match {
+          case End | Kill => F.point(None)
+          case _ : EarlyCause => C.fail(cause.asThrowable)
+        }
+      }
+    }
   }
 
   implicit class PrOpsTask[O](self: Process[Task, O])

--- a/core/src/main/scala/slamdata/engine/repl/prettify.scala
+++ b/core/src/main/scala/slamdata/engine/repl/prettify.scala
@@ -186,11 +186,11 @@ object Prettify {
        fields, if present.
    - If new fields appear after the first `n` rows, they're ignored.
    */
-  def renderStream(src: Process[Task, Data], n: Int): Process[Task, List[String]] = {
+  def renderStream[F[_]](src: Process[F, Data], n: Int): Process[F, List[String]] = {
     // Combinator that handles sampling the stream, computing some value from the sample,
     // and emiting a single "header" value, followed by each transformed value. The types
     // make this look generic, but it's not clear what else this would be useful for.
-    def sampleMap[A, B, C](src: Process[Task, A], n: Int, sample: IndexedSeq[A] => B, prefix: B => C, f: (A, B) => C): Process[Task, C] = {
+    def sampleMap[A, B, C](src: Process[F, A], n: Int, sample: IndexedSeq[A] => B, prefix: B => C, f: (A, B) => C): Process[F, C] = {
       (src.chunk(n) ++ Process.emit(Vector.empty) ++ Process.emit(Vector.empty)).zipWithState[Option[B]](None) { case (as, optB) =>
         optB.orElse(Some(sample(as)))
       }.zipWithPrevious.flatMap {

--- a/web/src/main/scala/slamdata/engine/api/fs.scala
+++ b/web/src/main/scala/slamdata/engine/api/fs.scala
@@ -77,34 +77,51 @@ final case class FileSystemApi(backend: Backend, contentPath: String, config: Co
 
   val CsvColumnsFromInitialRowsCount = 1000
 
-  private def jsonStream(codec: DataCodec, v: Process[PathTask, Data])(implicit EE: EncodeJson[DataEncodingError]): Task[Response] =
-    v.runLog.fold(
-      handlePathError,
-      vect => Ok(Process.emitAll(vect.map(
-        DataCodec.render(_)(codec).fold(EE.encode(_).toString, ɩ) + "\r\n")))).join
+  private def jsonLines(codec: DataCodec, v: Process[PathTask, Data])(implicit EE: EncodeJson[DataEncodingError]): Process[PathTask, String] =
+    v.map(DataCodec.render(_)(codec).fold(EE.encode(_).toString, ɩ) + "\r\n")
 
-  private def csvStream(v: Process[PathTask, Data]): Task[Response] = {
+  private def csvLines(v: Process[PathTask, Data]): Process[PathTask, String] = {
     import slamdata.engine.repl.Prettify
+    import com.github.tototoshi.csv._
 
-    v.runLog.fold(
-      handlePathError,
-      vect => Ok(Prettify.renderStream(Process.emitAll(vect), CsvColumnsFromInitialRowsCount).map { v =>
-        import com.github.tototoshi.csv._
-        val w = new java.io.StringWriter
-        val cw = CSVWriter.open(w)
-        cw.writeRow(v)
-        cw.close
-        w.toString
-      })).join
+    Prettify.renderStream(v, CsvColumnsFromInitialRowsCount).map { v =>
+      val w = new java.io.StringWriter
+      val cw = CSVWriter.open(w)
+      cw.writeRow(v)
+      cw.close
+      w.toString
+    }
+  }
+
+  private def linesResponse(v: Process[PathTask, String]): Task[Response] = {
+    import slamdata.engine.fp._
+
+    val unstack = new (PathTask ~> Task) {
+      def apply[A](t: PathTask[A]): Task[A] = t.run.flatMap(_.fold(Task.fail, Task.now))
+    }
+
+    val v1: Process[Task, Throwable \/ String] = v.translate(unstack).attempt()
+    v1.unconsOption.flatMap(_ match {
+      case Some((first, rest)) =>
+        first.fold(
+          {
+            case e: PathError => handlePathError(e)
+            case e: ScanError => handleScanError(e)
+            case err => InternalServerError(err.toString)
+          },
+          _ => Ok((Process.emit(first) ++ rest).map(_.fold("error: " + _, ɩ))))
+      case None =>
+        Ok("")
+    })
   }
 
   private def responseStream(accept: Option[Accept], v: Process[PathTask, Data]):
       Task[Response] = {
     ResponseFormat.fromAccept(accept) match {
       case ResponseFormat.Json(codec, mediaType) =>
-        jsonStream(codec, v).map(_.putHeaders(`Content-Type`(mediaType, Some(Charset.`UTF-8`))))
+        linesResponse(jsonLines(codec, v)).map(_.putHeaders(`Content-Type`(mediaType, Some(Charset.`UTF-8`))))
       case ResponseFormat.Csv =>
-        csvStream(v).map(_.putHeaders(`Content-Type`(ResponseFormat.Csv.mediaType, Some(Charset.`UTF-8`))))
+        linesResponse(csvLines(v)).map(_.putHeaders(`Content-Type`(ResponseFormat.Csv.mediaType, Some(Charset.`UTF-8`))))
     }
   }
 
@@ -361,6 +378,8 @@ final case class FileSystemApi(backend: Backend, contentPath: String, config: Co
         case _                          => BadRequest
       },
       error)
+
+  def handleScanError(error: ScanError): Task[Response] = errorResponse(BadRequest, error)
 
   // NB: EntityDecoders handle media types but not streaming, so the entire body is
   // parsed at once.

--- a/web/src/main/scala/slamdata/engine/api/fs.scala
+++ b/web/src/main/scala/slamdata/engine/api/fs.scala
@@ -109,7 +109,7 @@ final case class FileSystemApi(backend: Backend, contentPath: String, config: Co
             case e: ScanError => handleScanError(e)
             case err => InternalServerError(err.toString)
           },
-          _ => Ok((Process.emit(first) ++ rest).map(_.fold("error: " + _, ɩ))))
+          _ => Ok((Process.emit(first) ++ rest).flatMap(_.fold(Process.fail, Process.emit))))
       case None =>
         Ok("")
     })

--- a/web/src/test/scala/slamdata/engine/api/fs.scala
+++ b/web/src/test/scala/slamdata/engine/api/fs.scala
@@ -154,7 +154,8 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     Path("quoting") -> List(
       Data.Obj(ListMap(
         "a" -> Data.Str("\"Hey\""),
-        "b" -> Data.Str("a, b, c")))))
+        "b" -> Data.Str("a, b, c")))),
+    Path("empty") -> List())
   val noBackends = NestedBackend(Map())
   val backends1 = NestedBackend(ListMap(
     Path("/empty/") -> Stub.backend(ListMap()),
@@ -274,6 +275,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
               Json("name" := "a file",  "type" := "file"),
               Json("name" := "bar",     "type" := "file"),
               Json("name" := "dir",     "type" := "directory"),
+              Json("name" := "empty",   "type" := "file"),
               Json("name" := "quoting", "type" := "file"),
               Json("name" := "tmp",     "type" := "directory"))))))
       }
@@ -332,6 +334,17 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
           meta() must beRightDisj((
             readableContentType,
             List(Json("a" := 1), Json("b" := 2), Json("c" := List(3)))))
+        }
+      }
+
+      "read empty file" in {
+        withServer(backends1, config1) {
+          val path = root / "foo" / "empty"
+          val meta = Http(path OK asJson)
+
+          meta() must beRightDisj((
+            readableContentType,
+            List()))
         }
       }
 


### PR DESCRIPTION
Fixes #782.

Includes an ugly back-port of `unconsOption` from scalaz-stream/master.