### PR TITLE
zip up directories for downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,8 @@ Retrieves data from the specified path, formatted in JSON or CSV format. The `of
 
 The output format can be selected using an `Accept` header as described above.
 
+Given a directory path (ending with a slash), produces a `zip` archive containing the contents of the named directory, database, etc. Each file in the archive is formatted as specified in the request query and/or `Accept` header.
+
 ### PUT /data/fs/[path]
 
 Replaces data at the specified path, formatted as one JSON object per line in the same format as above.

--- a/web/src/main/scala/slamdata/engine/api/zip.scala
+++ b/web/src/main/scala/slamdata/engine/api/zip.scala
@@ -1,0 +1,92 @@
+package slamdata.engine.api
+
+import java.util.{zip => jzip}
+
+import scalaz.concurrent._
+import scalaz.stream._
+import scodec.bits.{ByteVector}
+
+import slamdata.engine.fs.{Path}
+
+object Zip {
+  def zipFiles(files: List[(Path, Process[Task, ByteVector])]): Process[Task, ByteVector] = {
+    // First construct a single Process of Ops which can be performed in sequence
+    // to produce the entire archive.
+    sealed trait Op
+    object Op {
+      final case object Start extends Op
+      final case class StartEntry(entry: jzip.ZipEntry) extends Op
+      final case class Chunk(bytes: ByteVector) extends Op
+      final case object EndEntry extends Op
+      final case object End extends Op
+    }
+
+    val ops: Process[Task, Op] = {
+      def fileOps(path: Path, bytes: Process[Task, ByteVector]) =
+        Process.emit(Op.StartEntry(new jzip.ZipEntry(path.simplePathname))) ++
+          bytes.map(Op.Chunk(_)) ++
+          Process.emit(Op.EndEntry)
+
+      Process.emit(Op.Start) ++
+        Process.emitAll(files).flatMap((fileOps _).tupled) ++
+        Process.emit(Op.End)
+    }
+
+    // Wrap up ZipOutputStream's statefulness in a class offering just two
+    // mutating operations: one to accept an Op to be processed, and another
+    // to poll for data that's been written.
+    class Buffer {
+      private var chunks = ByteVector.empty
+
+      private def append(bytes: ByteVector) = chunks = chunks ++ bytes
+
+      private val sink = {
+        val os = new java.io.OutputStream {
+          def write(b: Int) = append(ByteVector(b.toByte))
+
+          // NB: overriding here to process each buffer-worth coming from the ZipOS in one call
+          override def write(b: Array[Byte], off: Int, len: Int) = append(ByteVector(b, off, len))
+        }
+        val zos = new jzip.ZipOutputStream(os)
+        // zos.setLevel(jzip.Deflater.NO_COMPRESSION)  // about 2x faster
+        // zos.setLevel(jzip.Deflater.BEST_SPEED)  // no noticable speedup
+        zos
+      }
+
+      def accept(op: Op): Task[Unit] = Task.delay {
+        op match {
+          case Op.Start             => ()
+          case Op.StartEntry(entry) => sink.putNextEntry(entry)
+          case Op.Chunk(bytes)      => sink.write(bytes.toArray)
+          case Op.EndEntry          => sink.closeEntry
+          case Op.End               => sink.close
+        }
+      }
+
+      def poll: Task[ByteVector] = Task.delay {
+        val result = chunks
+        chunks = ByteVector.empty
+        result
+      }
+    }
+
+    // Fold the allocation of Buffer instances in to the processing
+    // of Ops, so that a new instance is created as needed each time
+    // the resulting process is run, then flatMap so that each chunk
+    // can be handled in Task.
+    ops.zipWithState[Option[Buffer]](None) {
+      case (_, None)         => Some(new Buffer)
+      case (Op.End, Some(_)) => None
+      case (_, buf@Some(_))  => buf
+    }.flatMap {
+      case (Op.Start, _)   => Process.emit(ByteVector.empty)
+      case (op, Some(buf)) =>
+        Process.eval(
+          for {
+            _ <- buf.accept(op)
+            b <- buf.poll
+          } yield b)
+      case (_, None)       => Process.fail(new RuntimeException("unexpected state"))
+    }
+  }
+}

--- a/web/src/test/scala/slamdata/engine/api/zip.scala
+++ b/web/src/test/scala/slamdata/engine/api/zip.scala
@@ -1,0 +1,96 @@
+package slamdata.engine.api
+
+import org.specs2.mutable._
+
+import scalaz.concurrent._
+import scalaz.stream.{Process}
+import scodec.bits._
+
+import slamdata.engine.fs.{Path}
+
+class ZipSpecs extends Specification {
+  args.report(showtimes=true)
+
+  "zipFiles" should {
+    import Zip._
+
+    def rand: Byte = (java.lang.Math.random*256).toByte
+
+    val f1: Process[Task, ByteVector] = Process.emit(ByteVector(Array[Byte](0)))
+    val f2: Process[Task, ByteVector] = Process.emit(ByteVector(Array.fill[Byte](1000)(0)))
+    def f3: Process[Task, ByteVector] = Process.emit(ByteVector(Array.fill[Byte](1000)(rand)))
+    def f4: Process[Task, ByteVector] = Process.emitAll(Vector.fill(1000)(ByteVector(Array.fill[Byte](1000)(rand))))
+
+    // For testing, capture all the bytes from a process, parse them with a
+    // ZipInputStream, and capture just the size of the contents of each file.
+    def list(p: Process[Task, ByteVector]): Task[List[(Path, Long)]] = {
+      def count(is: java.io.InputStream): Long = {
+        def loop(n: Long): Long = if (is.read == -1) n else loop(n+1)
+        loop(0)
+      }
+
+      Task.delay {
+        val bytes = p.runLog.run.reduce(_ ++ _)  // FIXME: this means we can't use this to test anything big
+        val is = new java.io.ByteArrayInputStream(bytes.toArray)
+        val zis = new java.util.zip.ZipInputStream(is)
+        Stream.continually(zis.getNextEntry).takeWhile(_ != null).map { entry =>
+          Path(entry.getName) -> count(zis)
+        }.toList
+      }
+    }
+
+    "zip one file" in {
+      val z = zipFiles(List(Path("foo") -> f1))
+      list(z).run must_== List(Path("foo") -> 1)
+    }
+
+    "zip two files" in {
+      val z = zipFiles(List(
+        Path("foo") -> f1,
+        Path("bar") -> f1))
+      list(z).run must_== List(Path("foo") -> 1, Path("bar") -> 1)
+    }
+
+    "zip one larger file" in {
+      val z = zipFiles(List(
+        Path("foo") -> f2))
+      list(z).run must_== List(Path("foo") -> 1000)
+    }
+
+    "zip one file of random bytes" in {
+      val z = zipFiles(List(
+        Path("foo") -> f3))
+      list(z).run must_== List(Path("foo") -> 1000)
+    }
+
+    "zip one large file of random bytes" in {
+      val z = zipFiles(List(
+        Path("foo") -> f4))
+      list(z).run must_== List(Path("foo") -> 1000*1000)
+    }
+
+    "zip many large files of random bytes" in {
+      // NB: this is mainly a performance check. Right now it's about 7 seconds for 100 MB for me.
+      // That seems reasonable, but the main point is that it doesn't explode the heap.
+      val Files = 100
+      val MinExpectedSize = Files*1000*1000
+      val MaxExpectedSize = (MinExpectedSize*1.001).toInt
+
+      val paths = (0 until Files).toList.map(i => Path("foo" + i))
+      val z = zipFiles(paths.map(_ -> f4))
+
+      // NB: can't use my naive `list` function on a large file
+      z.map(_.size).sum.runLog.run(0) must beBetween(MinExpectedSize, MaxExpectedSize)
+    }
+
+    "read twice without conflict" in {
+      val z = zipFiles(List(
+        Path("foo") -> f2,
+        Path("bar") -> f2))
+
+      val t = z.runLog
+
+      t.run.reduce(_ ++ _) must_== t.run.reduce(_ ++ _)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #763 (the last checklist item).

Wraps Java's ZipOutputStream so that it can be used to transform the bytes of
a scalaz-stream Process.

This is all a bit tricky to test without writing the corresponding wrapping
for ZipInputStream, which I did not do. Instead, it tests some small data sets
for their exact contents, and tests some large data sets for performance,
without trying to do both at once.

Includes a simple test at the API level of the zipped content-type and
disposition, which required implementing `ls` properly in the test stub. Also
changed the expected behavior of `GET /metadata` with a non-existent directory
to match that implementation.