### PR TITLE
restore cleanup of temp files after integration tests

### DIFF
--- a/it/src/test/scala/slamdata/engine/fs/filesystem.scala
+++ b/it/src/test/scala/slamdata/engine/fs/filesystem.scala
@@ -342,7 +342,7 @@ class FileSystemSpecs extends BackendTest with slamdata.engine.DisjunctionMatche
     }
 
     val cleanup = step {
-      deleteTempFiles(fs, TestDir)
+      deleteTempFiles(fs, TestDir).run
     }
   }
 }

--- a/it/src/test/scala/slamdata/engine/regression.scala
+++ b/it/src/test/scala/slamdata/engine/regression.scala
@@ -113,7 +113,7 @@ class RegressionSpec extends BackendTest {
     }
 
     val cleanup = step {
-      deleteTempFiles(backend, tmpDir)
+      deleteTempFiles(backend, tmpDir).run
     }
   }
 


### PR DESCRIPTION
Refactoring put this effectful code into Task, and then we never
bothered to run the task.

Also some cleanup to make the effectful-ness more obvious.