### PR TITLE
two more API features related to formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,16 @@ Takes a port number in the body, and restarts the server on that port, shutting 
 Removes any configured port, reverting to the default (20223) and restarting, as with `PUT`.
 
 
+## Request Headers
+
+Request headers my be supplied via a query parameter in case the client is unable to send arbitrary headers (e.g. browsers, in certain circumstances). The parameter name is `request-headers` and the value should be a JSON-formatted string containing an object whose field are named for the corresponding header and whose values are strings or arrays of strings. If any header appears both in the `request-headers` query parameter and also as an ordinary header, the query parameter takes precedence.
+
+For example:
+```
+GET http://localhost:8080/data/fs/local/test/foo?request-headers=%7B%22Accept%22%3A+%22text%2Fcsv%22%7D
+```
+Note: that's the URL-encoded form of `{"Accept": "text/csv"}`.
+
 ## Data Formats
 
 SlamEngine produces and accepts data in two JSON-based formats or CSV. Each JSON-based format can

--- a/web/src/main/scala/slamdata/engine/api/fs.scala
+++ b/web/src/main/scala/slamdata/engine/api/fs.scala
@@ -26,29 +26,30 @@ import scalaz.stream._
 
 sealed trait ResponseFormat {
   def mediaType: MediaType
+  def disposition: Option[`Content-Disposition`]
 }
 object ResponseFormat {
-  final case class JsonStream private[ResponseFormat] (codec: DataCodec, mode: String) extends ResponseFormat {
+  final case class JsonStream private[ResponseFormat] (codec: DataCodec, mode: String, disposition: Option[`Content-Disposition`]) extends ResponseFormat {
     def mediaType = JsonStream.mediaType.withExtensions(Map("mode" -> mode))
   }
   object JsonStream {
     val mediaType = new MediaType("application", "ldjson", compressible = true)
 
-    val Readable = JsonStream(DataCodec.Readable, "readable")
-    val Precise  = JsonStream(DataCodec.Precise,  "precise")
+    val Readable = JsonStream(DataCodec.Readable, "readable", None)
+    val Precise  = JsonStream(DataCodec.Precise,  "precise", None)
   }
 
-  final case class JsonArray private[ResponseFormat] (codec: DataCodec, mode: String) extends ResponseFormat {
+  final case class JsonArray private[ResponseFormat] (codec: DataCodec, mode: String, disposition: Option[`Content-Disposition`]) extends ResponseFormat {
     def mediaType = JsonArray.mediaType.withExtensions(Map("mode" -> mode))
   }
   object JsonArray {
     def mediaType = new MediaType("application", "json", compressible = true)
 
-    val Readable = JsonArray(DataCodec.Readable, "readable")
-    val Precise  = JsonArray(DataCodec.Precise,  "precise")
+    val Readable = JsonArray(DataCodec.Readable, "readable", None)
+    val Precise  = JsonArray(DataCodec.Precise,  "precise", None)
   }
 
-  final case class Csv(columnDelimiter: Char, rowDelimiter: String, quoteChar: Char, escapeChar: Char) extends ResponseFormat {
+  final case class Csv(columnDelimiter: Char, rowDelimiter: String, quoteChar: Char, escapeChar: Char, disposition: Option[`Content-Disposition`]) extends ResponseFormat {
     import Csv._
 
     def mediaType = Csv.mediaType.withExtensions(Map(
@@ -60,7 +61,7 @@ object ResponseFormat {
   object Csv {
     val mediaType = new MediaType("text", "csv", compressible = true)
 
-    val Default = Csv(',', "\r\n", '"', '"')
+    val Default = Csv(',', "\r\n", '"', '"', None)
 
     def escapeNewlines(str: String): String =
       str.replace("\r", "\\r").replace("\n", "\\n")
@@ -83,6 +84,10 @@ object ResponseFormat {
       //       application/* if they have the same q-value).
       mediaType <- acc.values.toList.sortBy(_.qValue).find(a => mediaTypes.toList.exists(a.satisfies(_)))
     } yield {
+      import org.http4s.parser.HttpHeaderParser.parseHeader
+      val disposition = mediaType.extensions.get("disposition").flatMap { str =>
+        parseHeader(Header.Raw(CaseInsensitiveString("Content-Disposition"), str)).toOption.map(_.asInstanceOf[`Content-Disposition`])
+      }
       if (mediaType satisfies Csv.mediaType) {
         def toChar(str: String): Option[Char] = str.toList match {
           case c :: Nil => Some(c)
@@ -91,15 +96,16 @@ object ResponseFormat {
         Csv(mediaType.extensions.get("columnDelimiter").map(Csv.unescapeNewlines).flatMap(toChar).getOrElse(','),
           mediaType.extensions.get("rowDelimiter").map(Csv.unescapeNewlines).getOrElse("\r\n"),
           mediaType.extensions.get("quoteChar").map(Csv.unescapeNewlines).flatMap(toChar).getOrElse('"'),
-          mediaType.extensions.get("escapeChar").map(Csv.unescapeNewlines).flatMap(toChar).getOrElse('"'))
+          mediaType.extensions.get("escapeChar").map(Csv.unescapeNewlines).flatMap(toChar).getOrElse('"'),
+          disposition)
       }
       else {
         ((mediaType satisfies JsonArray.mediaType) && mediaType.extensions.get("boundary") != Some("NL"),
             mediaType.extensions.get("mode")) match {
-          case (true, Some("precise"))  => JsonArray.Precise
-          case (true, _)                => JsonArray.Readable
-          case (false, Some("precise")) => JsonStream.Precise
-          case (false, _)               => JsonStream.Readable
+          case (true, Some("precise"))  => JsonArray.Precise.copy(disposition = disposition)
+          case (true, _)                => JsonArray.Readable.copy(disposition = disposition)
+          case (false, Some("precise")) => JsonStream.Precise.copy(disposition = disposition)
+          case (false, _)               => JsonStream.Readable.copy(disposition = disposition)
         }
       }
     }).getOrElse(JsonStream.Readable)
@@ -169,15 +175,17 @@ final case class FileSystemApi(backend: Backend, contentPath: String, config: Co
 
   private def responseStream(accept: Option[Accept], v: Process[PathTask, Data]):
       Task[Response] = {
-    val (mediaType, lines) = ResponseFormat.fromAccept(accept) match {
-      case f @ ResponseFormat.JsonStream(codec, _) =>
-        f.mediaType -> jsonStreamLines(codec, v)
-      case f @ ResponseFormat.JsonArray(codec, _) =>
-        f.mediaType -> jsonArrayLines(codec, v)
-      case f @ ResponseFormat.Csv(r, c, q, e) =>
-        f.mediaType -> csvLines(v, Some(CsvParser.Format(r, q, e, c)))
+    val (mediaType, lines, disposition) = ResponseFormat.fromAccept(accept) match {
+      case f @ ResponseFormat.JsonStream(codec, _, disposition) =>
+        (f.mediaType, jsonStreamLines(codec, v), disposition)
+      case f @ ResponseFormat.JsonArray(codec, _, disposition) =>
+        (f.mediaType, jsonArrayLines(codec, v), disposition)
+      case f @ ResponseFormat.Csv(r, c, q, e, disposition) =>
+        (f.mediaType, csvLines(v, Some(CsvParser.Format(r, q, e, c))), disposition)
     }
-    linesResponse(lines).map(_.putHeaders(`Content-Type`(mediaType, Some(Charset.`UTF-8`))))
+    linesResponse(lines).map(_.putHeaders(
+      `Content-Type`(mediaType, Some(Charset.`UTF-8`)) ::
+      disposition.toList: _*))
   }
 
   private def errorResponse(

--- a/web/src/test/scala/slamdata/engine/api/fs.scala
+++ b/web/src/test/scala/slamdata/engine/api/fs.scala
@@ -492,7 +492,6 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
           "rowDelimiter=\"\\\\r\\\\n\"",
           "quoteChar=\"\"",
           "escapeChar=\"\\\"\"").mkString("; ")
-        println(s"mt: $mt")
 
         withServer(backends1, config1) {
           val req = (root / "foo" / "bar")
@@ -502,6 +501,17 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
           meta() must_==
             csvResponseContentType ->
             List("a,b,c[0]", "1,,", ",2,", ",,3")
+        }
+      }
+
+      "read with disposition" in {
+        withServer(backends1, config1) {
+          val req = (root / "foo" / "bar")
+                    .setHeader("Accept", "application/ldjson; disposition=\"attachment; filename=data.json\"")
+          val meta = Http(req)
+
+          val resp = meta()
+          resp.getHeader("Content-Disposition") must_== "attachment; filename=\"data.json\""
         }
       }
 
@@ -1422,7 +1432,7 @@ class ResponseFormatSpecs extends Specification {
           "rowDelimiter" -> ";",
           "quoteChar" -> "'",
           "escapeChar" -> "\\")))
-      fromAccept(Some(accept)) must_== Csv('\t', ";", '\'', '\\')
+      fromAccept(Some(accept)) must_== Csv('\t', ";", '\'', '\\', None)
     }
 
     "choose CSV over JSON" in {

--- a/web/src/test/scala/slamdata/engine/api/fs.scala
+++ b/web/src/test/scala/slamdata/engine/api/fs.scala
@@ -398,6 +398,17 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
         }
       }
 
+      "read entire file precisely when specified in request-headers" in {
+        withServer(backends1, config1) {
+          val req = root / "foo" / "bar" <<? Map("request-headers" -> """{"Accept": "application/ldjson; mode=precise" }""")
+          val meta = Http(req OK asJson)
+
+          meta() must beRightDisj((
+            preciseContentType,
+            List(Json("a" := 1), Json("b" := 2), Json("c" := Json("$set" := List(3))))))
+        }
+      }
+
       "read entire file precisely with complicated Accept" in {
         withServer(backends1, config1) {
           val path = root / "foo" / "bar"
@@ -1467,6 +1478,66 @@ class ResponseFormatSpecs extends Specification {
 
     """not affect \"""" in {
       Csv.escapeNewlines("""\"""") must_== """\""""
+    }
+  }
+}
+
+class HeaderParamSpecs extends Specification {
+  import org.http4s.util._
+
+  import HeaderParam._
+
+  "parse" should {
+    "parse one" in {
+      parse("""{ "Accept": "text/csv" }""") must_==
+        \/-(Map(CaseInsensitiveString("Accept") -> List("text/csv")))
+    }
+
+    "parse mulitple values" in {
+      parse("""{ "Foo": [ "bar", "baz" ] }""") must_==
+        \/-(Map(CaseInsensitiveString("Foo") -> List("bar", "baz")))
+    }
+
+    "fail with invalid json" in {
+      parse("""{""") must_==
+        -\/("parse error (JSON terminates unexpectedly.)")
+    }
+
+    "fail with non-object" in {
+      parse("""0""") must_==
+        -\/("expected a JSON object; found: 0")
+    }
+
+    "fail with non-string/array value" in {
+      parse("""{ "Foo": 0 }""") must_==
+        -\/("expected a string or array of strings; found: 0")
+    }
+
+    "fail with non-string value in array" in {
+      parse("""{ "Foo": [ 0 ] }""") must_==
+        -\/("expected string in array; found: 0")
+    }
+  }
+
+  "rewrite" should {
+    import org.http4s._
+    import org.http4s.headers._
+
+    "overwrite conflicting header" in {
+      val headers = rewrite(
+        Headers(`Accept`(MediaType.`text/csv`)),
+        Map(CaseInsensitiveString("accept") -> List("application/json")))
+
+      headers.get(`Accept`) must beSome(`Accept`(MediaType.`application/json`))
+    }
+
+    "add non-conflicting header" in {
+      val headers = rewrite(
+        Headers(`Accept`(MediaType.`text/csv`)),
+        Map(CaseInsensitiveString("user-agent") -> List("some_phone_browser/0.0.1")))
+
+      headers.get(`Accept`) must beSome(`Accept`(MediaType.`text/csv`))
+      headers.get(`User-Agent`) must beSome(`User-Agent`(AgentProduct("some_phone_browser", Some("0.0.1"))))
     }
   }
 }


### PR DESCRIPTION
Providing two more of the items in the checklist in #763:

1. Handle `disposition` in the Accept header, returning it as `Content-Disposition` in the response.
2. Accept headers in `request-headers` query param on any request.

Also move the middleware to the package object, where it's easier to test.