### PR TITLE
Ensure constant projections don’t ignore the size of the input set.

### DIFF
--- a/core/src/main/scala/slamdata/engine/physical/mongodb/optimize/optimize.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/optimize/optimize.scala
@@ -17,9 +17,6 @@ package object optimize {
         Workflow = {
       def getRefs[A](op: WorkflowF[Workflow], prev: Option[Set[DocVar]]):
           Option[Set[DocVar]] = op match {
-        // Don't count unwinds (if the var isn't referenced elsewhere, it's
-        // effectively unused)
-        case $Unwind(_, _)              => prev
         case $Group(_, _, _)            => Some(refs(op).toSet)
         // FIXME: Since we can’t reliably identify which fields are used by a
         //        JS function, we need to assume they all are, until we hit the

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -113,6 +113,7 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
         Arity1(UnOp(op, _).fix)
 
       func match {
+        case `Constantly` => Arity1(ɩ)
         case `Count` => Arity1(Select(_, "count").fix)
         case `Length` => Arity1(Select(_, "length").fix)
         case `Sum` =>
@@ -405,6 +406,8 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
         case (`Or`, _)       => invoke2Nel(Selector.Or.apply _)
           // case (`Not`, _)      => invoke1(Selector.Not.apply _)
 
+        case (`Constantly`, const :: _ :: Nil) => const._2
+
         case _ => -\/(PlannerError.UnsupportedFunction(func))
       }
     }
@@ -562,6 +565,8 @@ object MongoDbPlanner extends Planner[Workflow] with Conversions {
           lift(Arity3(HasWorkflow, HasKeys, HasSortDirs).map {
             case (p1, p2, dirs) => sortBy(p1, p2, dirs)
           })
+
+        case `Constantly` => expr2((v, s) => v)
 
         case `Add`        => expr2(ExprOp.Add.apply _)
         case `Multiply`   => expr2(ExprOp.Multiply.apply _)

--- a/core/src/main/scala/slamdata/engine/semantics.scala
+++ b/core/src/main/scala/slamdata/engine/semantics.scala
@@ -336,7 +336,7 @@ trait SemanticAnalysis {
 
         case BoolLiteral(value) => success(Provenance.Value)
 
-        case NullLiteral() => success(Provenance.Value)
+        case NullLiteral => success(Provenance.Value)
 
         case r @ TableRelationAST(_, _) => success(Provenance.Relation(r))
 
@@ -447,7 +447,7 @@ trait SemanticAnalysis {
           case FloatLiteral(_) => NA
           case StringLiteral(_) => NA
           case BoolLiteral(_) => NA
-          case NullLiteral() => NA
+          case NullLiteral => NA
           case TableRelationAST(_, _) => NA
           case ExprRelationAST(expr, _) => propagate(expr)
           case JoinRelation(_, _, _, _) => NA
@@ -536,7 +536,7 @@ trait SemanticAnalysis {
           case FloatLiteral(value) => succeed(Type.Const(Data.Dec(value)))
           case StringLiteral(value) => succeed(Type.Const(Data.Str(value)))
           case BoolLiteral(value) => succeed(Type.Const(Data.Bool(value)))
-          case NullLiteral() => succeed(Type.Const(Data.Null))
+          case NullLiteral => succeed(Type.Const(Data.Null))
           case TableRelationAST(_, _) => NA
           case ExprRelationAST(expr, _) => propagate(expr)
           case JoinRelation(_, _, _, _) => succeed(Type.Bool)

--- a/core/src/main/scala/slamdata/engine/sql/ast.scala
+++ b/core/src/main/scala/slamdata/engine/sql/ast.scala
@@ -225,7 +225,7 @@ sealed trait Expr extends Node {
       case l @ IntLiteral(_)    => expr(l -> l)
       case l @ FloatLiteral(_)  => expr(l -> l)
       case l @ StringLiteral(_) => expr(l -> l)
-      case l @ NullLiteral()    => expr(l -> l)
+      case l @ NullLiteral      => expr(l -> l)
       case l @ BoolLiteral(_)   => expr(l -> l)
       case l @ Vari(_)          => expr(l -> l)
     }
@@ -448,7 +448,7 @@ final case class StringLiteral(v: String) extends LiteralExpr {
   def sql = _q(v)
 }
 
-final case class NullLiteral() extends LiteralExpr {
+final case object NullLiteral extends LiteralExpr {
   def sql = "null"
 }
 

--- a/core/src/main/scala/slamdata/engine/sql/parser.scala
+++ b/core/src/main/scala/slamdata/engine/sql/parser.scala
@@ -246,7 +246,7 @@ class SQLParser extends StandardTokenParsers {
     numericLit ^^ { case i => IntLiteral(i.toLong) } |
     floatLit ^^ { case f => FloatLiteral(f.toDouble) } |
     stringLit ^^ { case s => StringLiteral(s) } |
-    keyword("null") ^^^ NullLiteral.apply |
+    keyword("null") ^^^ NullLiteral |
     keyword("true") ^^^ BoolLiteral(true) |
     keyword("false") ^^^ BoolLiteral(false)
 

--- a/core/src/main/scala/slamdata/engine/std/relations.scala
+++ b/core/src/main/scala/slamdata/engine/std/relations.scala
@@ -105,7 +105,8 @@ trait RelationsLib extends Library {
   val IsNull = Mapping("IS_NULL", "Determines if a value is the special value Null. May or may not be equivalent to applying Eq to the value and Null.", Type.Top :: Nil,
     partialTyper {
       case Type.Const(Data.Null) :: Nil => Type.Const(Data.Bool(true))
-      case _ => Type.Bool
+      case Type.Const(_)         :: Nil => Type.Const(Data.Bool(false))
+      case _                            => Type.Bool
     },
     UnaryBool
   )
@@ -158,13 +159,17 @@ trait RelationsLib extends Library {
     partialTyper {
       case Type.Null             :: v2 :: Nil => v2
       case Type.Const(Data.Null) :: v2 :: Nil => v2
-      case (v1: Type.Const)      :: _  :: Nil => v1
+      case Type.Const(v1)        :: _  :: Nil => Type.Const(v1)
       case v1 :: Type.Null             :: Nil => v1
       case v1 :: Type.Const(Data.Null) :: Nil => v1
       case v1 :: v2                    :: Nil => Type.lub(v1, v2)
     },
-    t => success(t :: t :: Nil)
-  )
+    t => success(t :: t :: Nil))
+
+  val Constantly = Mapping("CONSTANTLY", "Always return the same value",
+    Type.Top :: Type.Top :: Nil,
+    partialTyper { case const :: _ :: Nil => const },
+    t => success(t :: Type.Top :: Nil))
 
   def functions = Eq :: Neq :: Lt :: Lte :: Gt :: Gte :: Between :: IsNull :: And :: Or :: Not :: Cond :: Coalesce :: Nil
 

--- a/core/src/main/scala/slamdata/engine/variables.scala
+++ b/core/src/main/scala/slamdata/engine/variables.scala
@@ -19,7 +19,7 @@ object Variables {
 
   def coerce(t: Type, varValue: VarValue): Option[Expr] = {
     val matchType: PartialFunction[Expr, Expr] = {
-      case l @ NullLiteral()    if t contains Type.Null => l
+      case l @ NullLiteral      if t contains Type.Null => l
       case l @ BoolLiteral(_)   if t contains Type.Bool => l
       case l @ IntLiteral(_)    if t contains Type.Int  => l
       case l @ FloatLiteral(_)  if t contains Type.Dec  => l

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -78,6 +78,15 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         beWorkflow($pure(Bson.Doc(ListMap("0" -> Bson.Int64(1)))))
     }
 
+    "plan simple constant from collection" in {
+      plan("select 1 from zips") must
+        beWorkflow(chain(
+          $read(Collection("db", "zips")),
+          $project(Reshape(ListMap(
+            BsonField.Name("0") -> -\/(ExprOp.Literal(Bson.Int64(1))))),
+            IgnoreId)))
+    }
+
     "plan simple select *" in {
       plan("select * from foo") must beWorkflow($read(Collection("db", "foo")))
     }
@@ -1569,7 +1578,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     "plan expression with timestamp, date, time, and interval" in {
       import org.threeten.bp.{Instant, LocalDateTime, ZoneOffset}
 
-      plan("select timestamp '2014-11-17T22:00:00Z' + interval 'PT43M40S', date '2015-01-19', time '14:21' from foo") must
+      plan("select timestamp '2014-11-17T22:00:00Z' + interval 'PT43M40S', date '2015-01-19', time '14:21'") must
         beWorkflow(
           $pure(Bson.Doc(ListMap(
             "0" -> Bson.Date(Instant.parse("2014-11-17T22:43:40Z")),
@@ -2082,7 +2091,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
   def genOuterInt = Gen.oneOf(
     Gen.const(IntLiteral(0)),
     genReduceInt,
-    genReduceInt.flatMap(x => sql.Binop(x, IntLiteral(1000), sql.Div)))
+    genReduceInt.flatMap(sql.Binop(_, IntLiteral(1000), sql.Div)))
 
   def genInnerStr = Gen.oneOf(
     sql.Ident("city"),

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -692,6 +692,21 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             ListMap())))
     }
 
+    "plan select with wildcard and two constants" in {
+      plan("select *, '1', '2' from zips") must
+        beWorkflow(chain(
+          $read(Collection("db", "zips")),
+          $simpleMap(
+            NonEmptyList(MapExpr(JsFn(Ident("x"),
+              SpliceObjects(List(
+                Ident("x").fix,
+                Obj(ListMap(
+                  "1" -> JsCore.Literal(Js.Str("1")).fix)).fix,
+                Obj(ListMap(
+                  "2" -> JsCore.Literal(Js.Str("2")).fix)).fix)).fix))),
+            ListMap())))
+    }
+
     "plan select with multiple wildcards and fields" in {
       plan("select state as state2, *, city as city2, *, pop as pop2 from zips where pop < 1000") must
         beWorkflow(chain(

--- a/core/src/test/scala/slamdata/engine/sql/SqlParserSpec.scala
+++ b/core/src/test/scala/slamdata/engine/sql/SqlParserSpec.scala
@@ -391,7 +391,7 @@ class SQLParserSpec extends Specification with ScalaCheck with DisjunctionMatche
         s  <- Gen.choose(1, 5)
         cs <- Gen.listOfN(s, Gen.oneOf("'", "\\", " ", "\n", "\t", "a", "b", "c"))
       } yield StringLiteral(cs.mkString),
-      Gen.const(NullLiteral()),
+      Gen.const(NullLiteral),
       Gen.const(BoolLiteral(true)),
       Gen.const(BoolLiteral(false)))
 

--- a/core/src/test/scala/slamdata/engine/variables.scala
+++ b/core/src/test/scala/slamdata/engine/variables.scala
@@ -38,7 +38,7 @@ class VariablesSpec extends Specification with ScalaCheck {
     }
 
     "coerce null / Top to null" in {
-      c("null", Type.Top) must beSome(NullLiteral())
+      c("null", Type.Top) must beSome(NullLiteral)
     }
 
     "coerce true / Top to Bool" in {
@@ -50,7 +50,7 @@ class VariablesSpec extends Specification with ScalaCheck {
     }
 
     "coerce null / Null to null" in {
-      c("null", Type.Null) must beSome(NullLiteral())
+      c("null", Type.Null) must beSome(NullLiteral)
     }
 
     "coerce true / Bool to Bool" in {

--- a/it/src/test/resources/tests/fieldOrder.test
+++ b/it/src/test/resources/tests/fieldOrder.test
@@ -3,10 +3,8 @@
 
   "data": "zips.data",
 
-  "query": "select count(*)/1000, 0 from zips",
+  "query": "select distinct count(*)/1000, 0 from zips",
 
   "predicate": "equalsExactly",
-  "expected": [
-    { "0": 29.353, "1": 0 }
-  ]
+  "expected": [{ "0": 29.353, "1": 0 }]
 }

--- a/it/src/test/resources/tests/fieldOrder.test
+++ b/it/src/test/resources/tests/fieldOrder.test
@@ -1,10 +1,14 @@
 {
-  "name": "reduced expressions which trigger bad field ordering (#584)",
+    "name": "reduced expressions which trigger bad field ordering (#584)",
 
-  "data": "zips.data",
+    "data": "zips.data",
 
-  "query": "select distinct count(*)/1000, 0 from zips",
+    "query": "select count(*)/1000, 0 from zips limit 5",
 
-  "predicate": "equalsExactly",
-  "expected": [{ "0": 29.353, "1": 0 }]
+    "predicate": "equalsExactly",
+    "expected": [{ "0": 29.353, "1": 0 },
+                 { "0": 29.353, "1": 0 },
+                 { "0": 29.353, "1": 0 },
+                 { "0": 29.353, "1": 0 },
+                 { "0": 29.353, "1": 0 }]
 }

--- a/it/src/test/resources/tests/wildcardWithMultipleConstants.test
+++ b/it/src/test/resources/tests/wildcardWithMultipleConstants.test
@@ -1,0 +1,17 @@
+{
+    "name": "splice a wildcard with multiple constants",
+
+    "data": "zips.data",
+
+    "query": "select *, '1', '2' from zips",
+
+    "predicate": "containsAtLeast",
+    "expected": [
+        { "value": { "_id": "01001", "1": "1", "2": "2", "city": "AGAWAM", "loc": [-72.622739, 42.070206], "pop": 15338, "state": "MA" } },
+        { "value": { "_id": "01008", "1": "1", "2": "2", "city": "BLANDFORD", "loc": [-72.936114, 42.182949], "pop": 1240, "state": "MA" } },
+        { "value": { "_id": "01010", "1": "1", "2": "2", "city": "BRIMFIELD", "loc": [-72.188455, 42.116543], "pop": 3706, "state": "MA" } },
+        { "value": { "_id": "01011", "1": "1", "2": "2", "city": "CHESTER", "loc": [-72.988761, 42.279421], "pop": 1688, "state": "MA" } },
+        { "value": { "_id": "01012", "1": "1", "2": "2", "city": "CHESTERFIELD", "loc": [-72.833309, 42.38167], "pop": 177, "state": "MA" } },
+        { "value": { "_id": "01013", "1": "1", "2": "2", "city": "CHICOPEE", "loc": [-72.607962, 42.162046], "pop": 23396, "state": "MA" } },
+        { "value": { "_id": "01020", "1": "1", "2": "2", "city": "CHICOPEE", "loc": [-72.576142, 42.176443], "pop": 31495, "state": "MA" } }]
+}


### PR DESCRIPTION
Fixes #608 and fixes #704.

Also, convert NullLiteral from a class to an object and add some tests
to improve coverage.