### PR TITLE
Don't push $$ROOT as a rule.

### DIFF
--- a/core/src/main/scala/slamdata/engine/backends.scala
+++ b/core/src/main/scala/slamdata/engine/backends.scala
@@ -39,7 +39,7 @@ object BackendDefinitions {
       } yield new MongoDbFileSystem {
         val planner = MongoDbPlanner
         val evaluator = MongoDbEvaluator(client, defaultDb)
-        val RP = implicitly[RenderTree[Workflow]]
+        val RP = RenderTree[Crystallized]
         protected def db = MongoWrapper(client, defaultDb)
       }
   })

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/filesystem.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/filesystem.scala
@@ -26,7 +26,7 @@ import scalaz.stream._
 import scalaz.stream.io._
 import scalaz.concurrent._
 
-trait MongoDbFileSystem extends PlannerBackend[Workflow.Workflow] {
+trait MongoDbFileSystem extends PlannerBackend[Workflow.Crystallized] {
   protected def db: MongoWrapper
 
   val ChunkSize = 1000

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -898,10 +898,10 @@ object WorkflowBuilder {
           delegate
 
         case (
-          DocBuilderF(s1, shape),
+          DocBuilderF(_, shape),
           DocBuilderF(Term(GroupBuilderF(_, Nil, _, id2)), _)) =>
           impl(
-            DocBuilder(GroupBuilder(s1, Nil, Expr(-\/(DocVar.ROOT())), id2), shape),
+            GroupBuilder(wb1, Nil, Doc(shape.map { case (n, _) => n -> -\/(DocField(n)) }), id2),
             wb2,
             combine)
         case (

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -572,9 +572,8 @@ object WorkflowBuilder {
   def build(wb: WorkflowBuilder): M[Workflow] =
     toCollectionBuilder(wb).map {
       case CollectionBuilderF(graph, base, struct) =>
-        finish(
-          if (base == DocVar.ROOT(None)) graph
-          else shift(base, struct, graph)._1)
+        if (base == DocVar.ROOT(None)) graph
+        else shift(base, struct, graph)._1
     }
 
   private def $project(shape: Reshape): WorkflowOp =
@@ -886,10 +885,10 @@ object WorkflowBuilder {
           }
 
         case (
-          DocBuilderF(s1, shape),
+          DocBuilderF(_, shape),
           GroupBuilderF(_, Nil, _, id2)) =>
           impl(
-            DocBuilder(GroupBuilder(s1, Nil, Expr(-\/(DocVar.ROOT())), id2), shape),
+            GroupBuilder(wb1, Nil, Doc(shape.map { case (n, _) => n -> -\/(DocField(n)) }), id2),
             wb2,
             combine)
         case (
@@ -1211,7 +1210,7 @@ object WorkflowBuilder {
 
     workflow(wb).evalZero.fold(
       κ(false),
-      wf => checkTask(task(wf._1)))
+      wf => checkTask(task(crystallize(wf._1))))
   }
 
   def join(left0: WorkflowBuilder, right0: WorkflowBuilder,

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowop.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowop.scala
@@ -176,8 +176,8 @@ object Workflow {
     }
   }
 
-  def task(op: Workflow): WorkflowTask =
-    (WorkflowTask.finish _).tupled(finalize(op).para(crush))._2
+  def task(fop: Crystallized): WorkflowTask =
+    (WorkflowTask.finish _).tupled(fop.op.para(crush))._2
 
   val finish: Workflow => Workflow = reorderOps _  >>> deleteUnusedFields _
 
@@ -515,6 +515,13 @@ object Workflow {
   def chain(src: Workflow, op1: WorkflowOp, ops: (WorkflowOp)*): Workflow =
     ops.foldLeft(op1(src))((s, o) => o(s))
 
+  /** A type for a `Workflow` which has had `crystallize` applied to it. */
+  final case class Crystallized(op: Workflow)
+
+  implicit val CrystallizedRenderTree = new RenderTree[Crystallized] {
+    def render(v: Crystallized) = RenderTree[Workflow].render(v.op)
+  }
+
   /**
     Performs some irreversible conversions, meant to be used once, after the
     entire workflow has been generated.
@@ -527,53 +534,53 @@ object Workflow {
   // none:             $Sort
   // NB: We don’t convert a $Project after a map/reduce op because it could
   //     affect the final shape unnecessarily.
-  private def finalize0(op: Workflow): Workflow = op.unFix match {
-    case mr: MapReduceF[Workflow] => mr.src.unFix match {
-      case $Project(src, shape, _)  =>
-        shape.toJs.fold(
-          κ(op.descend(finalize0(_))),
-          x => {
-            val base = JsCore.Ident("__rez")
-            finalize0(mr.reparentW($simpleMap(NonEmptyList(MapExpr(JsFn(base, x(base.fix)))), ListMap())(src)))
-          })
-      case uw @ $Unwind(_, _)       => finalize0(mr.reparentW(Term(uw.flatmapop)))
-      case sm @ $SimpleMap(_, _, _) => finalize0(mr.reparentW(Term(sm.raw)))
-      case _                        => op.descend(finalize0(_))
+  def crystallize(op: Workflow): Crystallized = {
+    def crystallize0(op: Workflow): Workflow = op.unFix match {
+      case mr: MapReduceF[Workflow] => mr.src.unFix match {
+        case $Project(src, shape, _)  =>
+          shape.toJs.fold(
+            κ(op.descend(crystallize0(_))),
+            x => {
+              val base = JsCore.Ident("__rez")
+              crystallize0(mr.reparentW($simpleMap(NonEmptyList(MapExpr(JsFn(base, x(base.fix)))), ListMap())(src)))
+            })
+        case uw @ $Unwind(_, _)       => crystallize0(mr.reparentW(Term(uw.flatmapop)))
+        case sm @ $SimpleMap(_, _, _) => crystallize0(mr.reparentW(Term(sm.raw)))
+        case _                        => op.descend(crystallize0(_))
+      }
+      case op @ $FoldLeft(head, tail) =>
+        $foldLeft(
+          crystallize0(chain(
+            head,
+            $project(Reshape(ListMap(
+              ExprName -> -\/(ExprOp.DocVar.ROOT()))),
+              IncludeId))),
+          crystallize0(tail.head.unFix match {
+            case $Reduce(_, _, _) => tail.head
+            case _ => chain(tail.head, $reduce($Reduce.reduceFoldLeft, ListMap()))
+          }),
+          tail.tail.map(x => crystallize0(x.unFix match {
+            case $Reduce(_, _, _) => x
+            case _ => chain(x, $reduce($Reduce.reduceFoldLeft, ListMap()))
+          })):_*)
+
+      case _ => op.descend(crystallize0)
     }
-    case op @ $FoldLeft(head, tail) =>
-      $foldLeft(
-        finalize0(chain(
-          head,
-          $project(Reshape(ListMap(
-            ExprName -> -\/(ExprOp.DocVar.ROOT()))),
-            IncludeId))),
-        finalize0(tail.head.unFix match {
-          case $Reduce(_, _, _) => tail.head
-          case _ => chain(tail.head, $reduce($Reduce.reduceFoldLeft, ListMap()))
-        }),
-        tail.tail.map(x => finalize0(x.unFix match {
-          case $Reduce(_, _, _) => x
-          case _ => chain(x, $reduce($Reduce.reduceFoldLeft, ListMap()))
-        })):_*)
 
-    case _ => op.descend(finalize0)
-  }
-
-  def finalize(op: Workflow): Workflow = {
-    val finalized = finalize0(finish(op))
+    val crystallized = crystallize0(finish(op))
 
     def fixShape(wf: Workflow) =
       Workflow.simpleShape(wf).fold(
-        finalized)(
-        n => $project(Reshape(n.map(_.toName -> -\/(Include)).toListMap), IgnoreId)(finalized))
+        crystallized)(
+        n => $project(Reshape(n.map(_.toName -> -\/(Include)).toListMap), IgnoreId)(crystallized))
 
     def promoteKnownShape(wf: Workflow): Workflow = wf.unFix match {
       case $SimpleMap(_, _, _)  => fixShape(wf)
       case sp: ShapePreservingF[_] => promoteKnownShape(sp.src)
-      case _                       => finalized
+      case _                       => crystallized
     }
 
-    promoteKnownShape(finalized)
+    Crystallized(promoteKnownShape(crystallized))
   }
 
   final case class $Pure(value: Bson) extends SourceOp

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/evaluator.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/evaluator.scala
@@ -18,7 +18,7 @@ class EvaluatorSpec extends Specification with DisjunctionMatchers {
     "write trivial workflow to JS" in {
       val wf = $read(Collection("db", "zips"))
 
-      MongoDbEvaluator.toJS(wf) must beRightDisj(
+      MongoDbEvaluator.toJS(crystallize(wf)) must beRightDisj(
         s"""db.zips.find();
            |""".stripMargin)
     }
@@ -26,7 +26,7 @@ class EvaluatorSpec extends Specification with DisjunctionMatchers {
     "write trivial workflow to JS with fancy collection name" in {
       val wf = $read(Collection("db", "tmp.123"))
 
-      MongoDbEvaluator.toJS(wf) must beRightDisj(
+      MongoDbEvaluator.toJS(crystallize(wf)) must beRightDisj(
         s"""db.getCollection(\"tmp.123\").find();
            |""".stripMargin)
     }
@@ -34,7 +34,7 @@ class EvaluatorSpec extends Specification with DisjunctionMatchers {
     "write workflow with simple pure value" in {
       val wf = $pure(Bson.Doc(ListMap("foo" -> Bson.Text("bar"))))
 
-        MongoDbEvaluator.toJS(wf) must beRightDisj(
+        MongoDbEvaluator.toJS(crystallize(wf)) must beRightDisj(
           """db.tmp.gen_0.insert({ "foo": "bar" });
             |db.tmp.gen_0.find();
             |""".stripMargin)
@@ -45,7 +45,7 @@ class EvaluatorSpec extends Specification with DisjunctionMatchers {
         Bson.Doc(ListMap("foo" -> Bson.Int64(1))),
         Bson.Doc(ListMap("bar" -> Bson.Int64(2))))))
 
-        MongoDbEvaluator.toJS(wf) must beRightDisj(
+        MongoDbEvaluator.toJS(crystallize(wf)) must beRightDisj(
           """db.tmp.gen_0.insert({ "foo": NumberLong(1) });
             |db.tmp.gen_0.insert({ "bar": NumberLong(2) });
             |db.tmp.gen_0.find();
@@ -55,7 +55,7 @@ class EvaluatorSpec extends Specification with DisjunctionMatchers {
     "fail with non-doc pure value" in {
       val wf = $pure(Bson.Text("foo"))
 
-      MongoDbEvaluator.toJS(wf) must beAnyLeftDisj
+      MongoDbEvaluator.toJS(crystallize(wf)) must beAnyLeftDisj
     }
 
     "fail with multiple pure values, one not a doc" in {
@@ -63,7 +63,7 @@ class EvaluatorSpec extends Specification with DisjunctionMatchers {
         Bson.Doc(ListMap("foo" -> Bson.Int64(1))),
         Bson.Int64(2))))
 
-        MongoDbEvaluator.toJS(wf) must beAnyLeftDisj
+        MongoDbEvaluator.toJS(crystallize(wf)) must beAnyLeftDisj
     }
 
     "write simple pipeline workflow to JS" in {
@@ -72,7 +72,7 @@ class EvaluatorSpec extends Specification with DisjunctionMatchers {
         $match(Selector.Doc(
           BsonField.Name("pop") -> Selector.Gte(Bson.Int64(1000)))))
 
-      MongoDbEvaluator.toJS(wf) must beRightDisj(
+      MongoDbEvaluator.toJS(crystallize(wf)) must beRightDisj(
         """db.zips.aggregate(
           |  [
           |    { "$match": { "pop": { "$gte": NumberLong(1000) } } },
@@ -91,7 +91,7 @@ class EvaluatorSpec extends Specification with DisjunctionMatchers {
           BsonField.Name("pop") -> Selector.Gte(Bson.Int64(100)))),
         $sort(NonEmptyList(BsonField.Name("city") -> Ascending)))
 
-      MongoDbEvaluator.toJS(wf) must beRightDisj(
+      MongoDbEvaluator.toJS(crystallize(wf)) must beRightDisj(
         """db.zips.aggregate(
           |  [
           |    {
@@ -121,7 +121,7 @@ class EvaluatorSpec extends Specification with DisjunctionMatchers {
             List(Js.Ident("values")))))),
           ListMap()))
 
-      MongoDbEvaluator.toJS(wf) must beRightDisj(
+      MongoDbEvaluator.toJS(crystallize(wf)) must beRightDisj(
         """db.zips.mapReduce(
           |  function () {
           |    emit.apply(
@@ -141,7 +141,7 @@ class EvaluatorSpec extends Specification with DisjunctionMatchers {
         $read(Collection("db", "zips2")),
         $match(Selector.Where(Js.Ident("foo"))))
 
-      MongoDbEvaluator.toJS(wf) must beRightDisj(
+      MongoDbEvaluator.toJS(crystallize(wf)) must beRightDisj(
         """db.zips2.mapReduce(
           |  function () {
           |    emit.apply(
@@ -178,7 +178,7 @@ class EvaluatorSpec extends Specification with DisjunctionMatchers {
                 List(Js.Ident("values")))))),
               ListMap())))
 
-      MongoDbEvaluator.toJS(wf) must beRightDisj(
+      MongoDbEvaluator.toJS(crystallize(wf)) must beRightDisj(
         """db.zips1.aggregate(
           |  [
           |    { "$match": { "city": "BOULDER" } },

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -28,18 +28,19 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
   import ExprOp._
   import IdHandling._
   import JsCore._
+  import Planner._
 
   case class equalToWorkflow(expected: Workflow)
-      extends Matcher[Workflow] {
-    def apply[S <: Workflow](s: Expectable[S]) = {
+      extends Matcher[Crystallized] {
+    def apply[S <: Crystallized](s: Expectable[S]) = {
       def diff(l: S, r: Workflow): String = {
-        val lt = RenderTree[Workflow].render(l)
+        val lt = RenderTree[Crystallized].render(l)
         val rt = RenderTree[Workflow].render(r)
         RenderTree.show(lt diff rt)(new RenderTree[RenderedTree] {
           override def render(v: RenderedTree) = v
         }).toString
       }
-      result(expected == s.value,
+      result(expected == s.value.op,
              "\ntrees are equal:\n" + diff(s.value, expected),
              "\ntrees are not equal:\n" + diff(s.value, expected),
              s)
@@ -48,17 +49,22 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
 
   val queryPlanner = MongoDbPlanner.queryPlanner(κ("Mongo" -> Cord.empty))
 
-  def plan(query: String): Either[Error, Workflow] =
+  def plan(query: String): Either[Error, Crystallized] =
     (for {
       expr <- SQLParser.parseInContext(Query(query), Path("/db/"))
-      plan <- queryPlanner(QueryRequest(expr, None, Variables(Map())))._2.map(Workflow.finish)
+      plan <- queryPlanner(QueryRequest(expr, None, Variables(Map())))._2
     } yield plan).toEither
 
-  def plan(logical: Term[LogicalPlan]): Either[Error, Workflow] =
+  def plan(logical: Term[LogicalPlan]): Either[Error, Crystallized] =
     (for {
-      simplified <- \/-(logical.cata(Optimizer.simplify))
-      phys <- MongoDbPlanner.plan(simplified)
-    } yield phys).toEither
+      simplified <- emit(Vector.empty, \/-(logical.cata(Optimizer.simplify)))
+      phys       <- MongoDbPlanner.plan(simplified)
+    } yield phys).run.run._2.toEither
+
+  def planLog(query: String): Error \/ Vector[PhaseResult] =
+    for {
+      expr <- SQLParser.parseInContext(Query(query), Path("/db/"))
+    } yield queryPlanner(QueryRequest(expr, None, Variables(Map())))._1
 
   def beWorkflow(wf: Workflow) = beRight(equalToWorkflow(wf))
 
@@ -280,7 +286,11 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         $simpleMap(NonEmptyList(MapExpr(JsFn(Ident("x"), Obj(ListMap(
           "0" -> Access(Select(Ident("x").fix, "loc").fix,
             JsCore.Literal(Js.Num(0, false)).fix).fix)).fix))),
-          ListMap())))
+          ListMap()),
+        $project(
+          reshape(
+            "0" -> Include),
+          IgnoreId)))
     }
 
     "plan array length" in {
@@ -462,7 +472,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     "plan filter with ~" in {
-      plan("select * from zips where city ~ '^B[AEIOU]+LD.*'").disjunction must beRightDisjOrDiff(chain(
+      plan("select * from zips where city ~ '^B[AEIOU]+LD.*'") must beWorkflow(chain(
         $read(Collection("db", "zips")),
         $match(
           Selector.Doc(
@@ -470,7 +480,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     "plan filter with alternative ~" in {
-      plan("select * from a where 'foo' ~ pattern or target ~ pattern").disjunction must beRightDisjOrDiff(chain(
+      plan("select * from a where 'foo' ~ pattern or target ~ pattern") must beWorkflow(chain(
         $read(Collection("db", "a")),
         $simpleMap(NonEmptyList(MapExpr(JsFn(Ident("x"), Obj(ListMap(
           "__tmp4" -> Call(
@@ -843,16 +853,11 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           chain(
             $read(Collection("db", "zips")),
             $group(
-              Grouped(ListMap(
-                BsonField.Name("cnt") -> Sum(ExprOp.Literal(Bson.Int32(1))),
-                BsonField.Name("__tmp0") -> Push(DocVar.ROOT()))),
+              grouped(
+                "city" -> Push(DocField("city")),
+                "cnt"  -> Sum(ExprOp.Literal(Bson.Int32(1)))),
               -\/(ExprOp.Literal(Bson.Null))),
-            $unwind(DocField(BsonField.Name("__tmp0"))),
-            $project(Reshape(ListMap(
-              BsonField.Name("cnt") -> -\/(DocField(BsonField.Name("cnt"))),
-              BsonField.Name("city") ->
-                -\/(DocField(BsonField.Name("__tmp0") \ BsonField.Name("city"))))),
-              IgnoreId),
+            $unwind(DocField("city")),
             $sort(NonEmptyList(BsonField.Name("cnt") -> Descending)))
         }
     }
@@ -862,16 +867,15 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         beWorkflow {
           chain(
             $read(Collection("db", "zips")),
-            $group(
-              Grouped(ListMap(
-                BsonField.Name("cnt") -> Sum(ExprOp.Literal(Bson.Int32(1))),
-                BsonField.Name("__tmp0") -> Push(DocVar.ROOT()))),
-              -\/(ExprOp.Literal(Bson.Null))),
-            $unwind(DocField(BsonField.Name("__tmp0"))),
             $simpleMap(NonEmptyList(MapExpr(JsFn(Ident("x"), Obj(ListMap(
-              "cnt" -> Select(Ident("x").fix, "cnt").fix,
-              "1" -> Select(Select(Select(Ident("x").fix, "__tmp0").fix, "city").fix, "length").fix)).fix))),
-              ListMap()))
+              "1" -> Select(Select(Ident("x").fix, "city").fix, "length").fix)).fix))),
+              ListMap()),
+            $group(
+              grouped(
+                "cnt" -> Sum(ExprOp.Literal(Bson.Int32(1))),
+                "1"   -> Push(DocField("1"))),
+              -\/(ExprOp.Literal(Bson.Null))),
+            $unwind(DocField("1")))
         }
     }
 
@@ -982,18 +986,25 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
       plan("select city, state, sum(pop) from zips") must
       beWorkflow(chain(
         $read(Collection("db", "zips")),
+        $project(
+          reshape(
+            "__tmp1" -> reshape(
+              "city"  -> DocField("city"),
+              "state" -> DocField("state")),
+            "__tmp2" -> reshape(
+              "__tmp0" -> DocField("pop"))),
+          IgnoreId),
         $group(
-          Grouped(ListMap(
-            BsonField.Name("2") -> Sum(DocField(BsonField.Name("pop"))),
-            BsonField.Name("__tmp0") -> Push(DocVar.ROOT()))),
+          grouped(
+            "2"      -> Sum(DocField("__tmp2" \ "__tmp0")),
+            "__tmp1" -> Push(DocField("__tmp1"))),
           -\/(ExprOp.Literal(Bson.Null))),
-        $unwind(DocField(BsonField.Name("__tmp0"))),
-        $project(Reshape(ListMap(
-          BsonField.Name ("2") -> -\/(DocField(BsonField.Name("2"))),
-          BsonField.Name ("city") ->
-            -\/(DocField(BsonField.Name("__tmp0") \ BsonField.Name("city"))),
-          BsonField.Name ("state") ->
-            -\/(DocField(BsonField.Name("__tmp0") \ BsonField.Name("state"))))),
+        $unwind(DocField("__tmp1")),
+        $project(
+          reshape(
+            "city"  -> DocField("__tmp1" \ "city"),
+            "state" -> DocField("__tmp1" \ "state"),
+            "2"     -> DocField("2")),
           IgnoreId)))
     }
 
@@ -1001,20 +1012,25 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
       plan("select pop, sum(pop), pop/1000 from zips") must
       beWorkflow(chain(
         $read (Collection("db", "zips")),
+        $project(
+          reshape(
+            "__tmp0" -> reshape(
+              "pop" -> DocField("pop"),
+              "2"   -> ExprOp.Divide(DocField("pop"), ExprOp.Literal(Bson.Int64(1000)))),
+            "__tmp1" -> reshape(
+              "pop" -> DocField("pop"))),
+          IgnoreId),
         $group(
-          Grouped(ListMap(
-            BsonField.Name("1") -> Sum(DocField(BsonField.Name("pop"))),
-            BsonField.Name("__tmp0") -> Push(DocVar.ROOT()))),
+          grouped(
+            "1"      -> Sum(DocField("__tmp1" \ "pop")),
+            "__tmp0" -> Push(DocField("__tmp0"))),
           -\/(ExprOp.Literal(Bson.Null))),
-        $unwind(DocField(BsonField.Name("__tmp0"))),
-        $project(Reshape(ListMap(
-          BsonField.Name("2") ->
-            -\/(ExprOp.Divide(
-              DocField(BsonField.Name("__tmp0") \ BsonField.Name("pop")),
-              ExprOp.Literal(Bson.Int64(1000)))),
-          BsonField.Name("1") -> -\/(DocField(BsonField.Name("1"))),
-          BsonField.Name("pop") ->
-            -\/(DocField(BsonField.Name("__tmp0") \ BsonField.Name("pop"))))),
+        $unwind(DocField("__tmp0")),
+        $project(
+          reshape(
+            "pop" -> DocField("__tmp0" \ "pop"),
+            "1" -> DocField("1"),
+            "2" -> DocField("__tmp0" \ "2")),
           IgnoreId)))
     }
 
@@ -1043,15 +1059,21 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         beWorkflow(chain(
           $read(Collection("db", "zips")),
           $group(
-            Grouped(ListMap(
-              BsonField.Name("state") -> Push(DocField(BsonField.Name("state"))),
-              BsonField.Name("__tmp0") -> Min(DocField(BsonField.Name("city"))))),
+            grouped(
+              "state" -> Push(DocField("state")),
+              "__tmp0" -> Min(DocField("city"))),
             -\/(DocField(BsonField.Name("state")))),
-          $unwind(DocField(BsonField.Name("state"))),
-          $simpleMap(NonEmptyList(MapExpr(JsFn(Ident("x"), Obj(ListMap(
+          $simpleMap(NonEmptyList(
+            FlatExpr(JsFn(Ident("x"), Select(Ident("x").fix, "state").fix)),
+            MapExpr(JsFn(Ident("x"), Obj(ListMap(
             "state" -> Select(Ident("x").fix, "state").fix,
             "shortest" -> Select(Select(Ident("x").fix, "__tmp0").fix, "length").fix)).fix))),
-            ListMap())))
+            ListMap()),
+        $project(
+          reshape(
+            "state" -> Include,
+            "shortest" -> Include),
+          IgnoreId)))
     }
 
     "plan js expr grouped by js expr" in {
@@ -1079,11 +1101,15 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             "0" -> BinOp(JsCore.Add,
               Select(Select(Ident("x").fix, "city").fix, "length").fix,
               JsCore.Literal(Js.Num(1, false)).fix).fix)).fix))),
-            ListMap())))
+            ListMap()),
+          $project(
+            reshape(
+              "0" -> Include),
+            IgnoreId)))
     }
 
     "plan expressions with ~"in {
-      plan("select foo ~ 'bar.*', 'abc' ~ 'a|b', 'baz' ~ regex, target ~ regex from a").disjunction must beRightDisjOrDiff(chain(
+      plan("select foo ~ 'bar.*', 'abc' ~ 'a|b', 'baz' ~ regex, target ~ regex from a") must beWorkflow(chain(
         $read(Collection("db", "a")),
         $simpleMap(NonEmptyList(MapExpr(JsFn(Ident("x"),
           Obj(ListMap(
@@ -1097,7 +1123,14 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             "3" -> Call(
               Select(New("RegExp", List(Select(Ident("x").fix, "regex").fix)).fix, "test").fix,
               List(Select(Ident("x").fix, "target").fix)).fix)).fix))),
-          ListMap())))
+          ListMap()),
+        $project(
+          reshape(
+            "0" -> Include,
+            "1" -> Include,
+            "2" -> Include,
+            "3" -> Include),
+          IgnoreId)))
     }
 
     "plan object flatten" in {
@@ -1105,18 +1138,22 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         beWorkflow {
           chain(
             $read(Collection("db", "usa_factbook")),
-            $project(Reshape(ListMap(
-              BsonField.Name("__tmp0") ->
-                -\/(Cond(
-                  ExprOp.And(NonEmptyList(
-                    ExprOp.Lte(ExprOp.Literal(Bson.Doc(ListMap())), DocField(BsonField.Name("geo"))),
-                    ExprOp.Lt(DocField(BsonField.Name("geo")), ExprOp.Literal(Bson.Arr(List()))))),
-                  DocField(BsonField.Name("geo")),
-                  ExprOp.Literal(Bson.Doc(ListMap("" -> Bson.Null))))))),
-              IgnoreId),
-            $simpleMap(NonEmptyList(FlatExpr(JsFn(Ident("x"), Select(Ident("x").fix, "__tmp0").fix))), ListMap()),
-            $project(Reshape(ListMap(
-              BsonField.Name("geo") -> -\/(DocField(BsonField.Name("__tmp0"))))),
+            $simpleMap(
+              NonEmptyList(
+                MapExpr(JsFn(Ident("x"), Obj(ListMap(
+                  "__tmp0" ->
+                  If(
+                    BinOp(JsCore.And,
+                      BinOp(Instance, Select(Ident("x").fix, "geo").fix, Ident("Object").fix).fix,
+                      UnOp(JsCore.Not, BinOp(Instance, Select(Ident("x").fix, "geo").fix, Ident("Array").fix).fix).fix).fix,
+                    Select(Ident("x").fix, "geo").fix,
+                    Obj(ListMap(
+                      "" -> JsCore.Literal(Js.Null).fix)).fix).fix)).fix)),
+                FlatExpr(JsFn(Ident("x"), Select(Ident("x").fix, "__tmp0").fix))),
+              ListMap()),
+            $project(
+              reshape(
+                "geo" -> DocField("__tmp0")),
               IgnoreId))
         }
     }
@@ -1131,7 +1168,12 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               "1" -> JsCore.Access(
                 JsCore.Select(Ident("x").fix, "loc").fix,
                 JsCore.Literal(Js.Num(0, false)).fix).fix)).fix))),
-              ListMap()))
+              ListMap()),
+            $project(
+              reshape(
+                "city" -> Include,
+                "1"    -> Include),
+              IgnoreId))
         }
     }
 
@@ -1571,7 +1613,11 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           $read(Collection("db", "zips")),
           $simpleMap(NonEmptyList(MapExpr(JsFn(Ident("x"), Obj(ListMap(
             "0" -> Select(Select(Ident("x").fix, "city").fix, "length").fix)).fix))),
-            ListMap())))
+            ListMap()),
+          $project(
+            reshape(
+              "0" -> Include),
+            IgnoreId)))
     }
 
     "plan select length() and simple field" in {
@@ -1581,7 +1627,12 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         $simpleMap(NonEmptyList(MapExpr(JsFn(Ident("x"), Obj(ListMap(
           "city" -> Select(Ident("x").fix, "city").fix,
           "1" -> Select(Select(Ident("x").fix, "city").fix, "length").fix)).fix))),
-          ListMap())))
+          ListMap()),
+        $project(
+          reshape(
+            "city" -> Include,
+            "1" -> Include),
+          IgnoreId)))
     }
 
     "plan combination of two distinct sets" in {
@@ -1705,11 +1756,16 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             NonEmptyList(MapExpr(JsFn(Ident("x"), Obj(ListMap(
               "0" -> Select(Select(Ident("x").fix, "name").fix, "length").fix,
               "1" -> New("Date", List(Select(Ident("x").fix, "epoch").fix)).fix)).fix))),
-            ListMap()))
+            ListMap()),
+          $project(
+            reshape(
+              "0" -> Include,
+              "1" -> Include),
+            IgnoreId))
       }
     }
 
-    def joinStructure(
+    def joinStructure0(
       left: Workflow, leftName: String, right: Workflow,
       leftKey: ExprOp, rightKey: Term[JsCore],
       fin: WorkflowOp,
@@ -1762,6 +1818,13 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
                   Js.Return(Js.Ident("result")))),
               ListMap()))))
     }
+
+    def joinStructure(
+        left: Workflow, leftName: String, right: Workflow,
+        leftKey: ExprOp, rightKey: Term[JsCore],
+        fin: WorkflowOp,
+        swapped: Boolean) =
+      crystallize(finish(joinStructure0(left, leftName, right, leftKey, rightKey, fin, swapped))).op // HACK?
 
     "plan simple join" in {
       plan("select zips2.city from zips join zips2 on zips._id = zips2._id") must
@@ -1884,7 +1947,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
       beWorkflow(
         joinStructure(
           $read(Collection("db", "baz")), "__tmp1",
-          joinStructure(
+          joinStructure0(
             $read(Collection("db", "foo")), "__tmp0",
             $read(Collection("db", "bar")),
             DocField(BsonField.Name("id")),
@@ -1984,10 +2047,11 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         case _ => Nil
       }) aka "dangling references"
 
-    args.report(showtimes = true) // See #656
+    args.report(showtimes = true)
 
     "plan multiple reducing projections (all, distinct, orderBy)" ! Prop.forAll(select(distinct, maybeReducingExpr, Gen.option(filter), Gen.option(groupBySeveral), orderBySeveral)) { q =>
-      plan(q.value) must beRight.which { wf =>
+      plan(q.value) must beRight.which { fop =>
+        val wf = fop.op
         noConsecutiveProjectOps(wf)
         noConsecutiveSimpleMapOps(wf)
         maxGroupOps(wf, 2)
@@ -1999,10 +2063,11 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         (fields aka "column order" must beSome(columnNames(q))) or
           (fields must beSome(List("value")))  // NB: some edge cases (all constant projections) end up under "value" and aren't interesting anyway
       }
-    }.set(maxSize = 2)  // FIXME: with more then a few keys in the order by, the planner gets *very* slow (see #656)
+    }.set(maxSize = 3)  // FIXME: with more then a few keys in the order by, the planner gets *very* slow (see #656)
 
     "plan multiple reducing projections (all, distinct)" ! Prop.forAll(select(distinct, maybeReducingExpr, Gen.option(filter), Gen.option(groupBySeveral), noOrderBy)) { q =>
-      plan(q.value) must beRight.which { wf =>
+      plan(q.value) must beRight.which { fop =>
+        val wf = fop.op
         noConsecutiveProjectOps(wf)
         noConsecutiveSimpleMapOps(wf)
         maxGroupOps(wf, 2)
@@ -2017,7 +2082,8 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }.set(maxSize = 10)
 
     "plan multiple reducing projections (all)" ! Prop.forAll(select(notDistinct, maybeReducingExpr, Gen.option(filter), Gen.option(groupBySeveral), noOrderBy)) { q =>
-      plan(q.value) must beRight.which { wf =>
+      plan(q.value) must beRight.which { fop =>
+        val wf = fop.op
         noConsecutiveProjectOps(wf)
         noConsecutiveSimpleMapOps(wf)
         maxGroupOps(wf, 1)
@@ -2031,7 +2097,8 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
 
     // NB: tighter constraint because we know there's no filter.
     "plan multiple reducing projections (no filter)" ! Prop.forAll(select(notDistinct, maybeReducingExpr, noFilter, Gen.option(groupBySeveral), noOrderBy)) { q =>
-      plan(q.value) must beRight.which { wf =>
+      plan(q.value) must beRight.which { fop =>
+        val wf = fop.op
         noConsecutiveProjectOps(wf)
         noConsecutiveSimpleMapOps(wf)
         maxGroupOps(wf, 1)
@@ -2264,6 +2331,30 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             BsonField.Name("value") ->
               -\/(DocField(BsonField.Name("__tmp0"))))),
             ExcludeId)))
+    }
+  }
+
+  "planner log" should {
+    "include all phases when successful" in {
+      planLog("select city from zips").map(_.map(_.name)).toEither must
+        beRight(Vector(
+          "SQL AST", "Variables Substituted", "Annotated Tree",
+          "Logical Plan", "Simplified", "Logical Plan (projections preferred)",
+          "Workflow Builder", "Workflow (raw)", "Workflow (finished)",
+          "Physical Plan", "Mongo"))
+    }
+
+    "include correct phases with type error" in {
+      planLog("select 'a' || 0 from zips").map(_.map(_.name)).toEither must
+        beRight(Vector(
+          "SQL AST", "Variables Substituted", "Annotated Tree"))
+    }
+
+    "include correct phases with planner error" in {
+      planLog("select date_part('foo', bar) from zips").map(_.map(_.name)).toEither must
+        beRight(Vector(
+          "SQL AST", "Variables Substituted", "Annotated Tree",
+          "Logical Plan", "Simplified", "Logical Plan (projections preferred)"))
     }
   }
 }

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -1875,7 +1875,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         leftKey: ExprOp, rightKey: Term[JsCore],
         fin: WorkflowOp,
         swapped: Boolean) =
-      crystallize(finish(joinStructure0(left, leftName, right, leftKey, rightKey, fin, swapped))).op // HACK?
+      crystallize(finish(joinStructure0(left, leftName, right, leftKey, rightKey, fin, swapped)))
 
     "plan simple join" in {
       plan("select zips2.city from zips join zips2 on zips._id = zips2._id") must
@@ -1895,7 +1895,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
                 BsonField.Name("city") ->
                   -\/(DocField(BsonField.Name("right") \ BsonField.Name("city"))))),
                 IgnoreId)), // Note: becomes ExcludeId in conversion to WorkflowTask
-            false))
+            false).op)
     }
 
     "plan non-equi join" in {
@@ -1923,7 +1923,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               BsonField.Name("address") ->
                 -\/(DocField(BsonField.Name("right") \ BsonField.Name("address"))))),
               IgnoreId)), // Note: becomes ExcludeId in conversion to WorkflowTask
-          false))
+          false).op)
     }
 
     "plan simple outer equi-join with wildcard" in {
@@ -1956,7 +1956,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
                 Select(Ident("x").fix, "left").fix,
                 Select(Ident("x").fix, "right").fix)).fix))),
               ListMap())),
-          false))
+          false).op)
     }
 
     "plan simple left equi-join" in {
@@ -1987,7 +1987,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               BsonField.Name("name") -> -\/(DocField(BsonField.Name("left") \ BsonField.Name("name"))),
               BsonField.Name("address") -> -\/(DocField(BsonField.Name("right") \ BsonField.Name("address"))))),
               IgnoreId)), // Note: becomes ExcludeId in conversion to WorkflowTask
-          false))
+          false).op)
     }
 
     "plan 3-way right equi-join" in {
@@ -2031,7 +2031,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               BsonField.Name("address") -> -\/(DocField(BsonField.Name("left") \ BsonField.Name("right") \ BsonField.Name("address"))),
               BsonField.Name("zip") -> -\/(DocField(BsonField.Name("right") \ BsonField.Name("zip"))))),
               IgnoreId)), // Note: becomes ExcludeId in conversion to WorkflowTask
-          true))
+          true).op)
     }
 
     "plan simple cross" in {
@@ -2062,7 +2062,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             $project(Reshape(ListMap(
               BsonField.Name("city") -> -\/(DocField(BsonField.Name("city"))))),
               ExcludeId)),
-          false))
+          false).op)
     }
 
 

--- a/it/src/test/resources/tests/fieldOrder.test
+++ b/it/src/test/resources/tests/fieldOrder.test
@@ -1,5 +1,6 @@
 {
-    "name": "reduced expressions which trigger bad field ordering (#584)",
+    "name": "reduced expressions which trigger bad field ordering (#598)",
+    "backends": { "mongodb_2_6": "pending", "mongodb_3_0": "pending" },
 
     "data": "zips.data",
 

--- a/web/src/test/scala/slamdata/engine/api/fs.scala
+++ b/web/src/test/scala/slamdata/engine/api/fs.scala
@@ -64,7 +64,7 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     }
 
     lazy val planner = new Planner[Plan] {
-      def plan(logical: Term[LogicalPlan]) = \/- (Plan("logical: " + logical.toString))
+      def plan(logical: Term[LogicalPlan]) = Planner.emit(Vector.empty, \/-(Plan("logical: " + logical.toString)))
     }
     lazy val evaluator: Evaluator[Plan] = new Evaluator[Plan] {
       def execute(physical: Plan) = Task.now(ResultPath.Temp(Path("tmp/out")))


### PR DESCRIPTION
Fixes a case where we would invariably push `$$ROOT` if there was a single
simple field alongside an aggregate function (fixes #831). This is a one-line
fix in `objectConcat`.

Capture several steps within the Planner as PhaseResults to aid debugging:
- `Logical Plan (projections preferred)`: the rewritten LP actually used in
the planner
- `Workflow Builder`: speaks for itself
- `Workflow (raw)`: before any optimizations are applied
- `Workflow (finished)`: after reordering ops and deleting unused fields, but
before "crystallization" (see below)

The PhaseResult logged as `Physical Plan` now better represents what is
actually executed, because it shows inlining and shape-adjustments that are
done in `crystallize`.

Rename `Workflow.finalize` to `crystallize` to avoid clashing with the method
defined on every Java class/Scala trait, and wrap the result in a type,
`Crystallized`, to avoid errors that resulted from calling it more than once.
Thanks to @sellout for the name, which is meant to suggest both a
transformation and a kind of "freezing", since this is necessarily the last
transformation.

Planner tests now compare against the crystallized plan, which captures more
of the process but is slightly noisier in a few cases. In particular, inlining
of flattening into $SimpleMap is now verified.