### PR TITLE
Handle any error when trying to open the browser.

### DIFF
--- a/web/src/main/scala/slamdata/engine/api/server.scala
+++ b/web/src/main/scala/slamdata/engine/api/server.scala
@@ -85,9 +85,13 @@ object Server {
     help("help") text("prints this usage text")
   }
 
-  def openBrowser(port: Int): Task[Unit] =
-    Task.delay(java.awt.Desktop.getDesktop().browse(
-      java.net.URI.create(s"http://localhost:$port/")))
+  def openBrowser(port: Int): Task[Unit] = {
+    val url = s"http://localhost:$port/"
+    Task.delay(java.awt.Desktop.getDesktop().browse(java.net.URI.create(url)))
+      .handle { case _ =>
+        System.err.println("Failed to open browser, please navigate to " + url)
+    }
+  }
 
   def main(args: Array[String]): Unit = {
     serv = jarPath.flatMap { jp =>


### PR DESCRIPTION
Failing to open the browser should not cause the server to fail. Instead
we now send a message to stderr acknowledging the error and providing
the URL for the user to use.

This doesn’t fix the underlying issue in #797, but it does at least
allow users to continue working when this fails.