### PR TITLE
Convert NestedBackend into single steps.

### DIFF
--- a/core/src/main/scala/slamdata/engine/backend.scala
+++ b/core/src/main/scala/slamdata/engine/backend.scala
@@ -59,7 +59,13 @@ sealed trait Backend { self =>
    * Executes a query, producing a compilation log and the path where the result
    * can be found.
    */
-  def run(req: QueryRequest): (Vector[PhaseResult], PathTask[ResultPath])
+  def run(req: QueryRequest): (Vector[PhaseResult], PathTask[ResultPath]) =
+    run0(QueryRequest(
+      slamdata.engine.sql.SQLParser.mapPathsM[Id](req.query, Path.Current ++ _),
+      req.out.map(Path.Current ++ _),
+      req.variables))
+
+  def run0(req: QueryRequest): (Vector[PhaseResult], PathTask[ResultPath])
 
   /**
     * Executes a query, placing the output in the specified resource, returning
@@ -100,7 +106,7 @@ sealed trait Backend { self =>
       case (Some(o), _) if o < 0 => Process.fail(InvalidOffsetError(o))
       // NB: limit == 0 means no limit, and limit < 0 means request only a single batch (which we use below)
       case (_, Some(l)) if l < 1 => Process.fail(InvalidLimitError(l))
-      case _ => scan0(path, offset, limit)
+      case _ => scan0(Path.Current ++ path, offset, limit)
     }
 
   def scan0(path: Path, offset: Option[Long], limit: Option[Long]):
@@ -112,14 +118,19 @@ sealed trait Backend { self =>
 
   final def scanFrom(path: Path, offset: Long) = scan(path, Some(offset), None)
 
-  def count(path: Path): PathTask[Long]
+  def count(path: Path): PathTask[Long] = count0(Path.Current ++ path)
+
+  def count0(path: Path): PathTask[Long]
 
   /**
     Save a collection of documents at the given path, replacing any previous
     contents, atomically. If any error occurs while consuming input values,
     nothing is written and any previous values are unaffected.
     */
-  def save(path: Path, values: Process[Task, Data]): PathTask[Unit]
+  def save(path: Path, values: Process[Task, Data]): PathTask[Unit] =
+    save0(Path.Current ++ path, values)
+
+  def save0(path: Path, values: Process[Task, Data]): PathTask[Unit]
 
   /**
     Create a new collection of documents at the given path.
@@ -146,13 +157,28 @@ sealed trait Backend { self =>
    for each input value that is not written, or no values at all.
    */
   def append(path: Path, values: Process[Task, Data]):
+      Process[PathTask, WriteError] =
+    append0(Path.Current ++ path, values)
+
+  def append0(path: Path, values: Process[Task, Data]):
       Process[PathTask, WriteError]
 
-  def move(src: Path, dst: Path): PathTask[Unit]
+  def move(src: Path, dst: Path): PathTask[Unit] =
+    move0(Path.Current ++ src, Path.Current ++ dst)
 
-  def delete(path: Path): PathTask[Unit]
+  def move0(src: Path, dst: Path): PathTask[Unit]
 
-  def ls(dir: Path): PathTask[Set[FilesystemNode]]
+  def delete(path: Path): PathTask[Unit] =
+    delete0(Path.Current ++ path)
+
+  def delete0(path: Path): PathTask[Unit]
+
+  def ls(dir: Path): PathTask[Set[FilesystemNode]] =
+    dir.file.fold(
+      ls0(Path.Current ++ dir))(
+      κ(EitherT.left(Task.now(InvalidPathError("Can not ls a file: " + dir)))))
+
+  def ls0(dir: Path): PathTask[Set[FilesystemNode]]
 
   def ls: PathTask[Set[FilesystemNode]] = ls(Path.Root)
 
@@ -175,7 +201,7 @@ trait PlannerBackend[PhysicalPlan] extends Backend {
 
   def checkCompatibility = evaluator.checkCompatibility
 
-  def run(req: QueryRequest): (Vector[PhaseResult], PathTask[ResultPath]) = {
+  def run0(req: QueryRequest): (Vector[PhaseResult], PathTask[ResultPath]) = {
     val (phases, physical) = queryPlanner(req)
 
     phases ->
@@ -266,30 +292,37 @@ object Backend {
   Multi-mount backend that delegates each request to a single mount.
   Any request that references paths in more than one mount will fail.
 */
-final case class NestedBackend(mounts: Map[Path, Backend]) extends Backend {
+final case class NestedBackend(sourceMounts: Map[DirNode, Backend]) extends Backend {
   import Backend._
+
+  // We use a var because we can’t leave the user with a copy that has a
+  // reference to a concrete backend that no longer exists.
+  @SuppressWarnings(Array("org.brianmckenna.wartremover.warts.Var"))
+  var mounts = sourceMounts
+
+  def nodePath(node: DirNode) = Path(List(DirNode.Current, node), None)
 
   def checkCompatibility: Task[slamdata.engine.Error \/ Unit] =
     mounts.values.toList.map(_.checkCompatibility).sequenceU.map(_.sequenceU.map(κ(())))
 
-  def run(req: QueryRequest): (Vector[PhaseResult], PathTask[ResultPath]) = {
-    mounts.map { case (mountPath, backend) =>
-      val mountDir = mountPath.asDir
+  def run0(req: QueryRequest): (Vector[PhaseResult], PathTask[ResultPath]) = {
+    mounts.map { case (mountDir, backend) =>
+      val mountPath = nodePath(mountDir)
       (for {
-        q <- slamdata.engine.sql.SQLParser.mapPathsE(req.query, _.rebase(mountDir))
-        out <- req.out.map(_.rebase(mountDir).map(Some(_))).getOrElse(\/-(None))
-      } yield QueryRequest(q, out, req.variables)).toOption.map((backend, mountDir, _))
+        q <- slamdata.engine.sql.SQLParser.mapPathsE(req.query, _.rebase(mountPath))
+        out <- req.out.map(_.rebase(mountPath).map(Some(_))).getOrElse(\/-(None))
+      } yield (backend, mountPath, QueryRequest(q, out, req.variables))).toOption
     }.toList.flatten match {
-      case (backend, mountDir, req) :: Nil =>
-        val (phases, t) = backend.run(req)
+      case (backend, mountPath, req) :: Nil =>
+        val (phases, t) = backend.run0(req)
         phases -> t.map {
-          case ResultPath.User(path) => ResultPath.User(mountDir ++ path)
-          case ResultPath.Temp(path) => ResultPath.Temp(mountDir ++ path)
+          case ResultPath.User(path) => ResultPath.User(mountPath ++ path)
+          case ResultPath.Temp(path) => ResultPath.Temp(mountPath ++ path)
         }
       case Nil =>
         // TODO: Restore this error message when #771 is fixed.
         // val err = InternalPathError("no single backend can handle all paths for request: " + req)
-        val err = InvalidPathError("the request either contained a nonexistent path or could not be handled by a single backend")
+        val err = InvalidPathError("the request either contained a nonexistent path or could not be handled by a single backend: " + req.query)
         (Vector(PhaseResult.Error("Paths", err)), EitherT.left(Task.now(err)))
       case _   =>
         val err = InternalPathError("multiple backends can handle all paths for request: " + req)
@@ -299,61 +332,64 @@ final case class NestedBackend(mounts: Map[Path, Backend]) extends Backend {
 
   def scan0(path: Path, offset: Option[Long], limit: Option[Long]):
       Process[PathTask, Data] =
-    delegateP(path)(_.scan(_, offset, limit))
+    delegateP(path)(_.scan0(_, offset, limit))
 
-  def count(path: Path): PathTask[Long] = delegate(path)(_.count(_))
+  def count0(path: Path): PathTask[Long] = delegate(path)(_.count0(_))
 
-  def save(path: Path, values: Process[Task, Data]): PathTask[Unit] =
-    delegate(path)(_.save(_, values))
+  def save0(path: Path, values: Process[Task, Data]): PathTask[Unit] =
+    delegate(path)(_.save0(_, values))
 
-  def append(path: Path, values: Process[Task, Data]):
+  def append0(path: Path, values: Process[Task, Data]):
       Process[PathTask, WriteError] =
-    delegateP(path)(_.append(_, values))
+    delegateP(path)(_.append0(_, values))
 
-  def move(src: Path, dst: Path): PathTask[Unit] =
+  def move0(src: Path, dst: Path): PathTask[Unit] =
     delegate(src)((srcBackend, srcPath) => delegate(dst)((dstBackend, dstPath) =>
       if (srcBackend == dstBackend)
-        srcBackend.move(srcPath, dstPath)
+        srcBackend.move0(srcPath, dstPath)
       else
         EitherT.left(Task.now(InternalPathError("src and dst path not in the same backend")))))
 
-  def delete(path: Path): PathTask[Unit] =
-    delegate(path)(_.delete(_))
-
-  def ls(dir: Path): PathTask[Set[FilesystemNode]] = {
-    val mnts = mounts.keys.map(_.asAbsolute).map(
-      _.rebase(dir.asDir).toOption.flatMap { p =>
-        val dir = p.asAbsolute.asDir.dir
-        dir.headOption.map(d =>
-          FilesystemNode(
-            Path(List(d), None),
-            if (dir.length > 1) Plain else Mount))
-      }).flatten.toSet
-    relativize(dir).map { case (b, p) => b.ls(p) }.sequenceU.map(_.foldLeft(mnts.toSet)(_ ++ _))
+  def delete0(path: Path): PathTask[Unit] = path.dir match {
+    case Nil =>
+      path.file.fold(
+        // delete all children because a parent (and us) was deleted
+        mounts.toList.map(_._2.delete0(path)).sequenceU.map(_.concatenate))(
+        κ(EitherT.left(Task.now(NonexistentPathError(path, None)))))
+    case last :: Nil => for {
+      _ <- delegate(path)(_.delete0(_))
+      _ <- EitherT.right(path.file.fold(
+        Task.delay{ mounts = mounts - last })(
+        κ(().point[Task])))
+    } yield ()
+    case _ => delegate(path)(_.delete0(_))
   }
+
+  def ls0(dir: Path): PathTask[Set[FilesystemNode]] =
+    if (dir == Path.Current)
+      EitherT.right(Task.now(mounts.toSet[(DirNode, Backend)].map { case (d, b) =>
+        FilesystemNode(nodePath(d), b match {
+          case NestedBackend(_) => Plain
+          case _                => Mount
+        })
+      }))
+      else delegate(dir)(_.ls0(_))
 
   def defaultPath = Path.Root
 
   private def delegate[A](path: Path)(f: (Backend, Path) => PathTask[A]): PathTask[A] =
-    EitherT(Task.now(relativizeOne(path))).flatMap(f.tupled)
+    path.asAbsolute.dir.headOption.fold[PathTask[A]](
+      EitherT.left(Task.now(NonexistentPathError(path, None))))(
+      node => mounts.get(node).fold(
+        EitherT.left[Task, PathError, A](Task.now(NonexistentPathError(path, None))))(
+        b => EitherT(Task.now(path.rebase(nodePath(node)))).flatMap(f(b, _))))
 
   private def delegateP[A](path: Path)(f: (Backend, Path) => Process[PathTask, A]): Process[PathTask, A] =
-    relativizeOne(path).fold(
-      e => Process.eval[PathTask, A](EitherT.left(Task.now(e))),
-      f.tupled)
-
-  private def relativizeOne[A](path: Path): PathError \/ (Backend, Path) =
-    relativize(path) match {
-      case (backend, relPath) :: Nil => \/-((backend, relPath))
-      case Nil                       => -\/(NonexistentPathError(path, Some("no backend")))
-      case _                         => -\/(InvalidPathError("multiple backends for path: " + path))
-    }
-
-  private def relativize(path: Path): List[(Backend, Path)] =
-    if (path == Path.Root)
-      mounts.get(Path.Root).fold[List[(Backend, Path)]](Nil)(b => List(b -> Path(".")))
-    else
-      mounts.map { case (p, b) => path.rebase(p.asDir).toOption.map(b -> _) }.toList.flatten
+    path.asAbsolute.dir.headOption.fold[Process[PathTask, A]](
+      Process.eval[PathTask, A](EitherT.left(Task.now(NonexistentPathError(path, None)))))(
+      node => mounts.get(node).fold(
+        Process.eval[PathTask, A](EitherT.left(Task.now(NonexistentPathError(path, None)))))(
+        b => Process.eval[PathTask, Path](EitherT(Task.now(path.rebase(nodePath(node))))).flatMap(f(b, _))))
 }
 
 final case class BackendDefinition(create: PartialFunction[BackendConfig, Task[Backend]]) extends (BackendConfig => Option[Task[Backend]]) {

--- a/core/src/main/scala/slamdata/engine/backends.scala
+++ b/core/src/main/scala/slamdata/engine/backends.scala
@@ -20,7 +20,7 @@ object BackendDefinitions {
 
       for {
         client <- tclient
-      } yield new PlannerBackend[Workflow] with MongoDbFileSystem {
+      } yield new MongoDbFileSystem {
         val planner = MongoDbPlanner
         val evaluator = MongoDbEvaluator(client, defaultDb)
         val RP = implicitly[RenderTree[Workflow]]

--- a/core/src/main/scala/slamdata/engine/fs/path.scala
+++ b/core/src/main/scala/slamdata/engine/fs/path.scala
@@ -5,10 +5,6 @@ import Scalaz._
 
 // TODO: Should probably make this an ADT
 final case class Path(dir: List[DirNode], file: Option[FileNode]) {
-  def contains(that: Path): Boolean = {
-    file.isEmpty && dir.length <= that.dir.length && (that.dir.take(dir.length) == dir)
-  }
-
   def pureFile = (dir.isEmpty || (dir.length == 1 && dir(0).value == ".")) && !file.isEmpty
 
   def pureDir = file.isEmpty
@@ -64,7 +60,9 @@ final case class Path(dir: List[DirNode], file: Option[FileNode]) {
 
   def rebase(referenceDir: Path): PathError \/ Path =
     if (!referenceDir.pureDir) -\/(PathTypeError(referenceDir, Some("not a directory")))
-    else if (referenceDir.contains(this)) \/-(Path(DirNode.Current :: dir.drop(referenceDir.dir.length), file))
+    else if (referenceDir.dir.length <= dir.length &&
+             dir.take(referenceDir.dir.length) == referenceDir.dir)
+      \/-(Path.Current ++ Path(dir.drop(referenceDir.dir.length), file))
     else -\/(NonexistentPathError(this, Some("not contained by referenceDir (" + referenceDir + ")")))
 
   def from(workingDir: Path) : PathError \/ Path =

--- a/core/src/main/scala/slamdata/engine/fs/path.scala
+++ b/core/src/main/scala/slamdata/engine/fs/path.scala
@@ -34,6 +34,8 @@ final case class Path(dir: List[DirNode], file: Option[FileNode]) {
     case _ => this
   }
 
+  def asRelative: Path = Path.Current ++ this
+
   def asDir: Path = file match {
     case Some(fileNode) => Path(dir :+ DirNode(fileNode.value), None)
     case None => this
@@ -62,7 +64,7 @@ final case class Path(dir: List[DirNode], file: Option[FileNode]) {
     if (!referenceDir.pureDir) -\/(PathTypeError(referenceDir, Some("not a directory")))
     else if (referenceDir.dir.length <= dir.length &&
              dir.take(referenceDir.dir.length) == referenceDir.dir)
-      \/-(Path.Current ++ Path(dir.drop(referenceDir.dir.length), file))
+      \/-(Path(dir.drop(referenceDir.dir.length), file).asRelative)
     else -\/(NonexistentPathError(this, Some("not contained by referenceDir (" + referenceDir + ")")))
 
   def from(workingDir: Path) : PathError \/ Path =

--- a/core/src/main/scala/slamdata/engine/mounter.scala
+++ b/core/src/main/scala/slamdata/engine/mounter.scala
@@ -13,18 +13,29 @@ object Mounter {
   final case class MissingFileSystem(path: Path, config: BackendConfig) extends MountError {
     def message = "No data source could be mounted at the path " + path + " using the config " + config
   }
+  final case class InvalidConfig(message: String) extends MountError
 
-  def mountE(config: Config): MountError \/ Task[Backend] = {
-    val map: MountError \/ Map[Path, Task[Backend]] =
-      Traverse[Map[Path, ?]].sequence[MountError \/ ?, Task[Backend]](
-        config.mountings.transform {
-          case (path, config) => BackendDefinitions.All(config).map(backend => \/-(backend)).getOrElse(-\/(MissingFileSystem(path, config): MountError))
-       })
+  def mountE(config: Config): EitherT[Task, MountError, Backend] = {
+    def rec(backend: Backend, path: List[DirNode], conf: BackendConfig): EitherT[Task, MountError, Backend] =
+      backend match {
+        case NestedBackend(base) =>
+          path match {
+            case Nil => BackendDefinitions.All(conf).fold[EitherT[Task, MountError, Backend]](
+              EitherT.left(Task.now(MissingFileSystem(Path(path, None), conf))))(
+              EitherT.right)
+            case dir :: dirs =>
+              rec(base.get(dir).getOrElse(NestedBackend(Map())), dirs, conf).map(rez => NestedBackend(base + (dir -> rez)))
+          }
+        case _ => EitherT.left(Task.now(InvalidConfig("attempting to mount a backend within an existing backend.")))
+      }
 
-    map.map { map =>
-      Traverse[Map[Path, ?]].sequence[Task, Backend](map).map(NestedBackend)
+    config.mountings.foldLeft[EitherT[Task, MountError, Backend]](
+      EitherT.right(Task.now(NestedBackend(Map())))) {
+      case (root, (path, config)) =>
+        root.flatMap(rec(_, path.asAbsolute.asDir.dir, config))
     }
   }
 
-  def mount(config: Config): Task[Backend] = mountE(config).fold(Task.fail _, identity)
+  def mount(config: Config): Task[Backend] =
+    mountE(config).fold(Task.fail, Task.now).join
 }

--- a/core/src/test/scala/slamdata/engine/fs/path.scala
+++ b/core/src/test/scala/slamdata/engine/fs/path.scala
@@ -140,32 +140,6 @@ class PathSpecs extends Specification with DisjunctionMatchers {
     }
   }
 
-  "Path.contains" should {
-    "return true when parent contains child dir" in {
-      Path("/foo/bar/").contains(Path("/foo/bar/baz/")) must beTrue
-    }
-
-    "return true when parent contains child file" in {
-      Path("/foo/bar/").contains(Path("/foo/bar/baz")) must beTrue
-    }
-
-    "return true for abs path that contains itself" in {
-      Path("/foo/bar/").contains(Path("/foo/bar/")) must beTrue
-    }
-
-    "return true for rel path when parent contains child dir" in {
-      Path("./foo/bar/").contains(Path("./foo/bar/baz/")) must beTrue
-    }
-
-    "return true for rel path when parent contains child file" in {
-      Path("./foo/bar/").contains(Path("./foo/bar/baz")) must beTrue
-    }
-
-    "return true for rel path that contains itself" in {
-      Path("./foo/bar/").contains(Path("./foo/bar/")) must beTrue
-    }
-  }
-
   "Path.asAbsolute" should {
     "not modify /" in {
       Path("/").asAbsolute must_== Path("/")
@@ -305,6 +279,22 @@ class PathSpecs extends Specification with DisjunctionMatchers {
 
     "fail with file" in {
       Path("/foo/bar").rebase(Path("/foo")) must beAnyLeftDisj
+    }
+
+    "fail with rel file" in {
+      Path("./foo/bar").rebase(Path("./foo")) must beAnyLeftDisj
+    }
+
+    "return true for rel path when parent contains child dir" in {
+      Path("./foo/bar/baz/").rebase(Path("./foo/bar/")) must beRightDisj(Path("./baz/"))
+    }
+
+    "return true for rel path when parent contains child file" in {
+      Path("./foo/bar/baz").rebase(Path("./foo/bar/")) must beRightDisj(Path("./baz"))
+    }
+
+    "return true for rel path that contains itself" in {
+      Path("./foo/bar/").rebase(Path("./foo/bar/")) must beRightDisj(Path("./"))
     }
   }
 }

--- a/it/src/test/scala/slamdata/engine/fs/filesystem.scala
+++ b/it/src/test/scala/slamdata/engine/fs/filesystem.scala
@@ -310,6 +310,7 @@ class FileSystemSpecs extends BackendTest with slamdata.engine.DisjunctionMatche
             _      <- fs.delete(TestDir ++ tmpDir ++ tmp1)
             after  <- fs.ls(TestDir ++ tmpDir)
           } yield {
+            before must contain(FilesystemNode(tmp1, Plain))
             after must not(contain(FilesystemNode(tmp1, Plain)))
             after must contain(FilesystemNode(tmp2, Plain))
           }).fold(_ must beNull, ɩ).run

--- a/web/src/test/scala/slamdata/engine/api/fs.scala
+++ b/web/src/test/scala/slamdata/engine/api/fs.scala
@@ -83,10 +83,10 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
             .drop(offset.fold(0)(_.toInt))
             .take(limit.fold(Int.MaxValue)(_.toInt)))
 
-      def count(path: Path) =
+      def count0(path: Path) =
         EitherT(Task.now[PathError \/ List[Data]](files.get(path) \/> NonexistentPathError(path, Some("no backend")))).map(_.length.toLong)
 
-      def save(path: Path, values: Process[Task, Data]) =
+      def save0(path: Path, values: Process[Task, Data]) =
         if (path.pathname.contains("pathError"))
           EitherT.left(Task.now(InvalidPathError("simulated (client) error")))
         else if (path.pathname.contains("valueError"))
@@ -96,7 +96,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
           ()
         })
 
-      def append(path: Path, values: Process[Task, Data]) =
+      def append0(path: Path, values: Process[Task, Data]) =
         if (path.pathname.contains("pathError"))
           Process.eval[Backend.PathTask, WriteError](EitherT.left(Task.now(InvalidPathError("simulated (client) error"))))
         else if (path.pathname.contains("valueError"))
@@ -106,11 +106,11 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
             ()
         }))
 
-      def delete(path: Path) = ().point[Backend.PathTask]
+      def delete0(path: Path) = ().point[Backend.PathTask]
 
-      def move(src: Path, dst: Path) = ().point[Backend.PathTask]
+      def move0(src: Path, dst: Path) = ().point[Backend.PathTask]
 
-      def ls(dir: Path): Backend.PathTask[Set[Backend.FilesystemNode]] = {
+      def ls0(dir: Path): Backend.PathTask[Set[Backend.FilesystemNode]] = {
         val childrenOpt = files.keys.toList.map(_.rebase(dir).map(p => Backend.FilesystemNode(p.head, Backend.Plain))).sequenceU
         childrenOpt.fold(e => EitherT.left(Task.now(e)), _.toSet.point[Backend.PathTask])
       }
@@ -157,14 +157,17 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
         "b" -> Data.Str("a, b, c")))))
   val noBackends = NestedBackend(Map())
   val backends1 = NestedBackend(ListMap(
-    Path("/empty/") -> Stub.backend(ListMap()),
-    Path("/foo/") -> Stub.backend(files1),
-    Path("/non/root/mounting/") -> Stub.backend(files1),
-    Path("badPath1/") -> Stub.backend(ListMap()),
-    Path("/badPath2") -> Stub.backend(ListMap())))
+    DirNode("empty") -> Stub.backend(ListMap()),
+    DirNode("foo") -> Stub.backend(files1),
+    DirNode("non") -> NestedBackend(ListMap(
+      DirNode("root") -> NestedBackend(ListMap(
+        DirNode("mounting") -> Stub.backend(files1))))),
+    DirNode("badPath1") -> Stub.backend(ListMap()),
+    DirNode("badPath2") -> Stub.backend(ListMap())))
 
   val config1 = Config(SDServerConfig(Some(port)), ListMap(
-    Path("/foo/") -> MongoDbConfig("mongodb://localhost/foo")))
+    Path("/foo/") -> MongoDbConfig("mongodb://localhost/foo"),
+    Path("/non/root/mounting/") -> MongoDbConfig("mongodb://localhost/mounting")))
 
   "OPTIONS" should {
     val optionsRoot = svc.OPTIONS
@@ -1060,7 +1063,8 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
 
           result() must_== "moved /foo/ to /foo2/"
           history must_== List(Action.Reload(Config(SDServerConfig(Some(port)), Map(
-            Path("/foo2/") -> MongoDbConfig("mongodb://localhost/foo")))))
+            Path("/foo2/") -> MongoDbConfig("mongodb://localhost/foo"),
+            Path("/non/root/mounting/") -> MongoDbConfig("mongodb://localhost/mounting")))))
         }
       }
 
@@ -1123,6 +1127,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
           result() must_== "added /local/"
           history must_== List(Action.Reload(Config(SDServerConfig(Some(port)), Map(
             Path("/foo/") -> MongoDbConfig("mongodb://localhost/foo"),
+            Path("/non/root/mounting/") -> MongoDbConfig("mongodb://localhost/mounting"),
             Path("/local/") -> MongoDbConfig("mongodb://localhost/test")))))
         }
       }
@@ -1135,6 +1140,30 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
           val result = Http(req > code)
 
           result() must_== 409
+          history must_== Nil
+        }
+      }
+
+      "be 409 for conflicting mount above" in {
+        withServer (backends1, config1) {
+          val req = (root / "non" / "").POST
+                    .setHeader("X-File-Name", "root/")
+                    .setBody("""{ "mongodb": { "connectionUri": "mongodb://localhost/root" } }""")
+          val meta = Http(req > code)
+
+          meta() must_== 409
+          history must_== Nil
+        }
+      }
+
+      "be 409 for conflicting mount below" in {
+        withServer (backends1, config1) {
+          val req = (root / "foo" / "").POST
+                    .setHeader("X-File-Name", "nope/")
+                    .setBody("""{ "mongodb": { "connectionUri": "mongodb://localhost/root" } }""")
+          val meta = Http(req > code)
+
+          meta() must_== 409
           history must_== Nil
         }
       }
@@ -1197,6 +1226,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
           result() must_== "added /local/"
           history must_== List(Action.Reload(Config(SDServerConfig(Some(port)), Map(
             Path("/foo/") -> MongoDbConfig("mongodb://localhost/foo"),
+            Path("/non/root/mounting/") -> MongoDbConfig("mongodb://localhost/mounting"),
             Path("/local/") -> MongoDbConfig("mongodb://localhost/test")))))
         }
       }
@@ -1209,7 +1239,8 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
 
           result() must_== "updated /foo/"
           history must_== List(Action.Reload(Config(SDServerConfig(Some(port)), Map(
-            Path("/foo/") -> MongoDbConfig("mongodb://localhost/foo2")))))
+            Path("/foo/") -> MongoDbConfig("mongodb://localhost/foo2"),
+            Path("/non/root/mounting/") -> MongoDbConfig("mongodb://localhost/mounting")))))
         }
       }
 
@@ -1254,7 +1285,8 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
           val result = Http(req OK as.String)
 
           result() must_== "deleted /foo/"
-          history must_== List(Action.Reload(Config(SDServerConfig(Some(port)), Map())))
+          history must_== List(Action.Reload(Config(SDServerConfig(Some(port)), Map(
+            Path("/non/root/mounting/") -> MongoDbConfig("mongodb://localhost/mounting")))))
         }
       }
 

--- a/web/src/test/scala/slamdata/engine/api/fs.scala
+++ b/web/src/test/scala/slamdata/engine/api/fs.scala
@@ -115,7 +115,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
         childrenOpt.fold(e => EitherT.left(Task.now(e)), _.toSet.point[Backend.PathTask])
       }
 
-      def defaultPath = Path(".")
+      def defaultPath = Path.Current
     }
   }
 


### PR DESCRIPTION
Fixes #781, fixes #785, and fixes #788.

* removed `Path.contains`
* centralized normalization of paths
* error on conflicting paths
* add tests for conflicting configs and metadata issues.