### PR TITLE
In the API, test connection to new mount before saving

### DIFF
--- a/core/src/main/scala/slamdata/engine/backend.scala
+++ b/core/src/main/scala/slamdata/engine/backend.scala
@@ -340,7 +340,7 @@ object Backend {
         EitherT.left(Task.now(MissingBackend("no backend in config: " + config))))(
         EitherT.right(_))
       _       <- backend.checkCompatibility
-      _       <- trap(backend.ls.leftMap(EnvPathError(_)), wrap("listing files"))
+      _       <- trap(backend.ls.leftMap(EnvPathError(_)), err => InsufficientPermissions(err.toString))
       _       <- testWrite(backend)
     } yield ()
 

--- a/core/src/main/scala/slamdata/engine/evaluator.scala
+++ b/core/src/main/scala/slamdata/engine/evaluator.scala
@@ -78,6 +78,9 @@ object Evaluator {
     final case class EnvEvalError(error: EvaluationError) extends EnvironmentError {
       def message = error.message
     }
+    final case class EnvWriteError(error: Backend.ProcessingError) extends EnvironmentError {
+      def message = "write failed: " + error.message
+    }
     final case class UnsupportedVersion(backend: Evaluator[_], version: List[Int]) extends EnvironmentError {
       def message = "Unsupported " + backend + " version: " + version.mkString(".")
     }
@@ -122,6 +125,14 @@ object Evaluator {
       case _                       => None
     }
   }
+  object EnvWriteError {
+    def apply(error: Backend.ProcessingError): EnvironmentError =
+      EnvironmentError.EnvWriteError(error)
+    def unapply(obj: EnvironmentError): Option[Backend.ProcessingError] = obj match {
+      case EnvironmentError.EnvWriteError(error) => Some(error)
+      case _                       => None
+    }
+  }
   object EnvEvalError {
     def apply(error: EvaluationError): EnvironmentError = EnvironmentError.EnvEvalError(error)
     def unapply(obj: EnvironmentError): Option[EvaluationError] = obj match {
@@ -149,6 +160,7 @@ object Evaluator {
     }
     final case class UnableToStore(message: String) extends EvaluationError
     final case class InvalidTask(message: String) extends EvaluationError
+    final case class CommandFailed(message: String) extends EvaluationError
   }
 
   type EvaluationTask[A] = ETask[EvaluationError, A]
@@ -179,6 +191,13 @@ object Evaluator {
     def apply(message: String): EvaluationError = EvaluationError.InvalidTask(message)
     def unapply(obj: EvaluationError): Option[String] = obj match {
       case EvaluationError.InvalidTask(message) => Some(message)
+      case _                       => None
+    }
+  }
+  object CommandFailed {
+    def apply(message: String): EvaluationError = EvaluationError.CommandFailed(message)
+    def unapply(obj: EvaluationError): Option[String] = obj match {
+      case EvaluationError.CommandFailed(message) => Some(message)
       case _                       => None
     }
   }

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/evaluator.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/evaluator.scala
@@ -59,7 +59,7 @@ class MongoDbEvaluator(impl: MongoDbEvaluatorImpl[StateT[ETask[EvaluationError, 
   def checkCompatibility: ETask[EnvironmentError, Unit] = for {
     nameSt  <- EitherT.right(SequenceNameGenerator.startUnique)
     dbName  <- EitherT[Task, EnvironmentError, String](Task.now((impl.defaultDb \/> MissingDatabase())))
-    version <- impl.executor.version(dbName).eval(nameSt).leftMap(EnvEvalError(_))
+    version <- impl.executor.version(dbName).eval(nameSt).leftMap(MongoDbEvaluator.mapError)
     rez <- if (version >= MinVersion)
              ().point[ETask[EnvironmentError, ?]]
            else EitherT.left[Task, EnvironmentError, Unit](Task.now(UnsupportedVersion(this, version)))
@@ -93,6 +93,17 @@ object MongoDbEvaluator {
         col <- Collection.fromPath(path.path).leftMap(EvalPathError(_))
       } yield Js.Stmts((log :+ Js.Call(Js.Select(JSExecutor.toJsRef(col), "find"), Nil)).toList).pprint(0)
     }
+  }
+
+  def mapError(err: EvaluationError): EnvironmentError = err match {
+    case CommandFailed(msg) if (msg contains "Command failed with error 18: 'auth failed'") =>
+      InvalidCredentials(msg)
+    case CommandFailed(msg) if (msg contains "com.mongodb.MongoSocketException") =>
+      ConnectionFailed(msg)
+    case CommandFailed(msg) if (msg contains "com.mongodb.MongoSocketOpenException") =>
+      ConnectionFailed(msg)
+    case err =>
+      EnvEvalError(err)
   }
 }
 

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/evaluator.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/evaluator.scala
@@ -274,12 +274,11 @@ class MongoDbExecutor[S](client: MongoClient, nameGen: NameGenerator[State[S, ?]
   private def mongoCol(col: Collection) = client.getDatabase(col.databaseName).getCollection(col.collectionName)
 
   private def liftMongo[A](a: => A): M[A] =
-    StateT[ETask[EvaluationError, ?], S, A](s => EitherT.right(Task.delay(a).map((s, _))))
+    StateT[ETask[EvaluationError, ?], S, A](s => MongoWrapper.delay(a).map((s, _)))
 
   private def runMongoCommand(db: String, cmd: Bson.Doc): M[Unit] =
     liftMongo {
       ignore(client.getDatabase(db).runCommand(cmd.repr))
-      ()
     }
 }
 

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/filesystem.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/filesystem.scala
@@ -219,17 +219,10 @@ object MongoWrapper {
     def defaultDB = defaultDb0
   }
 
-  def mapException(e: java.lang.Throwable): EvaluationError = e match {
-    case e: com.mongodb.MongoTimeoutException =>
-      CommandFailed("connection timeout: " + e.getMessage)
-
-    case e => CommandFailed("other: " + e.getMessage)
-  }
-
   /**
    Defer an action to be performed against MongoDB, capturing exceptions
    in EvaluationError.
    */
   def delay[A](a: => A): ETask[EvaluationError, A] =
-    EitherT(Task.delay(a).attempt.map(_.leftMap(mapException)))
+    EitherT(Task.delay(a).attempt.map(_.leftMap(e => CommandFailed(e.getMessage))))
 }

--- a/core/src/test/scala/slamdata/engine/config/config.scala
+++ b/core/src/test/scala/slamdata/engine/config/config.scala
@@ -92,7 +92,7 @@ class ConfigSpec extends Specification with DisjunctionMatchers {
       val rez = (for {
         _ <- liftE[EnvironmentError](Config.write(BrokenTestConfig, Some(fileName)))
         config <- Config.loadAndTest(Some(fileName))
-      } yield config).run.run must beLeftDisjunction(InvalidConfig("mounting(s) failed"))
+      } yield config).run.run must beLeftDisjunction
       java.nio.file.Files.delete(java.nio.file.Paths.get(fileName))
 
       rez

--- a/web/src/main/scala/slamdata/engine/api/fs.scala
+++ b/web/src/main/scala/slamdata/engine/api/fs.scala
@@ -340,8 +340,8 @@ final case class FileSystemApi(backend: Backend, contentPath: String, config: Co
   def liftT[A](t: Task[A]): EnvTask[A] = EitherT.right(t)
   def liftE[A](v: EnvironmentError \/ A): EnvTask[A] = EitherT(Task.now(v))
 
-  def respond(v: EnvTask[String]): Task[Response] =
-    v.fold(err => BadRequest(errorBody(err.message, None)), Ok(_)).join
+  def respond(v: EnvTask[String])(implicit E: EncodeJson[EnvironmentError]): Task[Response] =
+    v.fold(err => BadRequest(E.encode(err)), Ok(_)).join
 
   def mountService(config: Config, tester: BackendConfig => EnvTask[Unit], reloader: Config => Task[Unit]) = {
     def addPath(path: Path, req: Request): EnvTask[Boolean] = for {

--- a/web/src/main/scala/slamdata/engine/api/fs.scala
+++ b/web/src/main/scala/slamdata/engine/api/fs.scala
@@ -124,7 +124,7 @@ object ResponseFormat {
   }
 }
 
-final case class FileSystemApi(backend: Backend, contentPath: String, config: Config, reloader: Config => Task[Unit]) {
+final case class FileSystemApi(backend: Backend, contentPath: String, config: Config, tester: BackendConfig => EnvTask[Unit], reloader: Config => Task[Unit]) {
   import Method.{MOVE, OPTIONS}
 
   val CsvColumnsFromInitialRowsCount = 1000
@@ -168,7 +168,7 @@ final case class FileSystemApi(backend: Backend, contentPath: String, config: Co
         Ok("")) {
         case (first, rest) => Ok(Process.emit(first) ++ rest.translate(unstack))
       }).join
-  
+
 
   private def responseLines[F[_]](accept: Option[Accept], v: Process[F, Data]) =
     ResponseFormat.fromAccept(accept) match {
@@ -343,11 +343,12 @@ final case class FileSystemApi(backend: Backend, contentPath: String, config: Co
   def respond(v: EnvTask[String]): Task[Response] =
     v.fold(err => BadRequest(errorBody(err.message, None)), Ok(_)).join
 
-  def mountService(config: Config, reloader: Config => Task[Unit]) = {
+  def mountService(config: Config, tester: BackendConfig => EnvTask[Unit], reloader: Config => Task[Unit]) = {
     def addPath(path: Path, req: Request): EnvTask[Boolean] = for {
       body <- liftT(EntityDecoder.decodeString(req))
       conf <- liftE(Parse.decodeEither[BackendConfig](body).leftMap(err => InvalidConfig("input error: " + err)))
       _    <- liftE(conf.validate(path))
+      _    <- tester(conf)
       _    <- liftT(reloader(config.copy(mountings = config.mountings + (path -> conf))))
     } yield config.mountings.keySet contains path
 
@@ -568,7 +569,7 @@ final case class FileSystemApi(backend: Backend, contentPath: String, config: Co
     "/compile/fs"  -> compileService,
     "/data/fs"     -> dataService,
     "/metadata/fs" -> metadataService,
-    "/mount/fs"    -> mountService(config, reloader),
+    "/mount/fs"    -> mountService(config, tester, reloader),
     "/query/fs"    -> queryService,
     "/server"      -> serverService(config, reloader),
     "/slamdata"    -> staticFileService(contentPath + "/slamdata"),

--- a/web/src/test/scala/slamdata/engine/api/fs.scala
+++ b/web/src/test/scala/slamdata/engine/api/fs.scala
@@ -36,26 +36,26 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
   var historyBuff = scala.collection.mutable.ListBuffer[Action]()
   def history = historyBuff.toList
 
+  def tester(cfg: BackendConfig) = Errors.liftE[slamdata.engine.Evaluator.EnvironmentError](Task.now(()))
+  def mounter(backend: Backend)(cfg: Config) = Errors.liftE[slamdata.engine.Evaluator.EnvironmentError](Task.now(backend))
+  def configWriter(cfg: Config) = Task.delay {
+    historyBuff += Action.Reload(cfg)
+    ()
+  }
+
  /**
   Start a server, with the given backend, execute something, and then tear
   down the server.
   */
   def withServer[A](backend: Backend, config: Config)(body: => A): A = {
-    def mounter(cfg: Config) = Errors.liftE[slamdata.engine.Evaluator.EnvironmentError](Task.now(backend))
-    def configWriter(cfg: Config) = Task.delay {
-      historyBuff += Action.Reload(cfg)
-      ()
-    }
-    val rez: slamdata.engine.Evaluator.EnvironmentError \/ Int = Server.run(port, config, "", 1.seconds, mounter, configWriter).run.run
+    val srv = Server.createServer(port, 1.seconds, FileSystemApi(backend, ".", config, tester, configWriter)).run
 
     try {
       body
     }
     finally {
-      // NB: in case the test provoked a deferred restart
-      java.lang.Thread.sleep(500)
+      ignore(srv.shutdown.run)
 
-      ignore(Server.serv.fold(κ(()), _.shutdown.run))
       historyBuff.clear
     }
   }
@@ -1618,8 +1618,29 @@ class ApiSpecs extends Specification with DisjunctionMatchers with PendingWithAc
     }
 
     "restart sequence" should {
+      // Exercises the server restarting code path in server.scala.
+       def withRestartableServer[A](backend: Backend, config: Config)(body: => A): A = {
+         val rez: slamdata.engine.Evaluator.EnvironmentError \/ Int = Server.run(port, config, "", 1.seconds, tester, mounter(backend), configWriter).run.run
+
+         try {
+           body
+         }
+         finally {
+           // NB: the test will have provoked a deferred restart
+           java.lang.Thread.sleep(500)
+
+           ignore(Server.serv.fold(κ(()), _.shutdown.run))
+
+           // NB: just to be safe
+           java.lang.Thread.sleep(500)
+
+           historyBuff.clear
+         }
+       }
+
+
       "restart on same port with new config" in {
-        withServer(noBackends, config1) {
+        withRestartableServer(noBackends, config1) {
           val req1 = root / "bar" / ""
           val result1 = Http(req1 > code)
           result1() must_== 404


### PR DESCRIPTION
Fixes #863.

Call `Backend.test` from the API before saving a new mount (previously it was
used only by the now defunct admin UI).

Make that test somewhat more robust by also writing a temp file so that it
fails in a read-only configuraiton.

Capture additional errors from MongoDB in our error types. Unfortunately, much
of the interesting information is available only in the message strings of the
MongoDB exceptions, so for now that's just captured and wrapped.

Also, went back to the simpler server setup for the bulk of the API tests. The
server restarting code path is now used only by the one test the depends on it
(and tests it), while the rest use the simpler, single-threaded setup.
Hopefully this will resolve the flakiness we've seen in Jenkins and elsewhere.