### PR TITLE
use infinite idleTimeout in the API server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,6 @@ import de.heikoseeberger.sbtheader.HeaderPlugin
 
 val scalazVersion     = "7.1.0"
 val monocleVersion    = "1.1.1"
-val http4sVersion     = "0.8.2"
 val unfilteredVersion = "0.8.1"
 
 lazy val standardSettings = Defaults.defaultSettings ++ Seq(
@@ -59,9 +58,6 @@ lazy val standardSettings = Defaults.defaultSettings ++ Seq(
     "com.github.scopt"  %% "scopt"                     % "3.3.0"           % "compile, test",
     "org.threeten"      %  "threetenbp"                % "1.2"             % "compile, test",
     "org.mongodb"       %  "mongo-java-driver"         % "3.0.2"           % "compile, test",
-    "org.http4s"        %% "http4s-dsl"                % http4sVersion     % "compile, test",
-    "org.http4s"        %% "http4s-argonaut"           % http4sVersion     % "compile, test",
-    "org.http4s"        %% "http4s-jetty"              % http4sVersion     % "compile, test",
     "io.argonaut"       %% "argonaut"                  % "6.1-M6"          % "compile, test",
     "org.jboss.aesh"    %  "aesh"                      % "0.55"            % "compile, test",
     "org.scalaz"        %% "scalaz-scalacheck-binding" % scalazVersion     % "compile, test",

--- a/web/build.sbt
+++ b/web/build.sbt
@@ -2,6 +2,11 @@ name := "Web"
 
 mainClass in Compile := Some("slamdata.engine.api.Server")
 
+val http4sVersion     = "0.8.3"
+
 libraryDependencies ++= Seq(
-  "com.github.tototoshi"    %% "scala-csv"         % "1.1.2"
+  "org.http4s"           %% "http4s-dsl"       % http4sVersion % "compile, test",
+  "org.http4s"           %% "http4s-argonaut"  % http4sVersion % "compile, test",
+  "org.http4s"           %% "http4s-blazeserver" % http4sVersion % "compile, test",
+  "com.github.tototoshi" %% "scala-csv"        % "1.1.2"
 )

--- a/web/src/main/scala/slamdata/engine/api/fs.scala
+++ b/web/src/main/scala/slamdata/engine/api/fs.scala
@@ -567,5 +567,5 @@ final case class FileSystemApi(backend: Backend, contentPath: String, config: Co
     "/server"      -> serverService(config, reloader),
     "/slamdata"    -> staticFileService(contentPath + "/slamdata"),
     "/"            -> redirectService("/slamdata")) ∘
-      (svc => FailSafe(Cors(middleware.GZip(HeaderParam(svc)))))
+      (svc => Cors(middleware.GZip(HeaderParam(svc))))
 }

--- a/web/src/test/scala/slamdata/engine/api/fs.scala
+++ b/web/src/test/scala/slamdata/engine/api/fs.scala
@@ -6,6 +6,8 @@ import slamdata.engine.config._
 import slamdata.engine.fp._
 import slamdata.engine.fs._
 
+import scala.concurrent.duration._
+
 import scala.collection.immutable.ListMap
 import scalaz._
 import scalaz.concurrent._
@@ -27,7 +29,7 @@ object Action {
   final case class Reload(cfg: Config) extends Action
 }
 
-class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAccurateCoverage {
+class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAccurateCoverage with org.specs2.time.NoTimeConversions {
   sequential  // Each test binds the same port
   args.report(showtimes = true)
 
@@ -41,7 +43,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
   down the server.
   */
   def withServer[A](backend: Backend, config: Config)(body: => A): A = {
-    val srv = Server.run(port, FileSystemApi(backend, ".", config, cfg => Task.delay {
+    val srv = Server.run(port, 1.seconds, FileSystemApi(backend, ".", config, cfg => Task.delay {
       historyBuff += Action.Reload(cfg)
       ()
     })).run


### PR DESCRIPTION
Fixes #833.

The timeout is now a parameter when running the server, which is hard-coded to
infinity for real life, and set to 1 second in tests.

This required switching to the Blaze backend (probably a good thing anyway),
because of a bug in the Jetty backend that we were using (see
http4s/http4s#336). That required a workaround for the bug in the Blaze
backend that was the reason we went with the Jetty backend in the first place
(see http4s/http4s#337).

Disabled our `FailSafe` middleware, which was only necessary due to another
bug in the Jetty backend (see http4s/http4s#338).

Moved the http4s dependencies to the web sub-project, and bumped the version
to 0.8.3 for good measure.