### PR TITLE
Convert Joins from an LP node to a Func.

### DIFF
--- a/core/src/main/scala/slamdata/engine/fp/EnvT.scala
+++ b/core/src/main/scala/slamdata/engine/fp/EnvT.scala
@@ -46,9 +46,9 @@ sealed abstract class EnvTInstances0 {
 }
 
 sealed abstract class EnvTInstances extends EnvTInstances0 {
-  implicit def envTComonad[E, W[_]]: Comonad[EnvT[E, W, ?]] = new EnvTComonad[E, W] {
-    implicit def W = implicitly
-  }
+  implicit def envTComonad[E, W[_]](implicit W0: Comonad[W]):
+      Comonad[EnvT[E, W, ?]] =
+    new EnvTComonad[E, W] { implicit def W = W0 }
 }
 
 trait EnvTFunctions {

--- a/core/src/main/scala/slamdata/engine/fp/package.scala
+++ b/core/src/main/scala/slamdata/engine/fp/package.scala
@@ -297,21 +297,6 @@ package object fp extends TreeInstances with ListMapInstances with ToCatchableOp
     def append[A: Monoid](fa1: F[A], fa2: F[A]): F[A]
   }
 
-  trait Empty[F[_]] {
-    def empty[A]: F[A]
-  }
-  object Empty {
-    def apply[F[+_]](value: F[Nothing]): Empty[F] = new Empty[F] {
-      def empty[A]: F[A] = value
-    }
-  }
-
-  implicit class ListOps[A](c: List[A]) {
-    def decon = c.headOption map ((_, c.drop(1)))
-
-    def tailOption = c.headOption map κ(c.drop(1))
-  }
-
   def unzipDisj[A, B](ds: List[A \/ B]): (List[A], List[B]) = {
     val (as, bs) = ds.foldLeft((List[A](), List[B]())) {
       case ((as, bs), -\/ (a)) => (a :: as, bs)

--- a/core/src/main/scala/slamdata/engine/functions.scala
+++ b/core/src/main/scala/slamdata/engine/functions.scala
@@ -17,7 +17,6 @@
 package slamdata.engine
 
 import slamdata.Predef._
-
 import slamdata.engine.analysis.fixplate._
 
 import scalaz._
@@ -33,6 +32,7 @@ sealed trait Func {
 
   def apply(args: Term[LogicalPlan]*): Term[LogicalPlan] = LogicalPlan.Invoke(this, args.toList)
 
+  // TODO: Make this `unapplySeq`
   def unapply[A](node: LogicalPlan[A]): Option[List[A]] = {
     node match {
       case LogicalPlan.InvokeF(f, a) if f == this => Some(a)
@@ -42,7 +42,7 @@ sealed trait Func {
 
   def apply: Func.Typer
 
-  val unapply: Func.Untyper
+  val untype: Func.Untyper
 
   final def apply(arg1: Type, rest: Type*): ValidationNel[SemanticError, Type] = apply(arg1 :: rest.toList)
 
@@ -63,38 +63,27 @@ object Func extends FuncInstances {
   type Untyper    = Type => ValidationNel[SemanticError, List[Type]]
 }
 
-trait VirtualFunc {
-  def apply(args: Term[LogicalPlan]*): Term[LogicalPlan]
-
-  def unapply(t: Term[LogicalPlan]): Option[List[Term[LogicalPlan]]] = Attr.unapply(attrK(t, ())).map(l => l.map(forget(_)))
-
-  def Attr: VirtualFuncAttrExtractor
-  trait VirtualFuncAttrExtractor {
-    def unapply[A](t: Cofree[LogicalPlan, A]): Option[List[Cofree[LogicalPlan, A]]]
-  }
-}
-
-final case class Reduction(name: String, help: String, domain: List[Type], simplify: Func.Simplifier, apply: Func.Typer, unapply: Func.Untyper) extends Func {
+final case class Reduction(name: String, help: String, domain: List[Type], simplify: Func.Simplifier, apply: Func.Typer, untype: Func.Untyper) extends Func {
   def mappingType = MappingType.ManyToOne
 }
 
-final case class Expansion(name: String, help: String, domain: List[Type], simplify: Func.Simplifier, apply: Func.Typer, unapply: Func.Untyper) extends Func {
+final case class Expansion(name: String, help: String, domain: List[Type], simplify: Func.Simplifier, apply: Func.Typer, untype: Func.Untyper) extends Func {
   def mappingType = MappingType.OneToMany
 }
 
-final case class ExpansionFlat(name: String, help: String, domain: List[Type], simplify: Func.Simplifier, apply: Func.Typer, unapply: Func.Untyper) extends Func {
+final case class ExpansionFlat(name: String, help: String, domain: List[Type], simplify: Func.Simplifier, apply: Func.Typer, untype: Func.Untyper) extends Func {
   def mappingType = MappingType.OneToManyFlat
 }
 
-final case class Mapping(name: String, help: String, domain: List[Type], simplify: Func.Simplifier, apply: Func.Typer, unapply: Func.Untyper) extends Func {
+final case class Mapping(name: String, help: String, domain: List[Type], simplify: Func.Simplifier, apply: Func.Typer, untype: Func.Untyper) extends Func {
   def mappingType = MappingType.OneToOne
 }
 
-final case class Squashing(name: String, help: String, domain: List[Type], simplify: Func.Simplifier, apply: Func.Typer, unapply: Func.Untyper) extends Func {
+final case class Squashing(name: String, help: String, domain: List[Type], simplify: Func.Simplifier, apply: Func.Typer, untype: Func.Untyper) extends Func {
   def mappingType = MappingType.Squashing
 }
 
-final case class Transformation(name: String, help: String, domain: List[Type], simplify: Func.Simplifier, apply: Func.Typer, unapply: Func.Untyper) extends Func {
+final case class Transformation(name: String, help: String, domain: List[Type], simplify: Func.Simplifier, apply: Func.Typer, untype: Func.Untyper) extends Func {
   def mappingType = MappingType.ManyToMany
 }
 

--- a/core/src/main/scala/slamdata/engine/mra.scala
+++ b/core/src/main/scala/slamdata/engine/mra.scala
@@ -239,7 +239,6 @@ object MRA {
   val dimsƒ: LogicalPlan[Dims] => Dims = {
     case ReadF(path) => Dims.set(path)
     case ConstantF(_) => Dims.Value
-    case JoinF(_, _, _, _) => ???
     case InvokeF(func, args) =>
       val d = Dims.combineAll(args)
 

--- a/core/src/main/scala/slamdata/engine/optimizer.scala
+++ b/core/src/main/scala/slamdata/engine/optimizer.scala
@@ -46,9 +46,6 @@ object Optimizer {
   val simplify: LogicalPlan[Term[LogicalPlan]] => Term[LogicalPlan] = {
     case v @ InvokeF(func, args) =>
       func.simplify(args).fold(Term(v))(x => simplify(x.unFix))
-    case JoinF(Term(ConstantF(Data.Set(Nil))), Term(ConstantF(Data.Set(Nil))), _, _) => Constant(Data.Set(Nil))
-    case JoinF(Term(ConstantF(Data.Set(Nil))), _, JoinType.Inner | JoinType.LeftOuter, _) => Constant(Data.Set(Nil))
-    case JoinF(_, Term(ConstantF(Data.Set(Nil))), JoinType.Inner | JoinType.RightOuter, _) => Constant(Data.Set(Nil))
     case LetF(ident, form @ Term(ConstantF(_)), in) =>
       in.para(inline(ident, form))
     case LetF(ident, form, in) => in.cata(countUsage(ident)) match {

--- a/core/src/main/scala/slamdata/engine/semantics.scala
+++ b/core/src/main/scala/slamdata/engine/semantics.scala
@@ -68,9 +68,6 @@ object SemanticError {
   final case class NoTableDefined(node: Node) extends SemanticError {
     def message = "No table was defined in the scope of \'" + node.sql + "\'"
   }
-  final case class UnboundVariable(v: Vari) extends SemanticError {
-    def message = "The variable " + v + " is not bound to any value"
-  }
   final case class MissingField(name: String) extends SemanticError {
     def message = "No field named '" + name + "' exists"
   }
@@ -88,12 +85,6 @@ object SemanticError {
   }
   final case class AmbiguousReference(node: Node, relations: List[SqlRelation]) extends SemanticError {
     def message = "The expression '" + node.sql + "' is ambiguous and might refer to any of the tables " + relations.mkString(", ")
-  }
-  final case class UnsupportedJoinCondition(clause: Expr) extends SemanticError {
-    def message = "The join clause is not supported: " + clause.sql
-  }
-  final case class ExpectedOneTableInJoin(expr: Expr) extends SemanticError {
-    def message = "In a join clause, expected to find an expression with a single table, but found: " + expr.sql
   }
   final case object CompiledTableMissing extends SemanticError {
     def message = "Expected the root table to be compiled but found nothing"
@@ -500,7 +491,7 @@ trait SemanticAnalysis {
 
         def annotateFunction(args: List[Node]) =
           (tree.attr(node).map { func =>
-            val typesV = inferredType.map(func.unapply).getOrElse(success(func.domain))
+            val typesV = inferredType.map(func.untype).getOrElse(success(func.domain))
             typesV map (types => (args zip types).toMap)
           }).getOrElse(fail(FunctionNotBound(node)))
 

--- a/core/src/main/scala/slamdata/engine/std/set.scala
+++ b/core/src/main/scala/slamdata/engine/std/set.scala
@@ -79,7 +79,7 @@ trait SetLib extends Library {
 
   val InnerJoin = Transformation(
     "INNER JOIN",
-    "Joins two sets …",
+    "Returns a new set containing the pairs values from the two sets that satisfy the condition.",
     Type.Top :: Type.Top :: Type.Bool :: Nil,
     noSimplification,
     partialTyper {
@@ -92,7 +92,7 @@ trait SetLib extends Library {
 
   val LeftOuterJoin = Transformation(
     "LEFT OUTER JOIN",
-    "Joins two sets …",
+    "Returns a new set containing the pairs values from the two sets that satisfy the condition, plus all other values from the left set.",
     Type.Top :: Type.Top :: Type.Bool :: Nil,
     noSimplification,
     partialTyper {
@@ -106,7 +106,7 @@ trait SetLib extends Library {
 
   val RightOuterJoin = Transformation(
     "RIGHT OUTER JOIN",
-    "Joins two sets …",
+    "Returns a new set containing the pairs values from the two sets that satisfy the condition, plus all other values from the right set.",
     Type.Top :: Type.Top :: Type.Bool :: Nil,
     noSimplification,
     partialTyper {
@@ -119,7 +119,7 @@ trait SetLib extends Library {
 
   val FullOuterJoin = Transformation(
     "FULL OUTER JOIN",
-    "Joins two sets …",
+    "Returns a new set containing the pairs values from the two sets that satisfy the condition, plus all other values from either set.",
     Type.Top :: Type.Top :: Type.Bool :: Nil,
     noSimplification,
     partialTyper {

--- a/core/src/test/scala/slamdata/engine/analysis/fixplate.scala
+++ b/core/src/test/scala/slamdata/engine/analysis/fixplate.scala
@@ -399,6 +399,18 @@ class FixplateSpecs extends Specification with ScalaCheck with ScalazMatchers {
       }
     }
 
+    "gpara" should {
+      "behave like para" in {
+        val v = mul(num(0), mul(num(0), num(1)))
+        v.gpara[Id, Int](
+          new (λ[α => Exp[Id[α]]] ~> λ[α => Id[Exp[α]]]) {
+            def apply[A](ex: Exp[Id[A]]): Id[Exp[A]] =
+              ex.map(_.copoint).point[Id]
+          },
+          expr => { peval(expr.map(_.runEnvT)) }) must_== 0
+      }
+    }
+
     "distCata" should {
       "behave like cata" in {
         val v = mul(num(0), mul(num(0), num(1)))

--- a/core/src/test/scala/slamdata/engine/compiler.scala
+++ b/core/src/test/scala/slamdata/engine/compiler.scala
@@ -120,7 +120,7 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile qualified select * with additional fields" in {
       testLogicalPlanCompile(
         "select foo.*, bar.address from foo, bar",
-        Let('tmp0, Cross(read("foo"), read("bar")),
+        Let('tmp0, InnerJoin(read("foo"), read("bar"), Constant(Data.Bool(true))),
           Let('tmp1,
             ObjectConcat(
               ObjectProject(Free('tmp0), Constant(Data.Str("left"))),
@@ -137,7 +137,7 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile deeply-nested qualified select *" in {
       testLogicalPlanCompile(
         "select foo.bar.baz.*, bar.address from foo, bar",
-        Let('tmp0, Cross(read("foo"), read("bar")),
+        Let('tmp0, InnerJoin(read("foo"), read("bar"), Constant(Data.Bool(true))),
           Let('tmp1,
             ObjectConcat(
               ObjectProject(
@@ -490,7 +490,7 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile cross select *" in {
       testLogicalPlanCompile(
         "select * from person, car",
-        Let('tmp0, Cross(read("person"), read("car")),
+        Let('tmp0, InnerJoin(read("person"), read("car"), Constant(Data.Bool(true))),
           Let('tmp1,
             ObjectConcat(
               ObjectProject(Free('tmp0), Constant(Data.Str("left"))),
@@ -503,7 +503,7 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
     "compile two term multiplication from two tables" in {
       testLogicalPlanCompile(
         "select person.age * car.modelYear from person, car",
-        Let('tmp0, Cross(read("person"), read("car")),
+        Let('tmp0, InnerJoin(read("person"), read("car"), Constant(Data.Bool(true))),
           Let('tmp1,
             makeObj(
               "0" ->
@@ -922,8 +922,7 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
         Let('tmp0,
           Let('left1, read("foo"),
             Let('right2, read("bar"),
-              Join(Free('left1), Free('right2),
-                JoinType.Inner,
+              InnerJoin(Free('left1), Free('right2),
                 relations.Eq(
                   ObjectProject(Free('left1), Constant(Data.Str("id"))),
                   ObjectProject(Free('right2), Constant(Data.Str("foo_id"))))))),
@@ -949,8 +948,7 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
         Let('tmp0,
           Let('left1, read("foo"),
             Let('right2, read("bar"),
-              Join(Free('left1), Free('right2),
-                JoinType.LeftOuter,
+              LeftOuterJoin(Free('left1), Free('right2),
                 relations.Lt(
                   ObjectProject(Free('left1), Constant(Data.Str("id"))),
                   ObjectProject(Free('right2), Constant(Data.Str("foo_id"))))))),
@@ -978,8 +976,7 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
           Let('left1,
             Let('left3, read("foo"),
               Let('right4, read("bar"),
-                Join(Free('left3), Free('right4),
-                  JoinType.Inner,
+                InnerJoin(Free('left3), Free('right4),
                   relations.Eq(
                     ObjectProject(
                       Free('left3),
@@ -988,8 +985,7 @@ class CompilerSpec extends Specification with CompilerHelpers with PendingWithAc
                       Free('right4),
                       Constant(Data.Str("foo_id"))))))),
             Let('right2, read("baz"),
-              Join(Free('left1), Free('right2),
-                JoinType.Inner,
+              InnerJoin(Free('left1), Free('right2),
                 relations.Eq(
                   ObjectProject(Free('right2),
                     Constant(Data.Str("bar_id"))),

--- a/core/src/test/scala/slamdata/engine/logicalplan.scala
+++ b/core/src/test/scala/slamdata/engine/logicalplan.scala
@@ -15,13 +15,13 @@ import scalaz.scalacheck.ScalazProperties._
 import shapeless.contrib.scalaz.instances._
 
 class LogicalPlanSpecs extends Spec {
-  import LogicalPlan._; import JoinType._
+  import LogicalPlan._
 
   implicit val arbLogicalPlan: Arbitrary ~> λ[α => Arbitrary[LogicalPlan[α]]] =
     new (Arbitrary ~> λ[α => Arbitrary[LogicalPlan[α]]]) {
       def apply[α](arb: Arbitrary[α]): Arbitrary[LogicalPlan[α]] =
         Arbitrary {
-          Gen.oneOf(readGen[α], addGen(arb), constGen[α], joinGen(arb), letGen(arb), freeGen[α](Nil))
+          Gen.oneOf(readGen[α], addGen(arb), constGen[α], letGen(arb), freeGen[α](Nil))
         }
     }
 
@@ -37,11 +37,6 @@ class LogicalPlanSpecs extends Spec {
   } yield LetF(Symbol("tmp" + n), form, body)
 
   def readGen[A]: Gen[LogicalPlan[A]] = Gen.const(ReadF(Path.Root))
-
-  def joinGen[A: Arbitrary]: Gen[LogicalPlan[A]] = for {
-    tpe <- Gen.oneOf(List(Inner, LeftOuter, RightOuter, FullOuter))
-    (l, r, comp) <- Arbitrary.arbitrary[(A, A, A)]
-  } yield JoinF(l, r, tpe, comp)
 
   import DataGen._
 

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -23,7 +23,7 @@ import org.scalacheck._
 import slamdata.specs2.PendingWithAccurateCoverage
 
 class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers with DisjunctionMatchers with PendingWithAccurateCoverage {
-  import StdLib._
+  import StdLib.{set => s, _}
   import structural._
   import LogicalPlan._
   import Grouped.grouped
@@ -2223,7 +2223,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           LogicalPlan.Let(
             'tmp1, makeObj("bar" -> ObjectProject(Free('tmp0), Constant(Data.Str("bar")))),
             LogicalPlan.Let('tmp2,
-              StdLib.set.OrderBy(
+              s.OrderBy(
                 Free('tmp1),
                 MakeArrayN(ObjectProject(Free('tmp1), Constant(Data.Str("bar")))),
                 MakeArrayN(Constant(Data.Str("ASC")))),
@@ -2241,7 +2241,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
       val lp =
         LogicalPlan.Let(
           'tmp0, read("db/foo"),
-          StdLib.set.OrderBy(
+          s.OrderBy(
             Free('tmp0),
             MakeArrayN(math.Divide(
               ObjectProject(Free('tmp0), Constant(Data.Str("bar"))),
@@ -2267,12 +2267,12 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           'tmp0, read("db/foo"),
           LogicalPlan.Let(
             'tmp1,
-            StdLib.set.Filter(
+            s.Filter(
               Free('tmp0),
               relations.Eq(
                 ObjectProject(Free('tmp0), Constant(Data.Str("baz"))),
                 Constant(Data.Int(0)))),
-            StdLib.set.OrderBy(
+            s.OrderBy(
               Free('tmp1),
               MakeArrayN(ObjectProject(Free('tmp1), Constant(Data.Str("bar")))),
               MakeArrayN(Constant(Data.Str("ASC"))))))
@@ -2292,7 +2292,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             'tmp9,
             makeObj(
               "bar" -> ObjectProject(Free('tmp0), Constant(Data.Str("bar")))),
-            StdLib.set.OrderBy(
+            s.OrderBy(
               Free('tmp9),
               MakeArrayN(math.Divide(
                 ObjectProject(Free('tmp9), Constant(Data.Str("bar"))),
@@ -2313,7 +2313,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     "plan distinct on full collection" in {
-      plan(StdLib.set.Distinct(read("db/cities"))) must
+      plan(s.Distinct(read("db/cities"))) must
         beWorkflow(chain(
           $read(Collection("db", "cities")),
           $simpleMap(NonEmptyList(MapExpr(JsFn(Ident("x"),
@@ -2331,18 +2331,18 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
 
   "alignJoinsƒ" should {
     "leave well enough alone" in {
-      MongoDbPlanner.alignJoinsƒ(JoinF(Free('left), Free('right),
-        JoinType.Inner,
-        relations.And(
-          relations.Eq(
-            ObjectProject(Free('left), Constant(Data.Str("foo"))),
-            ObjectProject(Free('right), Constant(Data.Str("bar")))),
-          relations.Eq(
-            ObjectProject(Free('left), Constant(Data.Str("baz"))),
-            ObjectProject(Free('right), Constant(Data.Str("zab"))))))) must
+      MongoDbPlanner.alignJoinsƒ(
+        InvokeF(s.InnerJoin,
+          List(Free('left), Free('right),
+            relations.And(
+              relations.Eq(
+                ObjectProject(Free('left), Constant(Data.Str("foo"))),
+                ObjectProject(Free('right), Constant(Data.Str("bar")))),
+              relations.Eq(
+                ObjectProject(Free('left), Constant(Data.Str("baz"))),
+                ObjectProject(Free('right), Constant(Data.Str("zab")))))))) must
       beRightDisjunction(
-        Join(Free('left), Free('right),
-          JoinType.Inner,
+        s.InnerJoin(Free('left), Free('right),
           relations.And(
             relations.Eq(
               ObjectProject(Free('left), Constant(Data.Str("foo"))),
@@ -2353,18 +2353,18 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     "swap a reversed condition" in {
-      MongoDbPlanner.alignJoinsƒ(JoinF(Free('left), Free('right),
-        JoinType.Inner,
-        relations.And(
-          relations.Eq(
-            ObjectProject(Free('right), Constant(Data.Str("bar"))),
-            ObjectProject(Free('left), Constant(Data.Str("foo")))),
-          relations.Eq(
-            ObjectProject(Free('left), Constant(Data.Str("baz"))),
-            ObjectProject(Free('right), Constant(Data.Str("zab"))))))) must
+      MongoDbPlanner.alignJoinsƒ(
+        InvokeF(s.InnerJoin,
+          List(Free('left), Free('right),
+            relations.And(
+              relations.Eq(
+                ObjectProject(Free('right), Constant(Data.Str("bar"))),
+                ObjectProject(Free('left), Constant(Data.Str("foo")))),
+              relations.Eq(
+                ObjectProject(Free('left), Constant(Data.Str("baz"))),
+                ObjectProject(Free('right), Constant(Data.Str("zab")))))))) must
       beRightDisjunction(
-        Join(Free('left), Free('right),
-          JoinType.Inner,
+        s.InnerJoin(Free('left), Free('right),
           relations.And(
             relations.Eq(
               ObjectProject(Free('left), Constant(Data.Str("foo"))),
@@ -2375,18 +2375,18 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     "swap multiple reversed conditions" in {
-      MongoDbPlanner.alignJoinsƒ(JoinF(Free('left), Free('right),
-        JoinType.Inner,
-        relations.And(
-          relations.Eq(
-            ObjectProject(Free('right), Constant(Data.Str("bar"))),
-            ObjectProject(Free('left), Constant(Data.Str("foo")))),
-          relations.Eq(
-            ObjectProject(Free('right), Constant(Data.Str("zab"))),
-            ObjectProject(Free('left), Constant(Data.Str("baz"))))))) must
+      MongoDbPlanner.alignJoinsƒ(
+        InvokeF(s.InnerJoin,
+          List(Free('left), Free('right),
+            relations.And(
+              relations.Eq(
+                ObjectProject(Free('right), Constant(Data.Str("bar"))),
+                ObjectProject(Free('left), Constant(Data.Str("foo")))),
+              relations.Eq(
+                ObjectProject(Free('right), Constant(Data.Str("zab"))),
+                ObjectProject(Free('left), Constant(Data.Str("baz")))))))) must
       beRightDisjunction(
-        Join(Free('left), Free('right),
-          JoinType.Inner,
+        s.InnerJoin(Free('left), Free('right),
           relations.And(
             relations.Eq(
               ObjectProject(Free('left), Constant(Data.Str("foo"))),
@@ -2397,17 +2397,18 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     "fail with “mixed” conditions" in {
-      MongoDbPlanner.alignJoinsƒ(JoinF(Free('left), Free('right),
-        JoinType.Inner,
-        relations.And(
-          relations.Eq(
-            math.Add(
-              ObjectProject(Free('right), Constant(Data.Str("bar"))),
-              ObjectProject(Free('left), Constant(Data.Str("baz")))),
-            ObjectProject(Free('left), Constant(Data.Str("foo")))),
-          relations.Eq(
-            ObjectProject(Free('left), Constant(Data.Str("baz"))),
-            ObjectProject(Free('right), Constant(Data.Str("zab"))))))) must
+      MongoDbPlanner.alignJoinsƒ(
+        InvokeF(s.InnerJoin,
+          List(Free('left), Free('right),
+            relations.And(
+              relations.Eq(
+                math.Add(
+                  ObjectProject(Free('right), Constant(Data.Str("bar"))),
+                  ObjectProject(Free('left), Constant(Data.Str("baz")))),
+                ObjectProject(Free('left), Constant(Data.Str("foo")))),
+              relations.Eq(
+                ObjectProject(Free('left), Constant(Data.Str("baz"))),
+                ObjectProject(Free('right), Constant(Data.Str("zab")))))))) must
       beLeftDisjunction(PlannerError.UnsupportedJoinCondition(
         relations.Eq(
           math.Add(


### PR DESCRIPTION
Now that we handle arbitrary conditions, Join doesn’t need any special
handling, so it’s simpler to handle it as functions.

Also, `Cross` is just an `InnerJoin` where the condition is constantly
`true`, so that’s how it’s implemented now.

Finally, add some fp package coverage:

* Add a simple `gpara` test,
* delete some dead code, and
* fix a bug in EnvT uncovered by the new coverage.