### PR TITLE
handle home directory without trailing slash on posix/mac

### DIFF
--- a/core/src/main/scala/slamdata/engine/config/FsPath.scala
+++ b/core/src/main/scala/slamdata/engine/config/FsPath.scala
@@ -91,6 +91,11 @@ object FsPath {
     windowsCodec.parseAbsFile(rest) >>= (p => sandboxFsPathIn(rootDir, InVolume(vol, p)))
   }
 
+  def parseWinAbsAsDir(s: String): Option[Aux[Abs, Dir, Sandboxed]] = {
+    val (vol, rest) = winVolAndPath(s)
+    windowsCodec.parseAbsAsDir(rest) >>= (p => sandboxFsPathIn(rootDir, InVolume(vol, p)))
+  }
+
   private def forCurrentOS[A](f: OS => Option[A]): OptionT[Task, A] =
     OptionT(OS.currentOS map f)
 
@@ -109,6 +114,13 @@ object FsPath {
       codec.parseAbsFile(s) >>= (p => sandboxFsPathIn(rootDir, Uniform(p)))
 
     if (os.isWin) parseWinAbsFile(s) else parseOther(codecForOS(os))
+  }
+
+  def parseAbsAsDir(os: OS, s: String): Option[Aux[Abs, Dir, Sandboxed]] = {
+    def parseOther(codec: PathCodec) =
+      codec.parseAbsAsDir(s) >>= (p => sandboxFsPathIn(rootDir, Uniform(p)))
+
+    if (os.isWin) parseWinAbsAsDir(s) else parseOther(codecForOS(os))
   }
 
   def parseSystemAbsFile(s: String): OptionT[Task, Aux[Abs, File, Sandboxed]] =

--- a/core/src/main/scala/slamdata/engine/config/config.scala
+++ b/core/src/main/scala/slamdata/engine/config/config.scala
@@ -113,11 +113,11 @@ object Config {
   def defaultPathForOS(os: OS): Task[FsPath[File, Sandboxed]] = {
     def localAppData: OptionT[Task, FsPath.Aux[Abs, Dir, Sandboxed]] =
       OptionT(Task.delay(envOrNone("LOCALAPPDATA")))
-        .flatMap(s => OptionT(parseWinAbsDir(s).point[Task]))
+        .flatMap(s => OptionT(parseWinAbsAsDir(s).point[Task]))
 
     def homeDir: OptionT[Task, FsPath.Aux[Abs, Dir, Sandboxed]] =
       OptionT(Task.delay(propOrNone("user.home")))
-        .flatMap(s => OptionT(parseAbsDir(os, s).point[Task]))
+        .flatMap(s => OptionT(parseAbsAsDir(os, s).point[Task]))
 
     val filePath: RelFile[Sandboxed] = os.fold(
       currentDir,

--- a/core/src/test/scala/slamdata/engine/config/config.scala
+++ b/core/src/test/scala/slamdata/engine/config/config.scala
@@ -119,7 +119,7 @@ class ConfigSpec extends Specification with DisjunctionMatchers {
     val posixp = ".config"
 
     "mac when home dir" in {
-      val p = withProp("user.home", "/home/foo/", Config.defaultPathForOS(OS.mac))
+      val p = withProp("user.home", "/home/foo", Config.defaultPathForOS(OS.mac))
       printPosix(p.run) ==== s"/home/foo/$macp/$comp"
     }
 
@@ -129,6 +129,11 @@ class ConfigSpec extends Specification with DisjunctionMatchers {
     }
 
     "posix when home dir" in {
+      val p = withProp("user.home", "/home/bar", Config.defaultPathForOS(OS.posix))
+      printPosix(p.run) ==== s"/home/bar/$posixp/$comp"
+    }
+
+    "posix when home dir with trailing slash" in {
       val p = withProp("user.home", "/home/bar/", Config.defaultPathForOS(OS.posix))
       printPosix(p.run) ==== s"/home/bar/$posixp/$comp"
     }


### PR DESCRIPTION
Fixes #879.

Requires updated pathy.