### PR TITLE
implement Not in the selector phase

### DIFF
--- a/core/src/main/scala/slamdata/engine/physical/mongodb/bson.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/bson.scala
@@ -60,7 +60,8 @@ object Bson {
       case _: types.MaxKey            => MaxKey
       case x: types.Symbol            => Symbol(x.getSymbol)
       case x: types.BSONTimestamp     => Timestamp(Instant.ofEpochSecond(x.getTime), x.getInc)
-      case x: java.util.regex.Pattern => Regex(x.pattern)
+      case x: java.util.regex.Pattern => Regex(x.pattern, "")
+      case x: org.bson.BsonRegularExpression => Regex(x.getPattern, x.getOptions)
       case x: Array[Byte]             => Binary(x)
       case x: java.util.UUID          =>
         val bos = new java.io.ByteArrayOutputStream
@@ -153,9 +154,9 @@ object Bson {
     def repr = new org.bson.BsonUndefined
     override def toJs = Js.Undefined
   }
-  final case class Regex(value: String) extends Bson {
-    def repr = java.util.regex.Pattern.compile(value)
-    def toJs = Js.New(Js.Call(Js.Ident("RegExp"), List(Js.Str(value))))
+  final case class Regex(value: String, options: String) extends Bson {
+    def repr = new org.bson.BsonRegularExpression(value, options)
+    def toJs = Js.New(Js.Call(Js.Ident("RegExp"), List(Js.Str(value), Js.Str(options))))
   }
   final case class JavaScript(value: Js.Expr) extends Bson {
     def repr = new types.Code(value.pprint(2))

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/expression/package.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/expression/package.scala
@@ -194,8 +194,8 @@ package object expression {
         case o @ Bson.ObjectId(_) => \/-(Conversions.jsObjectId(o))
         case d @ Bson.Date(_)     => \/-(Conversions.jsDate(d))
         // TODO: implement the rest of these (see #449)
-        case Bson.Regex(pattern)  => -\/(UnsupportedJS(bson.toString))
-        case Bson.Symbol(value)   => -\/(UnsupportedJS(bson.toString))
+        case Bson.Regex(_, _)     => -\/(UnsupportedJS(bson.toString))
+        case Bson.Symbol(_)       => -\/(UnsupportedJS(bson.toString))
 
         case _ => -\/(NonRepresentableInJS(bson.toString))
       }

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -420,7 +420,10 @@ object MongoDbPlanner extends Planner[Crystallized] with Conversions {
 
         case (And, _)      => invoke2Nel(Selector.And.apply _)
         case (Or, _)       => invoke2Nel(Selector.Or.apply _)
-          // case (Not, _)      => invoke1(Selector.Not.apply _)
+        case (Not, (_, v) :: Nil) =>
+          v.map { case (sel, loc) =>
+            (sel andThen (s => s.negate)) -> loc.map(there(0, _))
+          }
 
         case (Constantly, const :: _ :: Nil) => const._2
 

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/bson.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/bson.scala
@@ -111,7 +111,7 @@ object BsonGen {
     listOfN(12, arbitrary[Byte]).map(bytes => ObjectId(bytes.toArray)),
     const(Date(Instant.now)),
     const(Timestamp(Instant.now, 0)),
-    const(Regex("a.*")),
+    const(Regex("a.*", "")),
     const(JavaScript(Js.Null)),
     const(JavaScriptScope(Js.Null, Doc(ListMap.empty))),
     resize(5, arbitrary[String]).map(Symbol.apply),

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/findquery.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/findquery.scala
@@ -9,63 +9,100 @@ class FindQuerySpec extends Specification  {
   implicit def toBson(x: Int) = Bson.Int32(x)
   implicit def toField(name: String) = BsonField.Name(name)
 
-  "SelectorExpr" should {
+  "Selector" should {
     import Selector._
 
-    "render simple expr" in {
-      Expr(Lt(10)).bson must_== Bson.Doc(ListMap("$lt" -> 10))
-    }
+    "bson" should {
+      "render simple expr" in {
+        Expr(Lt(10)).bson must_== Bson.Doc(ListMap("$lt" -> 10))
+      }
 
-    "render $not expr" in {
-      NotExpr(Lt(10)).bson must_== Bson.Doc(ListMap("$not" -> Bson.Doc(ListMap("$lt" -> 10))))
-    }
+      "render $not expr" in {
+        NotExpr(Lt(10)).bson must_== Bson.Doc(ListMap("$not" -> Bson.Doc(ListMap("$lt" -> 10))))
+      }
 
-    "render simple selector" in {
-      val sel = Doc(BsonField.Name("foo") -> Gt(10))
+      "render simple selector" in {
+        val sel = Doc(BsonField.Name("foo") -> Gt(10))
 
-      sel.bson must_== Bson.Doc(ListMap("foo" -> Bson.Doc(ListMap("$gt" -> 10))))
-    }
+        sel.bson must_== Bson.Doc(ListMap("foo" -> Bson.Doc(ListMap("$gt" -> 10))))
+      }
 
-    "render simple selector with path" in {
-      val sel = Doc(
-        BsonField.Name("foo") \ BsonField.Index(3) \ BsonField.Name("bar") -> Gt(10)
-      )
-
-      sel.bson must_== Bson.Doc(ListMap("foo.3.bar" -> Bson.Doc(ListMap("$gt" -> 10))))
-    }
-
-    "render flattened $and" in {
-      val cs = And(
-        Doc(BsonField.Name("foo") -> Gt(10)),
-        And(
-          Doc(BsonField.Name("foo") -> Lt(20)),
-          Doc(BsonField.Name("foo") -> Neq(15))
+      "render simple selector with path" in {
+        val sel = Doc(
+          BsonField.Name("foo") \ BsonField.Index(3) \ BsonField.Name("bar") -> Gt(10)
         )
-      )
-      cs.bson must_==
-        Bson.Doc(ListMap("$and" -> Bson.Arr(List(
-          Bson.Doc(ListMap("foo" -> Bson.Doc(ListMap("$gt" -> 10)))),
-          Bson.Doc(ListMap("foo" -> Bson.Doc(ListMap("$lt" -> 20)))),
-          Bson.Doc(ListMap("foo" -> Bson.Doc(ListMap("$ne" -> 15))))
-        ))))
-    }
 
-    "define nested $and and $or" in {
-      val cs =
-        Or(
+        sel.bson must_== Bson.Doc(ListMap("foo.3.bar" -> Bson.Doc(ListMap("$gt" -> 10))))
+      }
+
+      "render flattened $and" in {
+        val cs = And(
+          Doc(BsonField.Name("foo") -> Gt(10)),
           And(
-            Doc(BsonField.Name("foo") -> Gt(10)),
-            Doc(BsonField.Name("foo") -> Lt(20))
-          ),
-          And(
-            Doc(BsonField.Name("bar") -> Gte(1)),
-            Doc(BsonField.Name("bar") -> Lte(5))
+            Doc(BsonField.Name("foo") -> Lt(20)),
+            Doc(BsonField.Name("foo") -> Neq(15))
           )
         )
+        cs.bson must_==
+          Bson.Doc(ListMap("$and" -> Bson.Arr(List(
+            Bson.Doc(ListMap("foo" -> Bson.Doc(ListMap("$gt" -> 10)))),
+            Bson.Doc(ListMap("foo" -> Bson.Doc(ListMap("$lt" -> 20)))),
+            Bson.Doc(ListMap("foo" -> Bson.Doc(ListMap("$ne" -> 15))))
+          ))))
+      }
 
-        1 must_== 1
+      "render not(eq(...))" in {
+        val cond = NotExpr(Eq(10))
+        cond.bson must_== Bson.Doc(ListMap("$ne" -> 10))
+      }
     }
 
-  }
+    "negate" should {
+      "rewrite singleton Doc" in {
+        val sel = Doc(
+          BsonField.Name("x") -> Lt(10),
+          BsonField.Name("y") -> Gt(10))
+        sel.negate must_== Or(
+          Doc(ListMap(("x": BsonField) -> NotExpr(Lt(10)))),
+          Doc(ListMap(("y": BsonField) -> NotExpr(Gt(10)))))
+      }
 
+      "rewrite And" in {
+        val sel =
+          And(
+            Doc(BsonField.Name("x") -> Lt(10)),
+            Doc(BsonField.Name("y") -> Gt(10)))
+        sel.negate must_== Or(
+          Doc(ListMap(("x": BsonField) -> NotExpr(Lt(10)))),
+          Doc(ListMap(("y": BsonField) -> NotExpr(Gt(10)))))
+      }
+
+      "rewrite Doc" in {
+        val sel = Doc(
+          BsonField.Name("x") -> Lt(10),
+          BsonField.Name("y") -> Gt(10))
+        sel.negate must_== Or(
+          Doc(ListMap(("x": BsonField) -> NotExpr(Lt(10)))),
+          Doc(ListMap(("y": BsonField) -> NotExpr(Gt(10)))))
+      }
+    }
+
+    "constructors" should {
+      "define nested $and and $or" in {
+        val cs =
+          Or(
+            And(
+              Doc(BsonField.Name("foo") -> Gt(10)),
+              Doc(BsonField.Name("foo") -> Lt(20))
+            ),
+            And(
+              Doc(BsonField.Name("bar") -> Gte(1)),
+              Doc(BsonField.Name("bar") -> Lte(5))
+            )
+          )
+
+        1 must_== 1
+      }
+    }
+  }
 }

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -510,7 +510,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
     }
 
     "plan filter with 'is not null'" in {
-      plan("select * from zips where not city is not null") must
+      plan("select * from zips where city is not null") must
         beWorkflow(chain(
           $read(Collection("db", "zips")),
           $match(

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -509,6 +509,15 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               BsonField.Name("pop") -> Selector.NotExpr(Selector.Eq(Bson.Int64(0))))))))
     }
 
+    "plan filter with 'is not null'" in {
+      plan("select * from zips where not city is not null") must
+        beWorkflow(chain(
+          $read(Collection("db", "zips")),
+          $match(
+            Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
+              BsonField.Name("city") -> Selector.NotExpr(Selector.Eq(Bson.Null)))))))
+    }
+
     "plan filter with both index and field projections" in {
       plan("select count(parents[0].sha) as count from slamengine_commits where parents[0].sha = '56d1caf5d082d1a6840090986e277d36d03f1859'") must
         beWorkflow(chain(

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -488,6 +488,27 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
                  Selector.Eq(Bson.Text("zebra"))))))))
     }
 
+    "plan filter with not" in {
+      plan("select * from zips where not (pop > 0 and pop < 1000)") must
+       beWorkflow(chain(
+         $read(Collection("db", "zips")),
+         $match(
+           Selector.Or(
+             Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
+               BsonField.Name("pop") -> Selector.NotExpr(Selector.Gt(Bson.Int64(0))))),
+             Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
+               BsonField.Name("pop") -> Selector.NotExpr(Selector.Lt(Bson.Int64(1000)))))))))
+    }
+
+    "plan filter with not and equality" in {
+      plan("select * from zips where not (pop = 0)") must
+        beWorkflow(chain(
+          $read(Collection("db", "zips")),
+          $match(
+            Selector.Doc(ListMap[BsonField, Selector.SelectorExpr](
+              BsonField.Name("pop") -> Selector.NotExpr(Selector.Eq(Bson.Int64(0))))))))
+    }
+
     "plan filter with both index and field projections" in {
       plan("select count(parents[0].sha) as count from slamengine_commits where parents[0].sha = '56d1caf5d082d1a6840090986e277d36d03f1859'") must
         beWorkflow(chain(

--- a/it/src/test/resources/tests/filterWithComplexNot.test
+++ b/it/src/test/resources/tests/filterWithComplexNot.test
@@ -1,0 +1,12 @@
+{
+  "name": "filter with complex query involving not",
+
+  "query": "select _id as zip from zips
+    where not (city not like 'BOULD%' or state != 'CO' or (pop between 20000 and 40000 and loc[1] != 40.017235))",
+
+  "predicate": "containsExactly",
+  "expected": [
+    { "zip": "80301" },
+    { "zip": "80302" }
+  ]
+}

--- a/it/src/test/resources/tests/filterWithNot.test
+++ b/it/src/test/resources/tests/filterWithNot.test
@@ -1,0 +1,10 @@
+{
+  "name": "filter with negated regex selector",
+
+  "query": "select city, state from zips where city not like 'BOULD%' and pop = 18174",
+
+  "predicate": "containsExactly",
+  "expected": [
+    { "city": "ESCONDIDO", "state": "CA" }
+  ]
+}


### PR DESCRIPTION
Fixes #418.

Add `negate` method on Selector with unit tests.

Also rewrite `not(eq(...))` as `$ne`, because `$eq` isn't a thing and `$not`
requires an operator, and switch to the 3.0 driver's new BsonRegularExpression
wrapper, since `$not: { $regex: "..."}` isn't allowed.