### PR TITLE
Refactor server config to use typesafe paths

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,6 +61,7 @@ lazy val standardSettings = Defaults.defaultSettings ++ Seq(
     "io.argonaut"       %% "argonaut"                  % "6.1-M6"       % "compile, test",
     "org.jboss.aesh"    %  "aesh"                      % "0.55"         % "compile, test",
     "org.typelevel"     %% "shapeless-scalaz"          % slcVersion     % "compile, test",
+    "com.slamdata"      %% "pathy"                     % "0.0.1-SNAPSHOT" % "compile, test",
     "com.github.mpilquist" %% "simulacrum"             % "0.3.0"        % "compile, test",
     "org.scalaz"        %% "scalaz-scalacheck-binding" % scalazVersion  % "test",
     "org.specs2"        %% "specs2-core"               % "2.4"          % "test",

--- a/core/src/main/scala/slamdata/engine/config/FsPath.scala
+++ b/core/src/main/scala/slamdata/engine/config/FsPath.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package slamdata.engine.config
+
+import slamdata.Predef._
+import slamdata.fp._
+
+import java.io.{File => JFile}
+import scala.util.Properties._
+import scalaz._, Scalaz._
+import scalaz.concurrent.Task
+import Leibniz.===
+import pathy._, Path._
+
+sealed trait FsPath[T, S] {
+  type Base
+
+  def fold[X](uni: Path[Base, T, S] => X, inv: (String, Path[Base, T, S], Base === Abs) => X): X
+
+  def forgetBase: FsPath[T, S] = this
+
+  def path: Path[Base, T, S] =
+    fold(ɩ, (_, p, _) => p)
+}
+
+object FsPath {
+  type Aux[Base0, T, S] = FsPath[T, S] { type Base = Base0 }
+
+  private final case class Uni[B, T, S](p: Path[B, T, S]) extends FsPath[T, S] {
+    type Base = B
+    def fold[X](uni: Path[Base, T, S] => X, inv: (String, Path[Base, T, S], Base === Abs) => X): X =
+      uni(p)
+  }
+
+  private final case class InV[B, T, S](vol: String, p: Path[B, T, S], ev: B === Abs) extends FsPath[T, S] {
+    type Base = B
+    def fold[X](uni: Path[Base, T, S] => X, inv: (String, Path[Base, T, S], Base === Abs) => X): X =
+      inv(vol, p, ev)
+  }
+
+  object Uniform {
+    def apply[B, T, S](path: Path[B, T, S]): Aux[B, T, S] =
+      Uni[B, T, S](path)
+  }
+
+  object InVolume {
+    def apply[B, T, S](vol: String, path: Path[B, T, S])(implicit ev: B === Abs): Aux[B, T, S] =
+      InV[B, T, S](vol, path, ev)
+  }
+
+  val systemCodec: Task[PathCodec] =
+    Task.delay(PathCodec.placeholder(JFile.separatorChar))
+
+  def printFsPath[T](codec: PathCodec, fp: FsPath[T, Sandboxed]): String =
+    fp.fold(codec.printPath, (v, p, _) => v + codec.printPath(p))
+
+  def sandboxFsPathIn[B, T, S](dir: Path[B, Dir, Sandboxed], fp: Aux[B, T, S]): Option[Aux[B, T, Sandboxed]] =
+    fp.fold(
+      p          => sandbox(dir, p) map (p1 => Uniform(dir </> p1)),
+      (v, p, ev) => sandbox(dir, p) map (p1 => InVolume(v, dir </> p1)(ev))
+    )
+
+  private def winVolAndPath(s: String): (String, String) = {
+    val (prefix, s1): (String, String) = if (s.startsWith("\\\\")) ("\\\\", s.drop(2)) else ("", s)
+    val (vol, rest) = s1.splitAt(s1.indexOf("\\"))
+    (prefix + vol, rest)
+  }
+
+  def parseWinAbsDir(s: String): Option[Aux[Abs, Dir, Sandboxed]] = {
+    val (vol, rest) = winVolAndPath(s)
+    windowsCodec.parseAbsDir(rest) >>= (p => sandboxFsPathIn(rootDir, InVolume(vol, p)))
+  }
+
+  def parseWinAbsFile(s: String): Option[Aux[Abs, File, Sandboxed]] = {
+    val (vol, rest) = winVolAndPath(s)
+    windowsCodec.parseAbsFile(rest) >>= (p => sandboxFsPathIn(rootDir, InVolume(vol, p)))
+  }
+
+  def parseSystemAbsDir(s: String): OptionT[Task, Aux[Abs, Dir, Sandboxed]] = {
+    def parseOther(codec: PathCodec) =
+      codec.parseAbsDir(s) >>= (p => sandboxFsPathIn(rootDir, Uniform(p)))
+
+    OptionT(Task.delay(isWin).ifM(Task.now(parseWinAbsDir(s)), systemCodec map parseOther))
+  }
+
+  def parseSystemAbsFile(s: String): OptionT[Task, Aux[Abs, File, Sandboxed]] = {
+    def parseOther(codec: PathCodec) =
+      codec.parseAbsFile(s) >>= (p => sandboxFsPathIn(rootDir, Uniform(p)))
+
+    OptionT(Task.delay(isWin).ifM(Task.now(parseWinAbsFile(s)), systemCodec map parseOther))
+  }
+
+  def parseSystemRelFile(s: String): OptionT[Task, Aux[Rel, File, Sandboxed]] =
+    OptionT(systemCodec map (c =>
+      c.parseRelFile(s) >>= (p => sandboxFsPathIn(currentDir, Uniform(p)))))
+
+  def parseSystemFile(s: String): OptionT[Task, FsPath[File, Sandboxed]] =
+    parseSystemAbsFile(s).map(_.forgetBase) orElse parseSystemRelFile(s).map(_.forgetBase)
+
+  implicit class FsDirOps[B, S](fd: Aux[B, Dir, S]) {
+    def </>[T](rel: Path[Rel, T, S]): Aux[B, T, S] =
+      fd.fold(
+        p          => Uniform(p </> rel),
+        (v, p, ev) => InVolume(v, p </> rel)(ev)
+      )
+  }
+}

--- a/core/src/main/scala/slamdata/engine/config/OS.scala
+++ b/core/src/main/scala/slamdata/engine/config/OS.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 - 2015 SlamData Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package slamdata.engine.config
+
+import slamdata.Predef._
+
+import scala.util.Properties._
+import scalaz.concurrent.Task
+
+sealed trait OS {
+  import OS._
+
+  def fold[X](win: => X, mac: => X, posix: => X): X =
+    this match {
+      case Windows => win
+      case Mac     => mac
+      case Posix   => posix
+    }
+
+  def isWin: Boolean = fold(true, false, false)
+
+  def isMac: Boolean = fold(false, true, false)
+
+  def isPosix: Boolean = fold(false, false, true)
+}
+
+object OS {
+  private case object Windows extends OS
+  private case object Mac extends OS
+  private case object Posix extends OS
+
+  val windows: OS = Windows
+  val mac: OS = Mac
+  val posix: OS = Posix
+
+  // NB: We lump everything that isn't Windows or Mac into posix, this may need
+  //     to change.
+  def currentOS: Task[OS] =
+    Task.delay(if (isWin) windows else if (isMac) mac else posix)
+}
+

--- a/core/src/test/scala/slamdata/engine/config/FsPath.scala
+++ b/core/src/test/scala/slamdata/engine/config/FsPath.scala
@@ -1,0 +1,50 @@
+package slamdata.engine.config
+
+import slamdata.Predef._
+
+import pathy._, Path._
+import org.specs2.mutable._
+
+class FsPathSpec extends Specification {
+  import windowsCodec._
+  import FsPath._
+
+  "printFsPath" should {
+    "equal printPath when uniform" in {
+      val p: RelFile[Sandboxed] = dir("foo") </> dir("bar") </> file("quux.txt")
+      printFsPath(windowsCodec, Uniform(p)) must_== printPath(p)
+    }
+
+    "include volume when in volume" in {
+      val s = "c:\\bat\\quux\\blaat.png"
+
+      parseWinAbsFile(s) map { fp =>
+        printFsPath(windowsCodec, fp) must_== s"c:${printPath(fp.path)}"
+      } getOrElse ko
+    }
+  }
+
+  "parseWinAbsDir" should {
+    "support volume + path" in {
+      val d = "d:\\foo\\bar\\"
+      parseWinAbsDir(d).map(printFsPath(windowsCodec, _)) must beSome(d)
+    }
+
+    "support UNC paths" in {
+      val d = "\\\\d\\foo\\bar\\"
+      parseWinAbsDir(d).map(printFsPath(windowsCodec, _)) must beSome(d)
+    }
+  }
+
+  "parseWinAbsFile" should {
+    "support volume + path" in {
+      val f = "c:\\over\\there\\pic.jpg"
+      parseWinAbsFile(f).map(printFsPath(windowsCodec, _)) must beSome(f)
+    }
+
+    "support UNC paths" in {
+      val f = "\\\\c\\over\\there\\pic.jpg"
+      parseWinAbsFile(f).map(printFsPath(windowsCodec, _)) must beSome(f)
+    }
+  }
+}

--- a/core/src/test/scala/slamdata/engine/config/FsPath.scala
+++ b/core/src/test/scala/slamdata/engine/config/FsPath.scala
@@ -6,45 +6,141 @@ import pathy._, Path._
 import org.specs2.mutable._
 
 class FsPathSpec extends Specification {
-  import windowsCodec._
+  import windowsCodec.printPath
   import FsPath._
+
+  def printWin[T](fp: FsPath[T, Sandboxed]) = printFsPath[T](windowsCodec, fp)
+  def printPosix[T](fp: FsPath[T, Sandboxed]) = printFsPath[T](posixCodec, fp)
 
   "printFsPath" should {
     "equal printPath when uniform" in {
-      val p: RelFile[Sandboxed] = dir("foo") </> dir("bar") </> file("quux.txt")
-      printFsPath(windowsCodec, Uniform(p)) must_== printPath(p)
+      val p = Uniform(dir[Sandboxed]("foo")) </> dir("bar") </> file("quux.txt")
+      printWin(p) ==== printPath(p.path)
     }
 
     "include volume when in volume" in {
-      val s = "c:\\bat\\quux\\blaat.png"
+      val p = InVolume("c:", rootDir[Sandboxed]) </> dir("bat") </> dir("quux") </> file("blaat.png")
+      printWin(p) ==== s"c:${printPath(p.path)}"
+    }
+  }
 
-      parseWinAbsFile(s) map { fp =>
-        printFsPath(windowsCodec, fp) must_== s"c:${printPath(fp.path)}"
-      } getOrElse ko
+  "sandboxFsPathIn" should {
+    def pAbs[S] = rootDir[S] </> dir("foo") </> dir("bar") </> file("baz.txt")
+    def pRel[S] = dir[S]("bar") </> dir("quux") </> dir("foo")
+
+    "sandbox uniform abs path when dir is a prefix" in {
+      val uni = Uniform(pAbs[Unsandboxed])
+      val base = rootDir[Sandboxed] </> dir("foo")
+      sandboxFsPathIn(base, uni).map(printWin) ==== Some(printPath(pAbs))
+    }
+
+    "sandbox uniform rel path when dir is a prefix" in {
+      val uni = Uniform(pRel[Unsandboxed])
+      val base = dir[Sandboxed]("bar") </> dir("quux")
+      sandboxFsPathIn(base, uni).map(printWin) ==== Some(printPath(pRel))
+    }
+
+    "fail when sandbox dir not a prefix" in {
+      val uni = Uniform(dir[Unsandboxed]("bar") </> dir("foo"))
+      val base = dir[Sandboxed]("sbox")
+      sandboxFsPathIn(base, uni) must beNone
+    }
+
+    "sandbox volume path in given dir" in {
+      val vol = InVolume("e:", pAbs[Unsandboxed])
+      val base = rootDir[Sandboxed] </> dir("foo") </> dir("bar")
+      sandboxFsPathIn(base, vol).map(printWin) ==== Some("e:\\foo\\bar\\baz.txt")
+    }
+
+    "fail for volume path when sandbox dir not a prefix" in {
+      val vol = InVolume("f:", rootDir[Unsandboxed] </> file("foo.txt"))
+      val base = rootDir[Sandboxed] </> dir("quux")
+      sandboxFsPathIn(base, vol) must beNone
     }
   }
 
   "parseWinAbsDir" should {
     "support volume + path" in {
       val d = "d:\\foo\\bar\\"
-      parseWinAbsDir(d).map(printFsPath(windowsCodec, _)) must beSome(d)
+      parseWinAbsDir(d).map(printWin(_)) must beSome(d)
     }
 
     "support UNC paths" in {
       val d = "\\\\d\\foo\\bar\\"
-      parseWinAbsDir(d).map(printFsPath(windowsCodec, _)) must beSome(d)
+      parseWinAbsDir(d).map(printWin(_)) must beSome(d)
     }
   }
 
   "parseWinAbsFile" should {
     "support volume + path" in {
       val f = "c:\\over\\there\\pic.jpg"
-      parseWinAbsFile(f).map(printFsPath(windowsCodec, _)) must beSome(f)
+      parseWinAbsFile(f).map(printWin(_)) must beSome(f)
     }
 
     "support UNC paths" in {
       val f = "\\\\c\\over\\there\\pic.jpg"
-      parseWinAbsFile(f).map(printFsPath(windowsCodec, _)) must beSome(f)
+      parseWinAbsFile(f).map(printWin(_)) must beSome(f)
     }
   }
+
+  "parseAbsDir" should {
+    "for windows" in {
+      parseAbsDir(OS.windows, "c:\\foo\\").map(printWin(_)) must beSome("c:\\foo\\")
+    }
+
+    "for mac" in {
+      parseAbsDir(OS.mac, "/foo/").map(printPosix(_)) must beSome("/foo/")
+    }
+
+    "for posix" in {
+      parseAbsDir(OS.posix, "/foo/").map(printPosix(_)) must beSome("/foo/")
+    }
+
+    "be none when not dir" in {
+      parseAbsDir(OS.posix, "/foo/bar.txt") must beNone
+    }
+
+    "be none when not absolute" in {
+      parseAbsDir(OS.posix, "./foo/") must beNone
+    }
+  }
+
+  "parseFile" should {
+    "windows relative" in {
+      parseFile(OS.windows, ".\\foo\\bar.txt").map(printWin(_)) must beSome(".\\foo\\bar.txt")
+    }
+
+    "windows absolute" in {
+      parseFile(OS.windows, "d:\\foo\\bar.txt").map(printWin(_)) must beSome("d:\\foo\\bar.txt")
+    }
+
+    "windows dir" in {
+      parseFile(OS.windows, "c:\\foo\\bar\\") must beNone
+    }
+
+    "mac relative" in {
+      parseFile(OS.mac, "./foo/bar.txt").map(printPosix(_)) must beSome("./foo/bar.txt")
+    }
+
+    "mac absolute" in {
+      parseFile(OS.mac, "/foo/bar.txt").map(printPosix(_)) must beSome("/foo/bar.txt")
+    }
+
+    "mac dir" in {
+      parseFile(OS.mac, "/foo/") must beNone
+    }
+
+    "posix relative" in {
+      parseFile(OS.posix, "./bar/foo.txt").map(printPosix(_)) must beSome("./bar/foo.txt")
+    }
+
+    "posix absolute" in {
+      parseFile(OS.posix, "/bar/foo.txt").map(printPosix(_)) must beSome("/bar/foo.txt")
+    }
+
+    "posix dir" in {
+      parseFile(OS.posix, "/bar/foo/") must beNone
+    }
+  }
+
 }


### PR DESCRIPTION
Integrates `pathy.Path` into the server config, replacing `String` paths with typesafe versions.

Introduces `FsPath` to encapsulate paths that may be in a volume (e.g. `c:\foo\bar`, `\\c\foo\bar`). I'm not sure if this is something we'd want to extend pathy with or if it lies outside the scope of that library. The library is advertised and dealing with filesystem paths, so in that sense it might belong, though there are other kinds of paths, like URIs, which pathy could be used for and also have a scheme prefix, similar to windows volumes.

Also, the system currently makes the assumption that any paths provided via the `LOCALAPPDATA` environment variable or the `user.home` JVM property are absolute, let me know if this is a poor assumption.

Fixes #858.