### PR TITLE
Delete our explicit sbt-plugin resolver.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,11 +9,6 @@ resolvers += "Jenkins-CI" at "http://repo.jenkins-ci.org/repo"
 
 libraryDependencies += "org.kohsuke" % "github-api" % "1.59"
 
-resolvers += Resolver.url(
-  "sbt-plugin-releases",
-  new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/")
-)(Resolver.ivyStylePatterns)
-
 // Scoverage & Coveralls:
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,10 @@
 resolvers += Resolver.sonatypeRepo("releases")
 
 // Standard sbt plugins:
-resolvers += Classpaths.sbtPluginReleases
+resolvers += Resolver.url(
+  "sbt-plugin-releases",
+  new URL("http://dl.bintray.com/content/sbt/sbt-plugin-releases")
+)(Resolver.ivyStylePatterns)
 
 // Jenkins CI
 resolvers += "Jenkins-CI" at "http://repo.jenkins-ci.org/repo"


### PR DESCRIPTION
These also eliminates a duplicate resolver warning we’ve been getting for a while.