### PR TITLE
fix exception in compiler with un-annotated Expr

### DIFF
--- a/core/src/test/scala/slamdata/engine/compiler.scala
+++ b/core/src/test/scala/slamdata/engine/compiler.scala
@@ -304,6 +304,16 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
               Free('tmp2)))))
     }
 
+    "compile conditional (match) without else" in {
+      compileExp("select case when pop = 0 then 'nobody' end from zips") must_==
+        compileExp("select case when pop = 0 then 'nobody' else null end from zips")
+    }
+
+    "compile conditional (switch) without else" in {
+      compileExp("select case pop when 0 then 'nobody' end from zips") must_==
+        compileExp("select case pop when 0 then 'nobody' else null end from zips")
+    }
+
     "compile array length" in {
       testLogicalPlanCompile(
         "select array_length(bar, 1) from foo",

--- a/it/src/test/resources/tests/caseVariations.test
+++ b/it/src/test/resources/tests/caseVariations.test
@@ -1,0 +1,44 @@
+{
+    "name": "four different kinds of CASE expressions (switch/match, with and without ELSE)",
+
+    "data": "zips.data",
+
+    "query": "select distinct
+                case pop
+                  when 0 then 'nobody'
+                  when 1 then 'one'
+                  when 2 then 'a couple'
+                  when 3 then 'a few'
+                  else 'more'
+                end as cardinal,
+                case pop
+                  when 1 then 0
+                  when 10 then 1
+                end as power,
+                case
+                  when pop % 2 = 0 then 'even'
+                  when pop = 1 or pop = 9 then 'odd'
+                  else 'prime'
+                end as parity,
+                case
+                  when pop > 5 then pop - 5
+                end as grade
+                from zips
+                where pop <= 10
+                order by pop",
+
+    "predicate": "equalsExactly",
+    "expected": [
+      { "cardinal": "nobody",   "power": null, "parity": "even" , "grade": null },
+      { "cardinal": "one",      "power": 0   , "parity": "odd"  , "grade": null },
+      { "cardinal": "a couple", "power": null, "parity": "even" , "grade": null },
+      { "cardinal": "a few",    "power": null, "parity": "prime", "grade": null },
+      { "cardinal": "more",     "power": null, "parity": "even" , "grade": null },
+      { "cardinal": "more",     "power": null, "parity": "prime", "grade": null },
+      { "cardinal": "more",     "power": null, "parity": "even" , "grade": 1    },
+      { "cardinal": "more",     "power": null, "parity": "prime", "grade": 2    },
+      { "cardinal": "more",     "power": null, "parity": "even" , "grade": 3    },
+      { "cardinal": "more",     "power": null, "parity": "odd"  , "grade": 4    },
+      { "cardinal": "more",     "power": 1   , "parity": "even" , "grade": 5    }
+    ]
+}


### PR DESCRIPTION
Fixes #815.

We were trying to compile an Expr that wasn't part of the original AST, so had
no annotations. This is the easy fix: just use the LogicalPlan equivalent
directly.

Really, `attr` should be partial, so it could fail if you ask for the
annotation for some unknown node. As it is, it has to be unsafe. But really
we'd rather use fixplate probably, so I'm not going there right now.