### PR TITLE
Fix combination of 3-arg exprs and grouping.

### DIFF
--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -594,20 +594,20 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         $read(Collection("db", "zips")),
         $project(
           Reshape(ListMap(
-            BsonField.Name("__tmp2") ->
+            BsonField.Name("__tmp4") ->
                 -\/(ExprOp.Neq(
                   DocField(BsonField.Name("city")),
                   DocField(BsonField.Name("state")))),
-            BsonField.Name("__tmp3") -> -\/(DocVar.ROOT()),
-            BsonField.Name("__tmp4") -> -\/(DocField(BsonField.Name("pop"))))),
+            BsonField.Name("__tmp5") -> -\/(DocVar.ROOT()),
+            BsonField.Name("__tmp6") -> -\/(DocField(BsonField.Name("pop"))))),
           IgnoreId),
         $match(Selector.And(
           Selector.Doc(
-            BsonField.Name("__tmp2") -> Selector.Eq(Bson.Bool(true))),
+            BsonField.Name("__tmp4") -> Selector.Eq(Bson.Bool(true))),
           Selector.Doc(
-            BsonField.Name("__tmp4") -> Selector.Lt(Bson.Int64(10000))))),
+            BsonField.Name("__tmp6") -> Selector.Lt(Bson.Int64(10000))))),
         $project(Reshape(ListMap(
-          BsonField.Name("value") -> -\/(DocField(BsonField.Name("__tmp3"))))),
+          BsonField.Name("value") -> -\/(DocField(BsonField.Name("__tmp5"))))),
           ExcludeId)))
     }
 
@@ -1609,23 +1609,23 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           $read(Collection("db", "days")),
           $project(
             Reshape(ListMap(
-              BsonField.Name("__tmp2") ->
+              BsonField.Name("__tmp4") ->
                 -\/(ExprOp.Subtract(
                   DocField(BsonField.Name("date")),
                   ExprOp.Literal(Bson.Dec(12*60*60*1000)))),
-              BsonField.Name("__tmp3") -> -\/(DocVar.ROOT()))),
+              BsonField.Name("__tmp5") -> -\/(DocVar.ROOT()))),
             IgnoreId),
           $match(
             Selector.And(
               Selector.Doc(
-                BsonField.Name("__tmp3") \ BsonField.Name("date") ->
+                BsonField.Name("__tmp5") \ BsonField.Name("date") ->
                   Selector.Lt(Bson.Date(Instant.parse("2014-11-17T22:00:00Z")))),
               Selector.Doc(
-                BsonField.Name("__tmp2") ->
+                BsonField.Name("__tmp4") ->
                   Selector.Gt(Bson.Date(Instant.parse("2014-11-17T00:00:00Z")))))),
           $project(Reshape(ListMap(
             BsonField.Name("value") ->
-              -\/(DocField(BsonField.Name("__tmp3"))))),
+              -\/(DocField(BsonField.Name("__tmp5"))))),
             ExcludeId)))
     }
 

--- a/it/src/test/resources/tests/caseWithGroup.test
+++ b/it/src/test/resources/tests/caseWithGroup.test
@@ -1,0 +1,26 @@
+{
+    "name": "combine case (3-arg expr) with group by",
+
+    "data": "zips.data",
+
+    "query": "select distinct
+                state as abbr,
+                count(pop) as quantity,
+                case
+                  when state = 'CO' then 1
+                  when state = 'WA' then 2
+                  when state = 'PA' then 3
+                  when state = 'VA' then 4
+                  else 100
+                end as funnel
+                from zips
+                group by state
+                order by funnel",
+
+    "predicate": "equalsInitial",
+    "expected": [{ "abbr": "CO", "quantity":  414, "funnel":   1 },
+                 { "abbr": "WA", "quantity":  484, "funnel":   2 },
+                 { "abbr": "PA", "quantity": 1458, "funnel":   3 },
+                 { "abbr": "VA", "quantity":  816, "funnel":   4 },
+                 { "abbr": "IL", "quantity": 1237, "funnel": 100 }]
+}

--- a/it/src/test/resources/tests/groupByExpression.test
+++ b/it/src/test/resources/tests/groupByExpression.test
@@ -3,11 +3,20 @@
 
   "data": "zips.data",
 
-  "query": "select substring(city, 0, 1) as \"first\", count(*) as numZips from zips group by substring(city, 0, 1)",
+  "query": "select distinct substring(city, 0, 1) as \"first\", count(*) as numZips from zips group by substring(city, 0, 1)",
 
   "predicate": "containsAtLeast",
-  "expected": [{ "numZips": 2,    "first": "X" },
-               { "numZips": 48,   "first": "Z" },
-               { "numZips": 2692, "first": "C" },
-               { "numZips": 2871, "first": "S" }]
+  "expected": [{ "first": "X", "numZips":    2 },
+               { "first": "Z", "numZips":   48 },
+               { "first": "C", "numZips": 2692 },
+               { "first": "B", "numZips": 2344 },
+               { "first": "M", "numZips": 2348 },
+               { "first": "H", "numZips": 1621 },
+               { "first": "A", "numZips": 1398 },
+               { "first": "W", "numZips": 1834 },
+               { "first": "U", "numZips":  165 },
+               { "first": "T", "numZips":  955 },
+               { "first": "F", "numZips": 1091 },
+               { "first": "O", "numZips":  767 },
+               { "first": "S", "numZips": 2871 }]
 }


### PR DESCRIPTION
Fixes #807.

The general `WorkflowBuilder.expr` has never been handled as well as
`expr1` and `expr2`. This finally corrects that and unifies all three
functions.

Also, fixed a bad integration test that expected the previous behavior.