### PR TITLE
Generalize LP.Join to take an arbitrary condition.

### DIFF
--- a/core/src/main/scala/slamdata/engine/analysis/fixplate.scala
+++ b/core/src/main/scala/slamdata/engine/analysis/fixplate.scala
@@ -137,6 +137,10 @@ sealed trait term {
     def cata[A](f: F[A] => A)(implicit F: Functor[F]): A =
       f(unFix.map(_.cata(f)(F)))
 
+    def cataM[M[_]: Monad, A](f: F[A] => M[A])(implicit F: Traverse[F]):
+        M[A] =
+      unFix.map(_.cataM(f)).sequence.flatMap(f)
+
     def para[A](f: F[(Term[F], A)] => A)(implicit F: Functor[F]): A =
       f(unFix.map(t => t -> t.para(f)(F)))
 

--- a/core/src/main/scala/slamdata/engine/analysis/fixplate.scala
+++ b/core/src/main/scala/slamdata/engine/analysis/fixplate.scala
@@ -36,6 +36,38 @@ sealed trait term {
     def universe(implicit F: Foldable[F]): List[Term[F]] =
       this :: children.flatMap(_.universe)
 
+    // Foldable-like operations
+    def all(p: Term[F] ⇒ Boolean)(implicit F: Foldable[F]): Boolean = {
+      def loop(z0: Boolean, term: Term[F]): Boolean =
+        term.unFix.foldLeft(z0 && p(term))(loop(_, _))
+
+      loop(true, this)
+    }
+    def any(p: Term[F] ⇒ Boolean)(implicit F: Foldable[F]): Boolean = {
+      def loop(z0: Boolean, term: Term[F]): Boolean =
+        term.unFix.foldLeft(z0 || p(term))(loop(_, _))
+
+      loop(false, this)
+    }
+    def contains(t: Term[F])(implicit E: EqualF[F], F: Foldable[F]): Boolean =
+      any(_ ≟ t)
+
+    def foldMap[Z](f: Term[F] => Z)(implicit F: Traverse[F], Z: Monoid[Z]): Z = {
+      (foldMapM[Free.Trampoline, Z] { (term: Term[F]) =>
+        f(term).pure[Free.Trampoline]
+      }).run
+    }
+    def foldMapM[M[_], Z](f: Term[F] => M[Z])(implicit F: Traverse[F], M: Monad[M], Z: Monoid[Z]): M[Z] = {
+      def loop(z0: Z, term: Term[F]): M[Z] = {
+        for {
+          z1 <- f(term)
+          z2 <- F.foldLeftM(term.unFix, Z.append(z0, z1))(loop(_, _))
+        } yield z2
+      }
+
+      loop(Z.zero, this)
+    }
+
     def transform(f: Term[F] => Term[F])(implicit T: Traverse[F]): Term[F] =
       transformM[Free.Trampoline]((v: Term[F]) => f(v).pure[Free.Trampoline]).run
 
@@ -67,23 +99,6 @@ sealed trait term {
 
     def topDownCata[A](a: A)(f: (A, Term[F]) => (A, Term[F]))(implicit F: Traverse[F]): Term[F] = {
       topDownCataM[Free.Trampoline, A](a)((a: A, term: Term[F]) => f(a, term).pure[Free.Trampoline]).run
-    }
-
-    def foldMap[Z](f: Term[F] => Z)(implicit F: Traverse[F], Z: Monoid[Z]): Z = {
-      (foldMapM[Free.Trampoline, Z] { (term: Term[F]) =>
-        f(term).pure[Free.Trampoline]
-      }).run
-    }
-
-    def foldMapM[M[_], Z](f: Term[F] => M[Z])(implicit F: Traverse[F], M: Monad[M], Z: Monoid[Z]): M[Z] = {
-      def loop(z0: Z, term: Term[F]): M[Z] = {
-        for {
-          z1 <- f(term)
-          z2 <- F.foldLeftM(term.unFix, Z.append(z0, z1))(loop(_, _))
-        } yield z2
-      }
-
-      loop(Z.zero, this)
     }
 
     def topDownCataM[M[_], A](a: A)(f: (A, Term[F]) => M[(A, Term[F])])(implicit M: Monad[M], F: Traverse[F]): M[Term[F]] = {

--- a/core/src/main/scala/slamdata/engine/compiler.scala
+++ b/core/src/main/scala/slamdata/engine/compiler.scala
@@ -617,18 +617,14 @@ trait Compiler[F[_]] {
               left0 <- compile0(left)
               right0 <- compile0(right)
               join <- CompilerState.contextual(
-                tableContext(leftFree, left) ++ tableContext(rightFree, right)
-              ) {
-                for {
-                  tuple  <- compileJoin(clause, leftFree, rightFree)
-                } yield LogicalPlan.Join(leftFree, rightFree,
+                tableContext(leftFree, left) ++ tableContext(rightFree, right))(
+                compile0(clause).map(LogicalPlan.Join(leftFree, rightFree,
                   tpe match {
                     case LeftJoin  => LogicalPlan.JoinType.LeftOuter
                     case InnerJoin => LogicalPlan.JoinType.Inner
                     case RightJoin => LogicalPlan.JoinType.RightOuter
                     case FullJoin  => LogicalPlan.JoinType.FullOuter
-                  }, tuple._1, tuple._2, tuple._3)
-              }
+                  }, _)))
             } yield LogicalPlan.Let(leftName, left0,
               LogicalPlan.Let(rightName, right0, join))
 

--- a/core/src/main/scala/slamdata/engine/errors.scala
+++ b/core/src/main/scala/slamdata/engine/errors.scala
@@ -16,6 +16,7 @@
 
 package slamdata.engine
 
+import slamdata.engine.analysis.fixplate._
 import scalaz._
 
 trait Error extends Throwable {
@@ -134,6 +135,9 @@ object SemanticError {
 
 sealed trait PlannerError extends Error
 object PlannerError {
+  final case class UnsupportedJoinCondition(cond: Term[LogicalPlan]) extends PlannerError {
+    def message = "Joining with " + cond + " is not currently supported"
+  }
   final case class InternalError(message: String) extends PlannerError
   final case class NonRepresentableData(data: Data) extends PlannerError {
     def message = "The back-end has no representation for the constant: " + data

--- a/core/src/main/scala/slamdata/engine/logicalplan.scala
+++ b/core/src/main/scala/slamdata/engine/logicalplan.scala
@@ -39,8 +39,8 @@ object LogicalPlan {
       fa match {
         case x @ ReadF(_) => G.point(x)
         case x @ ConstantF(_) => G.point(x)
-        case JoinF(left, right, tpe, rel, lproj, rproj) =>
-          G.apply4(f(left), f(right), f(lproj), f(rproj))(JoinF(_, _, tpe, rel, _, _))
+        case JoinF(left, right, tpe, rel) =>
+          G.apply3(f(left), f(right), f(rel))(JoinF(_, _, tpe, _))
         case InvokeF(func, values) => G.map(Traverse[List].sequence(values.map(f)))(InvokeF(func, _))
         case x @ FreeF(_) => G.point(x)
         case LetF(ident, form0, in0) =>
@@ -52,8 +52,8 @@ object LogicalPlan {
       v match {
         case x @ ReadF(_) => x
         case x @ ConstantF(_) => x
-        case JoinF(left, right, tpe, rel, lproj, rproj) =>
-          JoinF(f(left), f(right), tpe, rel, f(lproj), f(rproj))
+        case JoinF(left, right, tpe, rel) =>
+          JoinF(f(left), f(right), tpe, f(rel))
         case InvokeF(func, values) => InvokeF(func, values.map(f))
         case x @ FreeF(_) => x
         case LetF(ident, form, in) => LetF(ident, f(form), f(in))
@@ -64,8 +64,8 @@ object LogicalPlan {
       fa match {
         case x @ ReadF(_) => F.zero
         case x @ ConstantF(_) => F.zero
-        case JoinF(left, right, tpe, rel, lproj, rproj) =>
-          F.append(F.append(f(left), f(right)), F.append(f(lproj), f(rproj)))
+        case JoinF(left, right, tpe, rel) =>
+          F.append(F.append(f(left), f(right)), f(rel))
         case InvokeF(func, values) => Foldable[List].foldMap(values)(f)
         case x @ FreeF(_) => F.zero
         case LetF(_, form, in) => {
@@ -78,8 +78,7 @@ object LogicalPlan {
       fa match {
         case x @ ReadF(_) => z
         case x @ ConstantF(_) => z
-        case JoinF(left, right, tpe, rel, lproj, rproj) =>
-          f(left, f(right, f(lproj, f(rproj, z))))
+        case JoinF(left, right, tpe, rel) => f(left, f(right, f(rel, z)))
         case InvokeF(func, values) => Foldable[List].foldRight(values, z)(f)
         case x @ FreeF(_) => z
         case LetF(ident, form, in) => f(form, f(in, z))
@@ -93,7 +92,7 @@ object LogicalPlan {
     override def render(v: LogicalPlan[_]) = v match {
       case ReadF(name)                 => Terminal("Read" :: nodeType, Some(name.pathname))
       case ConstantF(data)             => Terminal("Constant" :: nodeType, Some(data.toString))
-      case JoinF(_, _, tpe, rel, _, _) => Terminal("Join" :: nodeType, Some(tpe.toString + ", " + rel))
+      case JoinF(_, _, tpe, _) => Terminal("Join" :: nodeType, Some(tpe.toString))
       case InvokeF(func, _     )       => Terminal(func.mappingType.toString :: "Invoke" :: nodeType, Some(func.name))
       case FreeF(name)                 => Terminal("Free" :: nodeType, Some(name.toString))
       case LetF(ident, _, _)           => Terminal("Let" :: nodeType, Some(ident.toString))
@@ -103,9 +102,9 @@ object LogicalPlan {
     def equal[A](v1: LogicalPlan[A], v2: LogicalPlan[A])(implicit A: Equal[A]): Boolean = (v1, v2) match {
       case (ReadF(n1), ReadF(n2)) => n1 == n2
       case (ConstantF(d1), ConstantF(d2)) => d1 == d2
-      case (JoinF(l1, r1, tpe1, rel1, lproj1, rproj1),
-            JoinF(l2, r2, tpe2, rel2, lproj2, rproj2)) =>
-        A.equal(l1, l2) && A.equal(r1, r2) && A.equal(lproj1, lproj2) && A.equal(rproj1, rproj2) && tpe1 == tpe2
+      case (JoinF(l1, r1, tpe1, rel1),
+            JoinF(l2, r2, tpe2, rel2)) =>
+        A.equal(l1, l2) && A.equal(r1, r2) && A.equal(rel1, rel2) && tpe1 == tpe2
       case (InvokeF(f1, v1), InvokeF(f2, v2)) => Equal[List[A]].equal(v1, v2) && f1 == f2
       case (FreeF(n1), FreeF(n2)) => n1 == n2
       case (LetF(ident1, form1, in1), LetF(ident2, form2, in2)) =>
@@ -128,16 +127,14 @@ object LogicalPlan {
       Term[LogicalPlan](ConstantF(data))
   }
 
-  final case class JoinF[A](left: A, right: A,
-                               joinType: JoinType, joinRel: Mapping,
-                               leftProj: A, rightProj: A) extends LogicalPlan[A] {
-    override def toString = s"Join($left, $right, $joinType, $joinRel, $leftProj, $rightProj)"
+  final case class JoinF[A](left: A, right: A, joinType: JoinType, joinRel: A)
+      extends LogicalPlan[A] {
+    override def toString = s"Join($left, $right, $joinType, $joinRel)"
   }
   object Join {
     def apply(left: Term[LogicalPlan], right: Term[LogicalPlan],
-               joinType: JoinType, joinRel: Mapping,
-               leftProj: Term[LogicalPlan], rightProj: Term[LogicalPlan]): Term[LogicalPlan] =
-      Term[LogicalPlan](JoinF(left, right, joinType, joinRel, leftProj, rightProj))
+              joinType: JoinType, joinRel: Term[LogicalPlan]): Term[LogicalPlan] =
+      Term[LogicalPlan](JoinF(left, right, joinType, joinRel))
   }
 
   final case class InvokeF[A](func: Func, values: List[A]) extends LogicalPlan[A] {
@@ -204,7 +201,7 @@ object LogicalPlan {
   }
 
   val shapeƒ: LogicalPlan[(Term[LogicalPlan], Option[List[Term[LogicalPlan]]])] => Option[List[Term[LogicalPlan]]] = {
-    case JoinF(left, right, _, _, _, _) =>
+    case JoinF(left, right, _, _) =>
       List(left._2, right._2).sequence.map(_.flatten)
     case LetF(_, _, body) => body._2
     case ConstantF(Data.Obj(map)) =>
@@ -232,20 +229,18 @@ object LogicalPlan {
   def lpParaZygoHistoM[M[_]: Monad, A, B](
     t: Term[LogicalPlan])(
     f: LogicalPlan[(Term[LogicalPlan], B)] => B,
-    g: LogicalPlan[(B, Cofree[LogicalPlan, A])] => M[A]):
+    g: LogicalPlan[Cofree[LogicalPlan, (B, A)]] => M[A]):
       M[A] = {
-    def loop(t: Term[LogicalPlan], bind: Map[Symbol, ((B, A), Cofree[LogicalPlan, A])]):
-        M[((B, A), Cofree[LogicalPlan, A])] = {
-      lazy val default: M[((B, A), Cofree[LogicalPlan, A])] = for {
-        tup <- (t.unFix.map { x => for {
-          tup <- loop(x, bind)
-          ((b, a), coa) = tup
-        } yield (((x, b), (b, coa)), coa)
-        }).sequence
-        (ba, coa) = tup.unfzip
-        (b, a) = ba.unfzip.bimap(f, g)
-        a0 <- a
-      } yield ((b, a0), Cofree(a0, coa))
+    def loop(t: Term[LogicalPlan], bind: Map[Symbol, Cofree[LogicalPlan, (B, A)]]):
+        M[Cofree[LogicalPlan, (B, A)]] = {
+      lazy val default: M[Cofree[LogicalPlan, (B, A)]] = for {
+        lp <- (t.unFix.map(x => for {
+          co <- loop(x, bind)
+        } yield ((x, co.head._1), co))).sequence
+        (xb, co) = lp.unfzip
+        b = f(xb)
+        a <- g(co)
+      } yield Cofree((b, a), co)
 
       t.unFix match {
         case FreeF(name)            => bind.get(name).fold(default)(_.point[M])
@@ -259,7 +254,7 @@ object LogicalPlan {
 
     for {
       rez <- loop(t, Map())
-    } yield rez._1._2
+    } yield rez.head._2
   }
 
   def lpParaZygoHistoS[S, A, B] = lpParaZygoHistoM[State[S, ?], A, B] _

--- a/core/src/main/scala/slamdata/engine/mra.scala
+++ b/core/src/main/scala/slamdata/engine/mra.scala
@@ -236,7 +236,7 @@ object MRA {
   val dimsƒ: LogicalPlan[Dims] => Dims = {
     case ReadF(path) => Dims.set(path)
     case ConstantF(_) => Dims.Value
-    case JoinF(_, _, _, _, _, _) => ???
+    case JoinF(_, _, _, _) => ???
     case InvokeF(func, args) =>
       val d = Dims.combineAll(args)
 

--- a/core/src/main/scala/slamdata/engine/optimizer.scala
+++ b/core/src/main/scala/slamdata/engine/optimizer.scala
@@ -44,9 +44,9 @@ object Optimizer {
   val simplify: LogicalPlan[Term[LogicalPlan]] => Term[LogicalPlan] = {
     case v @ InvokeF(func, args) =>
       func.simplify(args).fold(Term(v))(x => simplify(x.unFix))
-    case JoinF(Term(ConstantF(Data.Set(Nil))), Term(ConstantF(Data.Set(Nil))), _, _, _, _) => Constant(Data.Set(Nil))
-    case JoinF(Term(ConstantF(Data.Set(Nil))), _, JoinType.Inner | JoinType.LeftOuter, _, _, _) => Constant(Data.Set(Nil))
-    case JoinF(_, Term(ConstantF(Data.Set(Nil))), JoinType.Inner | JoinType.RightOuter, _, _, _) => Constant(Data.Set(Nil))
+    case JoinF(Term(ConstantF(Data.Set(Nil))), Term(ConstantF(Data.Set(Nil))), _, _) => Constant(Data.Set(Nil))
+    case JoinF(Term(ConstantF(Data.Set(Nil))), _, JoinType.Inner | JoinType.LeftOuter, _) => Constant(Data.Set(Nil))
+    case JoinF(_, Term(ConstantF(Data.Set(Nil))), JoinType.Inner | JoinType.RightOuter, _) => Constant(Data.Set(Nil))
     case LetF(ident, form @ Term(ConstantF(_)), in) =>
       in.para(inline(ident, form))
     case LetF(ident, form, in) => in.cata(countUsage(ident)) match {

--- a/core/src/test/scala/slamdata/engine/compiler.scala
+++ b/core/src/test/scala/slamdata/engine/compiler.scala
@@ -920,9 +920,10 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
           Let('left1, read("foo"),
             Let('right2, read("bar"),
               Join(Free('left1), Free('right2),
-                JoinType.Inner, relations.Eq,
-                ObjectProject(Free('left1), Constant(Data.Str("id"))),
-                ObjectProject(Free('right2), Constant(Data.Str("foo_id")))))),
+                JoinType.Inner,
+                relations.Eq(
+                  ObjectProject(Free('left1), Constant(Data.Str("id"))),
+                  ObjectProject(Free('right2), Constant(Data.Str("foo_id"))))))),
           Let('tmp3,
             makeObj(
               "name" ->
@@ -946,9 +947,10 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
           Let('left1, read("foo"),
             Let('right2, read("bar"),
               Join(Free('left1), Free('right2),
-                JoinType.LeftOuter, relations.Lt,
-                ObjectProject(Free('left1), Constant(Data.Str("id"))),
-                ObjectProject(Free('right2), Constant(Data.Str("foo_id")))))),
+                JoinType.LeftOuter,
+                relations.Lt(
+                  ObjectProject(Free('left1), Constant(Data.Str("id"))),
+                  ObjectProject(Free('right2), Constant(Data.Str("foo_id"))))))),
           Let('tmp3,
             makeObj(
               "name" ->
@@ -974,22 +976,24 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
             Let('left3, read("foo"),
               Let('right4, read("bar"),
                 Join(Free('left3), Free('right4),
-                  JoinType.Inner, relations.Eq,
-                  ObjectProject(
-                    Free('left3),
-                    Constant(Data.Str("id"))),
-                  ObjectProject(
-                    Free('right4),
-                    Constant(Data.Str("foo_id")))))),
+                  JoinType.Inner,
+                  relations.Eq(
+                    ObjectProject(
+                      Free('left3),
+                      Constant(Data.Str("id"))),
+                    ObjectProject(
+                      Free('right4),
+                      Constant(Data.Str("foo_id"))))))),
             Let('right2, read("baz"),
               Join(Free('left1), Free('right2),
-                JoinType.Inner, relations.Eq,
-                ObjectProject(
-                  ObjectProject(Free('left1),
-                    Constant(Data.Str("right"))),
-                  Constant(Data.Str("id"))),
-                ObjectProject(Free('right2),
-                  Constant(Data.Str("bar_id")))))),
+                JoinType.Inner,
+                relations.Eq(
+                  ObjectProject(Free('right2),
+                    Constant(Data.Str("bar_id"))),
+                  ObjectProject(
+                    ObjectProject(Free('left1),
+                      Constant(Data.Str("right"))),
+                    Constant(Data.Str("id"))))))),
           Let('tmp5,
             makeObj(
               "name" ->

--- a/core/src/test/scala/slamdata/engine/logicalplan.scala
+++ b/core/src/test/scala/slamdata/engine/logicalplan.scala
@@ -39,8 +39,8 @@ class LogicalPlanSpecs extends Spec {
 
   def joinGen[A: Arbitrary]: Gen[LogicalPlan[A]] = for {
     tpe <- Gen.oneOf(List(Inner, LeftOuter, RightOuter, FullOuter))
-    (l, r, lproj, rproj) <- Arbitrary.arbitrary[(A, A, A, A)]
-  } yield JoinF(l, r, tpe, std.RelationsLib.Eq, lproj, rproj)
+    (l, r, comp) <- Arbitrary.arbitrary[(A, A, A)]
+  } yield JoinF(l, r, tpe, comp)
 
   import DataGen._
 

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -1817,8 +1817,8 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     def joinStructure0(
-      left: Workflow, leftName: String, right: Workflow,
-      leftKey: ExprOp, rightKey: Term[JsCore],
+      left: Workflow, leftName: String, base: ExprOp, right: Workflow,
+      leftKey: ExprOp \/ Reshape, rightKey: Term[JsCore],
       fin: WorkflowOp,
       swapped: Boolean) = {
 
@@ -1828,8 +1828,8 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         chain(
           src,
           $group(
-            Grouped(ListMap(BsonField.Name(leftName) -> Push(DocVar.ROOT()))),
-            -\/(leftKey)),
+            Grouped(ListMap(BsonField.Name(leftName) -> Push(base))),
+            leftKey),
           $project(Reshape(ListMap(
             BsonField.Name(leftLabel)  -> -\/(DocField(BsonField.Name(leftName))),
             BsonField.Name(rightLabel) -> -\/(ExprOp.Literal(Bson.Arr(List()))),
@@ -1871,17 +1871,17 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     def joinStructure(
-        left: Workflow, leftName: String, right: Workflow,
-        leftKey: ExprOp, rightKey: Term[JsCore],
+        left: Workflow, leftName: String, base: ExprOp, right: Workflow,
+        leftKey: ExprOp \/ Reshape, rightKey: Term[JsCore],
         fin: WorkflowOp,
         swapped: Boolean) =
-      crystallize(finish(joinStructure0(left, leftName, right, leftKey, rightKey, fin, swapped)))
+      crystallize(finish(joinStructure0(left, leftName, base, right, leftKey, rightKey, fin, swapped)))
 
     "plan simple join" in {
       plan("select zips2.city from zips join zips2 on zips._id = zips2._id") must
         beWorkflow(
           joinStructure(
-            $read(Collection("db", "zips")), "__tmp0",
+            $read(Collection("db", "zips")), "__tmp0", DocVar.ROOT(),
             $read(Collection("db", "zips2")),
             DocField(BsonField.Name("_id")),
             Select(Ident("value").fix, "_id").fix,
@@ -1907,7 +1907,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         "select foo.name, bar.address from foo join bar on foo.id = bar.foo_id") must
       beWorkflow(
         joinStructure(
-          $read(Collection("db", "foo")), "__tmp0",
+          $read(Collection("db", "foo")), "__tmp0", DocVar.ROOT(),
           $read(Collection("db", "bar")),
           DocField(BsonField.Name("id")),
           Select(Ident("value").fix, "foo_id").fix,
@@ -1930,7 +1930,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
       plan("select * from foo full join bar on foo.id = bar.foo_id") must
       beWorkflow(
         joinStructure(
-          $read(Collection("db", "foo")), "__tmp0",
+          $read(Collection("db", "foo")), "__tmp0", DocVar.ROOT(),
           $read(Collection("db", "bar")),
           DocField(BsonField.Name("id")),
           Select(Ident("value").fix, "foo_id").fix,
@@ -1965,7 +1965,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           "from foo left join bar on foo.id = bar.foo_id") must
       beWorkflow(
         joinStructure(
-          $read(Collection("db", "foo")), "__tmp0",
+          $read(Collection("db", "foo")), "__tmp0", DocVar.ROOT(),
           $read(Collection("db", "bar")),
           DocField(BsonField.Name("id")),
           Select(Ident("value").fix, "foo_id").fix,
@@ -1997,9 +1997,9 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           "right join baz on bar.id = baz.bar_id") must
       beWorkflow(
         joinStructure(
-          $read(Collection("db", "baz")), "__tmp1",
+          $read(Collection("db", "baz")), "__tmp1", DocVar.ROOT(),
           joinStructure0(
-            $read(Collection("db", "foo")), "__tmp0",
+            $read(Collection("db", "foo")), "__tmp0", DocVar.ROOT(),
             $read(Collection("db", "bar")),
             DocField(BsonField.Name("id")),
             Select(Ident("value").fix, "foo_id").fix,
@@ -2034,11 +2034,47 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           true).op)
     }
 
+    "plan join with multiple conditions" in {
+      plan("select l.sha as child, l.author.login as c_auth, r.sha as parent, r.author.login as p_auth from slamengine_commits l join slamengine_commits r on r.sha = l.parents[0].sha and l.author.login = r.author.login") must
+      beWorkflow(
+        joinStructure(
+          chain(
+            $read(Collection("db", "slamengine_commits")),
+            $simpleMap(NonEmptyList(MapExpr(JsFn(Ident("x"),
+              Obj(ListMap(
+                "__tmp5" -> Select(Access(Select(Ident("x").fix, "parents").fix, JsCore.Literal(Js.Num(0, false)).fix).fix, "sha").fix,
+                "__tmp6" -> Ident("x").fix,
+                "__tmp7" -> Select(Select(Ident("x").fix, "author").fix, "login").fix)).fix))),
+              ListMap())),
+          "__tmp8", DocField(BsonField.Name("__tmp6")),
+          $read(Collection("db", "slamengine_commits")),
+          reshape(
+            "0" -> DocField(BsonField.Name("__tmp5")),
+            "1" -> DocField(BsonField.Name("__tmp7"))
+          ),
+          Obj(ListMap(
+            "0" -> Select(Ident("value").fix, "sha").fix,
+            "1" -> Select(Select(Ident("value").fix, "author").fix, "login").fix)).fix,
+          chain(_,
+            $match(Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
+              BsonField.Name("left") -> Selector.NotExpr(Selector.Size(0)),
+              BsonField.Name("right") -> Selector.NotExpr(Selector.Size(0))))),
+            $unwind(DocField(BsonField.Name("left"))),
+            $unwind(DocField(BsonField.Name("right"))),
+            $project(reshape(
+              "child"  -> ExprOp.DocField(BsonField.Name("left") \ BsonField.Name("sha")),
+              "c_auth" -> ExprOp.DocField(BsonField.Name("left") \ BsonField.Name("author") \ BsonField.Name("login")),
+              "parent" -> ExprOp.DocField(BsonField.Name("right") \ BsonField.Name("sha")),
+              "p_auth" -> ExprOp.DocField(BsonField.Name("right") \ BsonField.Name("author") \ BsonField.Name("login"))),
+              IgnoreId)),
+        false).op)
+    }
+
     "plan simple cross" in {
       plan("select zips2.city from zips, zips2 where zips._id = zips2._id") must
       beWorkflow(
         joinStructure(
-          $read(Collection("db", "zips")), "__tmp0",
+          $read(Collection("db", "zips")), "__tmp0", DocVar.ROOT(),
           $read(Collection("db", "zips2")),
           ExprOp.Literal(Bson.Null),
           JsCore.Literal(Js.Null).fix,

--- a/it/src/test/resources/tests/joinWithMultipleConditions.test
+++ b/it/src/test/resources/tests/joinWithMultipleConditions.test
@@ -1,0 +1,27 @@
+{
+    "name": "join with multiple conditions",
+    "data": "slamengine_commits.data",
+    "query": "select l.sha as child, l.author.login as c_auth, r.sha as parent, r.author.login as p_auth from slamengine_commits l join slamengine_commits r on r.sha = l.parents[0].sha and l.author.login = r.author.login",
+    "predicate": "containsAtLeast",
+    "expected": [
+        { "child": "b29d8f254e5df2c4d1792f077625924cd1fde2db", "c_auth": "mossprescott",
+          "parent": "166f7337c8fd5db13941abf482de05accb8e9380", "p_auth": "mossprescott" },
+        { "child": "166f7337c8fd5db13941abf482de05accb8e9380", "c_auth": "mossprescott",
+          "parent": "0999da94bddcbc5bf536e3874aaba50582e96959", "p_auth": "mossprescott" },
+        { "child": "85c3368890be18a77c1bbfd645228de9f43acd43", "c_auth": "jdegoes",
+          "parent": "292c4259f72adffe922a99f97f7b15e5330bc77a", "p_auth": "jdegoes" },
+        { "child": "f362cb55d8a4ea8fa23bde416530344438a10144", "c_auth": "mossprescott",
+          "parent": "3bacb29203d499edc69f7ff2b1f5ea681411eb75", "p_auth": "mossprescott" },
+        { "child": "b8a2302e6a0659875d03bfe4988c000f2ed027a0", "c_auth": "sellout",
+          "parent": "3d44ce48fc0670aaf39ba1acd0e1c161f14cc2d6", "p_auth": "sellout" },
+        { "child": "ad8a6a73f898860b48f3d71ed6110b3506a8c898", "c_auth": "mossprescott",
+          "parent": "3de46760d45c4fd0db9a03ad978361df3e8f0998", "p_auth": "mossprescott" },
+        { "child": "3de46760d45c4fd0db9a03ad978361df3e8f0998", "c_auth": "mossprescott",
+          "parent": "43b4018ae5d1e40bbbc2babb8929ed247b5d2dcb", "p_auth": "mossprescott" },
+        { "child": "56d1caf5d082d1a6840090986e277d36d03f1859", "c_auth": "jdegoes",
+          "parent": "472dd80e8bdffae0c1bded28a91139941433550d", "p_auth": "jdegoes" },
+        { "child": "82e67fef1aae1d283bff90d1d27efd4266d26d49", "c_auth": "jdegoes",
+          "parent": "5b54522e340244d618645ace4bd0cbb7edf8bd5b", "p_auth": "jdegoes" },
+        { "child": "f1b375cf28abebb32f296119dbb347e5121c3a7a", "c_auth": "sellout",
+          "parent": "696c6ff2556bb1ea6a6de86a03736058e8f6c52a", "p_auth": "sellout" }]
+}

--- a/it/src/test/scala/slamdata/engine/backendtest.scala
+++ b/it/src/test/scala/slamdata/engine/backendtest.scala
@@ -12,8 +12,8 @@ import slamdata.engine.fs._
 
 object TestConfig {
   private val defaultConfig: Map[String, Option[BackendConfig]] = Map(
-    "mongodb_2_6" -> Some(MongoDbConfig("mongodb://slamengine:slamengine@ds045089.mongolab.com:45089/slamengine-test-01")),
-    "mongodb_3_0" -> None
+    "mongodb_2_6" -> None,
+    "mongodb_3_0" -> Some(MongoDbConfig("mongodb://slamengine:slamengine@ds045089.mongolab.com:45089/slamengine-test-01"))
   )
 
   lazy val AllBackends: List[String] = defaultConfig.keys.toList


### PR DESCRIPTION
Fixes #847.

The compiler is simplified to merely compile the JoinRelation clause,
while there is a new (optional) LP phase to “align” the
condition (previously done by the compiler). And then the mongo planner
separates the list of expressions for the left and right sides of the join.

Also,
* add `cataM`,
* “fix” lpParaZygoHistoM to match other zygoHisto constructions, and
* change the default it config to use mongodb_3_0.