### PR TITLE
Put Expression on the right of various disjunctions.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val standardSettings = Defaults.defaultSettings ++ Seq(
   headers := Map(
     "scala" -> Apache2_0("2014 - 2015", "SlamData Inc."),
     "java"  -> Apache2_0("2014 - 2015", "SlamData Inc.")),
-  scalaVersion := "2.11.6",
+  scalaVersion := "2.11.7",
   logBuffered in Compile := false,
   logBuffered in Test := false,
   outputStrategy := Some(StdoutOutput),

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -39,14 +39,14 @@ object WorkflowBuilder {
   type WorkflowBuilder = Fix[WorkflowBuilderF]
   type Schema = Option[List[String]]
 
-  type Expr = Expression \/ JsFn
-  private def exprToJs(expr: Expr) = expr.fold(toJs, \/-(_))
+  type Expr = JsFn \/ Expression
+  private def exprToJs(expr: Expr) = expr.fold(\/-(_), toJs)
   implicit val ExprRenderTree = new RenderTree[Expr] {
-      def render(x: Expr) =
-        x.fold(
-          op => Terminal(List("ExprOp"), Some(op.toString)),
-          _.render)
-    }
+    def render(x: Expr) =
+      x.fold(
+        _.render,
+        op => Terminal(List("ExprOp"), Some(op.toString)))
+  }
 
   final case class CollectionBuilderF(
     graph: Workflow,
@@ -134,7 +134,7 @@ object WorkflowBuilder {
   }
   import Contents._
 
-  type GroupValue[A] = A \/ AccumOp[A]
+  type GroupValue[A] = AccumOp[A] \/ A
   type GroupContents = DocContents[GroupValue[Expression]]
 
   final case class GroupId(srcs: List[WorkflowBuilder]) {
@@ -283,16 +283,30 @@ object WorkflowBuilder {
       def rewriteExpr(t: Expression)(applyExpr: PartialFunction[ExprOp[Expr], Option[Expr]]): Option[Expr] =
         t.cataM[Option, Expr] { x =>
           applyExpr.lift(x).getOrElse {
-            x.map(_.swap).sequenceU.fold(
-              _ => for {
-                op <- x.map(_.fold(toJs(_).toOption, Some(_))).sequence
+            x.sequenceU.fold(
+              κ(for {
+                op <- x.map(exprToJs(_).toOption).sequence
                 js <- toJsSimpleƒ(op).toOption
-              } yield \/-(js),
-              op => Some(-\/(Fix(op))))
+              } yield -\/(js)),
+              op => Some(\/-(Fix(op))))
           }
         }
 
       outer.fold(
+        js =>
+          for {
+            xs <- inner.map { case (n, x) =>
+                    jscore.Select(jscore.Ident(js.base), n.value) -> x.fold(
+                      \/-(_),
+                      toJs)
+                  }.sequenceU.toOption
+            expr1 <- js.expr.topDownTransformM {
+                    case t @ jscore.Access(b, _) if b == jscore.Ident(js.base) =>
+                      xs.get(t).map(_(jscore.Ident(js.base)))
+                    case t =>
+                      Some(t)
+                  }
+          } yield -\/(JsFn(js.base, expr1)),
         expr =>
           rewriteExpr(expr) {
               case $varF(DocVar(_, Some(f))) =>
@@ -301,27 +315,13 @@ object WorkflowBuilder {
                 case ls =>
                   ls.head match {
                     case n @ BsonField.Name(_) => inner.get(n).flatMap {
-                      case -\/($var(DocVar(b, None))) => BsonField(ls.tail).map(f => -\/($var(DocVar(b, Some(f)))))
+                      case \/-($var(DocVar(b, None))) => BsonField(ls.tail).map(f => \/-($var(DocVar(b, Some(f)))))
                       case _ => None
                     }
                     case _ => None
                   }
               }
-            },
-        js =>
-          for {
-            xs <- inner.map { case (n, x) =>
-                    jscore.Select(jscore.Ident(js.base), n.value) -> x.fold(
-                      toJs,
-                      \/-(_))
-                  }.sequenceU.toOption
-            expr1 <- js.expr.topDownTransformM {
-                    case t @ jscore.Access(b, _) if b == jscore.Ident(js.base) =>
-                      xs.get(t).map(_(jscore.Ident(js.base)))
-                    case t =>
-                      Some(t)
-                  }
-          } yield \/-(JsFn(js.base, expr1)))
+            })
     }
 
     def loop(w: WorkflowBuilder): Option[WorkflowBuilder] = (w.unFix match {
@@ -336,13 +336,14 @@ object WorkflowBuilder {
   private def rewriteObjRefs(
     obj: ListMap[BsonField.Name, GroupValue[Expression]])(
     f: PartialFunction[DocVar, DocVar]) =
-    obj ∘ (_.bimap(rewriteExprRefs(_)(f), accumulator.rewriteGroupRefs(_)(f)))
+    obj ∘ (_.bimap(accumulator.rewriteGroupRefs(_)(f), rewriteExprRefs(_)(f)))
 
   private def rewriteGroupRefs(
     contents: GroupContents)(
     f: PartialFunction[DocVar, DocVar]) =
     contents match {
-      case Expr(expr) => Expr(expr.bimap(rewriteExprRefs(_)(f), accumulator.rewriteGroupRefs(_)(f)))
+      case Expr(expr) =>
+        Expr(expr.bimap(accumulator.rewriteGroupRefs(_)(f), rewriteExprRefs(_)(f)))
       case Doc(doc)   => Doc(rewriteObjRefs(doc)(f))
     }
 
@@ -350,7 +351,7 @@ object WorkflowBuilder {
     doc ∘ (rewriteExprPrefix(_, base))
 
   private def rewriteExprPrefix(expr: Expr, base: DocVar): Expr =
-    expr.bimap(rewriteExprRefs(_)(prefixBase(base)), base.toJs >>> _)
+    expr.bimap(base.toJs >>> _, rewriteExprRefs(_)(prefixBase(base)))
 
   type EitherE[X] = PlannerError \/ X
   type M[X] = StateT[EitherE, NameGen, X]
@@ -368,9 +369,11 @@ object WorkflowBuilder {
   def swapM[A](v: State[NameGen, PlannerError \/ A]): M[A] =
     StateT[EitherE, NameGen, A](s => { val (s1, x) = v.run(s); x.map(s1 -> _) })
 
-  def commonMap[K, A, B](m: ListMap[K, A \/ B])(f: A => PlannerError \/ B): PlannerError \/ (ListMap[K, A] \/ ListMap[K, B]) = {
-    val allAs = (m ∘ (_.swap.toOption)).sequenceU
-    allAs.map(l => \/-(-\/(l))).getOrElse((m ∘ (_.fold(f, \/.right))).sequenceU.map(\/.right))
+  def commonMap[K, A, B](m: ListMap[K, A \/ B])(f: B => PlannerError \/ A):
+      PlannerError \/ (ListMap[K, A] \/ ListMap[K, B]) = {
+    m.sequenceU.fold(
+      κ((m ∘ (_.fold(\/.right, f))).sequenceU.map(\/.left)),
+      l => \/-(\/-(l)))
   }
 
   private def commonShape(shape: ListMap[BsonField.Name, Expr]) =
@@ -392,7 +395,7 @@ object WorkflowBuilder {
               op.lift(_).fold(
                 fail[CollectionBuilderF](UnsupportedFunction(set.Filter, "failed to build operation")))(
                 op =>
-                (toCollectionBuilder(src) |@| toCollectionBuilder(DocBuilder(input, ListMap(name -> -\/($$ROOT))))) {
+                (toCollectionBuilder(src) |@| toCollectionBuilder(DocBuilder(input, ListMap(name -> \/-($$ROOT))))) {
                   case (
                     CollectionBuilderF(_, _, srcStruct),
                     CollectionBuilderF(graph, _, _)) =>
@@ -433,7 +436,7 @@ object WorkflowBuilder {
                 case2(src, input1, base, op, _))
             }
           })
-      case ExprBuilderF(src, -\/($var(d))) =>
+      case ExprBuilderF(src, \/-($var(d))) =>
         toCollectionBuilder(src).map {
           case CollectionBuilderF(graph, base, _) =>
             CollectionBuilderF(graph, base \\ d, None)
@@ -446,8 +449,8 @@ object WorkflowBuilder {
           CollectionBuilderF(
             chain(graph,
               rewriteExprPrefix(expr, base).fold(
-                op => $project(Reshape(ListMap(name -> -\/(op)))),
-                js => $simpleMap(NonEmptyList(MapExpr(JsFn(jsBase, jscore.Obj(ListMap(jscore.Name(name.asText) -> js(jscore.Ident(jsBase))))))), ListMap()))),
+                js => $simpleMap(NonEmptyList(MapExpr(JsFn(jsBase, jscore.Obj(ListMap(jscore.Name(name.asText) -> js(jscore.Ident(jsBase))))))), ListMap()),
+                op => $project(Reshape(ListMap(name -> \/-(op)))))),
             DocField(name),
             None)
       }
@@ -458,19 +461,19 @@ object WorkflowBuilder {
             s => emit(CollectionBuilderF(
               chain(wf,
                 s.fold(
-                  exprOps => $project(Reshape(exprOps ∘ \/.left)),
                   jsExprs => $simpleMap(NonEmptyList(
                     MapExpr(JsFn(jsBase,
                       jscore.Obj(jsExprs.map {
                         case (name, expr) => jscore.Name(name.asText) -> expr(jscore.Ident(jsBase))
                       })))),
-                    ListMap()))),
+                    ListMap()),
+                  exprOps => $project(Reshape(exprOps ∘ \/.right)))),
               DocVar.ROOT(),
               Some(shape.toList.map(_._1.asText)))))
         }
       case ArrayBuilderF(src, shape) =>
         workflow(src).flatMap { case (wf, base) =>
-          lift(shape.map(_.fold(toJs, \/-(_))).sequenceU.map(jsExprs =>
+          lift(shape.map(exprToJs).sequenceU.map(jsExprs =>
             CollectionBuilderF(
               chain(wf,
                 $simpleMap(NonEmptyList(
@@ -483,25 +486,21 @@ object WorkflowBuilder {
       case GroupBuilderF(src, keys, content, _) =>
         foldBuilders(src, keys).flatMap { case (wb, base, fields) =>
           def key(base: DocVar) = keys.zip(fields) match {
-            case Nil        => -\/($literal(Bson.Null))
-            case (key, field) :: Nil => -\/(key.unFix match {
+            case Nil        => \/-($literal(Bson.Null))
+            case (key, field) :: Nil => \/-(key.unFix match {
               // NB: normalize to Null, to ease merging
-              case ValueBuilderF(_)                       => $literal(Bson.Null)
-              case ExprBuilderF(_, -\/($literal(_))) => $literal(Bson.Null)
+              case ValueBuilderF(_)                  => $literal(Bson.Null)
+              case ExprBuilderF(_, \/-($literal(_))) => $literal(Bson.Null)
               case _ => rewriteExprRefs($var(field))(prefixBase(base))
             })
-            case _          => \/-(Reshape(fields.zipWithIndex.map {
+            case _          => -\/(Reshape(fields.zipWithIndex.map {
               case (field, index) =>
-                BsonField.Index(index).toName -> -\/($var(field))
+                BsonField.Index(index).toName -> \/-($var(field))
             }.toListMap).rewriteRefs(prefixBase(base)))
           }
 
           content match {
-            case Expr(-\/(expr)) =>
-              // NB: This case just winds up a single value, then unwinds it.
-              //     It’s effectively a no-op, so we just use the src and expr.
-              toCollectionBuilder(ExprBuilder(src, -\/(expr)))
-            case Expr(\/-(grouped)) =>
+            case Expr(-\/(grouped)) =>
               for {
                 cb <- toCollectionBuilder(wb)
                 rootName <- emitSt(freshName)
@@ -514,14 +513,18 @@ object WorkflowBuilder {
                     DocField(rootName),
                     struct)
               }
+            case Expr(\/-(expr)) =>
+              // NB: This case just winds up a single value, then unwinds it.
+              //     It’s effectively a no-op, so we just use the src and expr.
+              toCollectionBuilder(ExprBuilder(src, \/-(expr)))
             case Doc(obj) =>
-              val (ungrouped, grouped) =
-                obj.foldLeft[(ListMap[BsonField.Name, Expression], ListMap[BsonField.Leaf, Accumulator])]((ListMap.empty[BsonField.Name, Expression], ListMap.empty[BsonField.Leaf, Accumulator]))((acc, item) =>
+              val (grouped, ungrouped) =
+                obj.foldLeft[(ListMap[BsonField.Leaf, Accumulator], ListMap[BsonField.Name, Expression])]((ListMap.empty[BsonField.Leaf, Accumulator], ListMap.empty[BsonField.Name, Expression]))((acc, item) =>
                   item match {
                     case (k, -\/(v)) =>
-                      ((x: ListMap[BsonField.Name, Expression]) => x + (k -> v)).first(acc)
+                      ((x: ListMap[BsonField.Leaf, Accumulator]) => x + (k -> v)).first(acc)
                     case (k, \/-(v)) =>
-                      ((x: ListMap[BsonField.Leaf, Accumulator]) => x + (k -> v)).second(acc)
+                      ((x: ListMap[BsonField.Name, Expression]) => x + (k -> v)).second(acc)
                   })
 
               workflow(wb).flatMap { case (wf, base0) =>
@@ -533,8 +536,10 @@ object WorkflowBuilder {
                     state[NameGen, Workflow](chain(wf,
                       $group(Grouped(
                         obj.transform {
-                          case (_, -\/ (v)) => $push(rewriteExprRefs(v)(prefixBase(base0 \\ base)))
-                          case (_,  \/-(v)) => accumulator.rewriteGroupRefs(v)(prefixBase(base0 \\ base))
+                          case (_, -\/(v)) =>
+                            accumulator.rewriteGroupRefs(v)(prefixBase(base0 \\ base))
+                          case (_, \/-(v)) =>
+                            $push(rewriteExprRefs(v)(prefixBase(base0 \\ base)))
                         }),
                         key(base0)),
                       $unwind(DocField(ungrouped.head._1))))
@@ -544,18 +549,18 @@ object WorkflowBuilder {
                   } yield
                     chain(wf,
                       $project(Reshape(ListMap(
-                        ungroupedName -> \/-(Reshape(ungrouped.map {
-                          case (k, v) => k -> -\/(rewriteExprRefs(v)(prefixBase(base0 \\ base)))
+                        ungroupedName -> -\/(Reshape(ungrouped.map {
+                          case (k, v) => k -> \/-(rewriteExprRefs(v)(prefixBase(base0 \\ base)))
                         })),
-                        groupedName -> -\/($$ROOT)))),
+                        groupedName -> \/-($$ROOT)))),
                       $group(Grouped(
                         (grouped ∘ (accumulator.rewriteGroupRefs(_)(prefixBase(DocField(groupedName) \\ base0)))) +
                           (ungroupedName -> $push($var(DocField(ungroupedName))))),
                         key(DocField(groupedName) \\ base0)),
                       $unwind(DocField(ungroupedName)),
                       $project(Reshape(obj.transform {
-                        case (k, -\/(_)) => -\/($var(DocField(ungroupedName \ k)))
-                        case (k, \/-(_)) => -\/($var(DocField(k)))
+                        case (k, -\/ (_)) => \/-($var(DocField(k)))
+                        case (k,  \/-(_)) => \/-($var(DocField(ungroupedName \ k)))
                       })))
                 }).map(CollectionBuilderF(
                   _,
@@ -606,14 +611,14 @@ object WorkflowBuilder {
       case (ExprVar, None)         => (graph, ExprVar)
       case (_,       None)         =>
         (chain(graph,
-          Workflow.$project(Reshape(ListMap(ExprName -> -\/($var(base)))),
+          Workflow.$project(Reshape(ListMap(ExprName -> \/-($var(base)))),
             ExcludeId)),
         ExprVar)
       case (_,       Some(fields)) =>
         (chain(graph,
           Workflow.$project(Reshape(fields.map(name =>
             BsonField.Name(name) ->
-              -\/($var(base \ BsonField.Name(name)))).toListMap),
+              \/-($var(base \ BsonField.Name(name)))).toListMap),
             if (fields.exists(_ == IdLabel)) IncludeId else ExcludeId)),
         DocVar.ROOT())
     }
@@ -632,7 +637,7 @@ object WorkflowBuilder {
 
   def asLiteral(wb: WorkflowBuilder): Option[Bson] = wb.unFix match {
     case ValueBuilderF(value)                  => Some(value)
-    case ExprBuilderF(_, -\/($literal(value))) => Some(value)
+    case ExprBuilderF(_, \/-($literal(value))) => Some(value)
     case _                                     => None
   }
 
@@ -671,17 +676,17 @@ object WorkflowBuilder {
     ShapePreservingBuilder(src, those, PartialFunction(fields => $match(sel(fields))))
 
 
-  def inlineExprs[R](contents: DocContents[Expression \/ R], expr: Expression): Option[Expression] =
+  def inlineExprs(contents: DocContents[_ \/ Expression], expr: Expression): Option[Expression] =
     contents match {
-      case Expr(-\/($var(dv))) =>
+      case Expr(\/-($var(dv))) =>
         Some(rewriteExprRefs(expr)(prefixBase(dv)))
-      case Expr(-\/(ex)) => Some(expr.cata[Expression] {
+      case Expr(\/-(ex)) => Some(expr.cata[Expression] {
         case $varF(DocVar.ROOT(None)) => ex
         case x                     => Fix(x)
       })
       case Doc(map) => expr.cataM[Option, Expression] {
         case $varF(DocField(field @ BsonField.Name(_))) =>
-          map.get(field).flatMap(_.fold(Some(_), κ(None)))
+          map.get(field).flatMap(_.toOption)
         case x => Some(Fix(x))
       }
       case _ => None
@@ -699,27 +704,27 @@ object WorkflowBuilder {
 
   private def coalesceSource(src: WorkflowBuilder, expr: Expression):
       WorkflowBuilder = {
-    lazy val default = ExprBuilder(src, -\/(expr))
-    def inln[R](cont: DocContents[Expression \/ R])(f: Expression => WorkflowBuilder) =
+    lazy val default = ExprBuilder(src, \/-(expr))
+    def inln(cont: DocContents[_ \/ Expression])(f: Expression => WorkflowBuilder) =
       inlineExprs(cont, expr).fold(default)(f)
 
     src.unFix match {
-      case ExprBuilderF(wb0, \/-(js1)) =>
-        toJs(expr).fold(κ(default), js => ExprBuilder(wb0, \/-(js1 >>> js)))
+      case ExprBuilderF(wb0, -\/(js1)) =>
+        toJs(expr).fold(κ(default), js => ExprBuilder(wb0, -\/(js1 >>> js)))
       case ExprBuilderF(src0, contents) =>
-        inln(Expr(contents))(expr => ExprBuilder(src0, -\/(expr)))
+        inln(Expr(contents))(expr => ExprBuilder(src0, \/-(expr)))
       case DocBuilderF(src0, contents) =>
-        inln(Doc(contents))(expr => ExprBuilder(src0, -\/(expr)))
+        inln(Doc(contents))(expr => ExprBuilder(src0, \/-(expr)))
       case ShapePreservingBuilderF(src0, inputs, op) =>
         ShapePreservingBuilder(coalesceSource(src0, expr), inputs, op)
-      case GroupBuilderF(wb0, key, Expr(-\/($var(DocVar.ROOT(None)))), id) =>
+      case GroupBuilderF(wb0, key, Expr(\/-($var(DocVar.ROOT(None)))), id) =>
         GroupBuilder(
           coalesceSource(wb0, expr),
           key,
-          Expr(-\/($$ROOT)),
+          Expr(\/-($$ROOT)),
           id)
       case GroupBuilderF(wb0, key, contents, id) =>
-        inln(contents)(expr => GroupBuilder(wb0, key, Expr(-\/(expr)), id))
+        inln(contents)(expr => GroupBuilder(wb0, key, Expr(\/-(expr)), id))
       case _ => default
     }
   }
@@ -737,15 +742,15 @@ object WorkflowBuilder {
     wb.unFix match {
       case ShapePreservingBuilderF(src, inputs, op) =>
         jsExpr1(src, js).map(ShapePreservingBuilder(_, inputs, op))
-      case ExprBuilderF(wb1, -\/ (expr1)) =>
-        toJs(expr1).map(js1 => ExprBuilder(wb1, \/-(js1 >>> js)))
-      case ExprBuilderF(wb1,  \/-(js1)) =>
-        \/-(ExprBuilder(wb1, \/-(js1 >>> js)))
-      case GroupBuilderF(wb0, key, Expr(-\/(expr)), id) =>
+      case ExprBuilderF(wb1, \/-(expr1)) =>
+        toJs(expr1).map(js1 => ExprBuilder(wb1, -\/(js1 >>> js)))
+      case ExprBuilderF(wb1, -\/(js1)) =>
+        \/-(ExprBuilder(wb1, -\/(js1 >>> js)))
+      case GroupBuilderF(wb0, key, Expr(\/-(expr)), id) =>
         toJs(expr).flatMap(
           ex => jsExpr1(wb0, JsFn(jsBase, ex(js(jscore.Ident(jsBase))))).map(
-            GroupBuilder(_, key, Expr(-\/($$ROOT)), id)))
-      case _ => \/-(ExprBuilder(wb, \/-(js)))
+            GroupBuilder(_, key, Expr(\/-($$ROOT)), id)))
+      case _ => \/-(ExprBuilder(wb, -\/(js)))
     }
 
   object HasLiteral {
@@ -772,7 +777,7 @@ object WorkflowBuilder {
         lift(jsExpr1(wb2, JsFn(jsBase, js(lit, jscore.Ident(jsBase)))))
       case _ =>
         merge(wb1, wb2).map { case (lbase, rbase, src) =>
-          ExprBuilder(src, \/-(JsFn(jsBase, js(lbase.toJs(jscore.Ident(jsBase)), rbase.toJs(jscore.Ident(jsBase))))))
+          ExprBuilder(src, -\/(JsFn(jsBase, js(lbase.toJs(jscore.Ident(jsBase)), rbase.toJs(jscore.Ident(jsBase))))))
         }
     }
 
@@ -787,12 +792,12 @@ object WorkflowBuilder {
       case ShapePreservingBuilderF(src, inputs, op) =>
         ShapePreservingBuilder(makeObject(src, name), inputs, op)
       case _ =>
-        DocBuilder(wb, ListMap(BsonField.Name(name) -> -\/($$ROOT)))
+        DocBuilder(wb, ListMap(BsonField.Name(name) -> \/-($$ROOT)))
     }
 
   def makeArray(wb: WorkflowBuilder): WorkflowBuilder = wb.unFix match {
     case ValueBuilderF(value) => ValueBuilder(Bson.Arr(List(value)))
-    case _ => ArrayBuilder(wb, List(-\/($$ROOT)))
+    case _ => ArrayBuilder(wb, List(\/-($$ROOT)))
   }
 
   def mergeContents[A](c1: DocContents[A], c2: DocContents[A]):
@@ -871,7 +876,7 @@ object WorkflowBuilder {
             Fix(ShapePreservingBuilderF(_, inputs2, op2)),
             Nil, _, id2))
           if inputs1 == inputs2 && op1 == op2 =>
-          impl(GroupBuilder(wb1, Nil, Doc(shape1.keys.toList.map(n => n -> -\/($var(DocField(n)))).toListMap), id2), wb2, combine)
+          impl(GroupBuilder(wb1, Nil, Doc(shape1.keys.toList.map(n => n -> \/-($var(DocField(n)))).toListMap), id2), wb2, combine)
         case (
           GroupBuilderF(
           Fix(ShapePreservingBuilderF(_, inputs1, op1)),
@@ -888,7 +893,7 @@ object WorkflowBuilder {
               Nil, _, id2)),
            shape2))
           if inputs1 == inputs2 && op1 == op2 =>
-          impl(GroupBuilder(wb1, Nil, Doc(shape1.keys.toList.map(n => n -> -\/($var(DocField(n)))).toListMap), id2), wb2, combine)
+          impl(GroupBuilder(wb1, Nil, Doc(shape1.keys.toList.map(n => n -> \/-($var(DocField(n)))).toListMap), id2), wb2, combine)
         case (
           DocBuilderF(
             Fix(GroupBuilderF(
@@ -908,22 +913,22 @@ object WorkflowBuilder {
         case (ValueBuilderF(Bson.Doc(map1)), DocBuilderF(s2, shape2)) =>
           emit(DocBuilder(s2,
             combine(
-              map1.map { case (k, v) => BsonField.Name(k) -> -\/($literal(v)) },
+              map1.map { case (k, v) => BsonField.Name(k) -> \/-($literal(v)) },
               shape2)(_ ++ _)))
         case (DocBuilderF(_, _), ValueBuilderF(Bson.Doc(_))) => delegate
 
         case (ValueBuilderF(Bson.Doc(map1)), GroupBuilderF(s1, k1, Doc(c2), id2)) =>
           val content = combine(
-            map1.map { case (k, v) => BsonField.Name(k) -> -\/($literal(v)) },
+            map1.map { case (k, v) => BsonField.Name(k) -> \/-($literal(v)) },
             c2)(_ ++ _)
           emit(GroupBuilder(s1, k1, Doc(content), id2))
         case (GroupBuilderF(_, _, Doc(_), _), ValueBuilderF(_)) => delegate
 
         case (
-          GroupBuilderF(src1, keys, Expr(-\/($var(DocVar.ROOT(_)))), id1),
-          GroupBuilderF(src2, _,    Expr(-\/($var(DocVar.ROOT(_)))), id2))
+          GroupBuilderF(src1, keys, Expr(\/-($var(DocVar.ROOT(_)))), id1),
+          GroupBuilderF(src2, _,    Expr(\/-($var(DocVar.ROOT(_)))), id2))
             if id1 == id2 =>
-          impl(src1, src2, combine).map(GroupBuilder(_, keys, Expr(-\/($$ROOT)), id1))
+          impl(src1, src2, combine).map(GroupBuilder(_, keys, Expr(\/-($$ROOT)), id1))
 
         case (
           GroupBuilderF(s1, keys, c1 @ Doc(_), id1),
@@ -937,7 +942,7 @@ object WorkflowBuilder {
             if id1 == id2 =>
           mergeGroups(s1, s2, c1, c2, keys, id1).map { case ((glbase, grbase), g) =>
             DocBuilder(g, combine(
-              d1.transform { case (n, _) => -\/($var(DocField(n))) },
+              d1.transform { case (n, _) => \/-($var(DocField(n))) },
               (shape2 ∘ (rewriteExprPrefix(_, grbase))))(_ ++ _))
           }
         case (
@@ -961,7 +966,7 @@ object WorkflowBuilder {
           DocBuilderF(_, shape),
           GroupBuilderF(_, Nil, _, id2)) =>
           impl(
-            GroupBuilder(wb1, Nil, Doc(shape.map { case (n, _) => n -> -\/($var(DocField(n))) }), id2),
+            GroupBuilder(wb1, Nil, Doc(shape.map { case (n, _) => n -> \/-($var(DocField(n))) }), id2),
             wb2,
             combine)
         case (
@@ -973,7 +978,7 @@ object WorkflowBuilder {
           DocBuilderF(_, shape),
           DocBuilderF(Fix(GroupBuilderF(_, Nil, _, id2)), _)) =>
           impl(
-            GroupBuilder(wb1, Nil, Doc(shape.map { case (n, _) => n -> -\/($var(DocField(n))) }), id2),
+            GroupBuilder(wb1, Nil, Doc(shape.map { case (n, _) => n -> \/-($var(DocField(n))) }), id2),
             wb2,
             combine)
         case (
@@ -1011,11 +1016,19 @@ object WorkflowBuilder {
           }
         case (DocBuilderF(_, _), SpliceBuilderF(_, _)) => delegate
 
+        case (SpliceBuilderF(src1, structure1), ExprBuilderF(src2, expr2)) =>
+          merge(src1, src2).map { case (left, right, list) =>
+            SpliceBuilder(list, combine(
+              structure1,
+              List(Expr(rewriteExprPrefix(expr2, right))))(_ ++ _))
+          }
+        case (ExprBuilderF(_, _), SpliceBuilderF(_, _)) => delegate
+
         case (SpliceBuilderF(src1, structure1), CollectionBuilderF(_, _, _)) =>
           merge(src1, wb2).map { case (left, right, list) =>
             SpliceBuilder(list, combine(
               structure1,
-              List(Expr(-\/($var(right)))))(_ ++ _))
+              List(Expr(\/-($var(right)))))(_ ++ _))
           }
         case (CollectionBuilderF(_, _, _), SpliceBuilderF(_, _)) => delegate
 
@@ -1023,7 +1036,7 @@ object WorkflowBuilder {
           merge(src, wb2).map { case (left, right, list) =>
             SpliceBuilder(list, combine(
               Doc(rewriteDocPrefix(shape, left)),
-              Expr(-\/($var(right))))(List(_, _)))
+              Expr(\/-($var(right))))(List(_, _)))
           }
         case (CollectionBuilderF(_, _, _), DocBuilderF(_, _)) => delegate
 
@@ -1036,7 +1049,7 @@ object WorkflowBuilder {
             DocBuilder(src,
               combine(
                 rewriteDocPrefix(shape1, lbase),
-                c2.map { case (n, _) => (n, rewriteExprPrefix(-\/($var(DocField(n))), rbase)) })(_ ++ _))
+                c2.map { case (n, _) => (n, rewriteExprPrefix(\/-($var(DocField(n))), rbase)) })(_ ++ _))
           }
         case (GroupBuilderF(_, _, _, _), DocBuilderF(Fix(ArraySpliceBuilderF(_, _)), _)) => delegate
 
@@ -1061,7 +1074,7 @@ object WorkflowBuilder {
 
         case (ValueBuilderF(Bson.Arr(seq)), ArrayBuilderF(src, shape)) =>
           emit(ArrayBuilder(src,
-            combine(seq.map(x => -\/($literal(x))), shape)(_ ++ _)))
+            combine(seq.map(x => \/-($literal(x))), shape)(_ ++ _)))
         case (ArrayBuilderF(_, _), ValueBuilderF(Bson.Arr(_))) => delegate
 
         case (
@@ -1073,7 +1086,7 @@ object WorkflowBuilder {
             ShapePreservingBuilder(
               ArraySpliceBuilder(wb, combine(
                 Array(shape1.map(rewriteExprPrefix(_, lbase))),
-                Expr(-\/($var(rbase))))(List(_, _))),
+                Expr(\/-($var(rbase))))(List(_, _))),
               inputs1, op1)
           }
         case (ShapePreservingBuilderF(_, in1, op1), ArrayBuilderF(Fix(ShapePreservingBuilderF(_, in2, op2)), _)) => delegate
@@ -1086,12 +1099,12 @@ object WorkflowBuilder {
               Nil, cont2, id2)),
               shape2)) if inputs1 == inputs2 && op1 == op2 =>
           merge(src1, src2).flatMap { case (lbase, rbase, wb) =>
-            combine(Expr(-\/($var(lbase))), rewriteGroupRefs(cont2)(prefixBase(rbase)))(mergeContents).map { case ((lbase1, rbase1), cont) =>
+            combine(Expr(\/-($var(lbase))), rewriteGroupRefs(cont2)(prefixBase(rbase)))(mergeContents).map { case ((lbase1, rbase1), cont) =>
               ShapePreservingBuilder(
                 ArraySpliceBuilder(
                   GroupBuilder(wb, Nil, cont, id2),
                   combine(
-                    Expr(-\/($var(lbase1))),
+                    Expr(\/-($var(lbase1))),
                     Array(shape2.map(rewriteExprPrefix(_, rbase1))))(List(_, _))),
                 inputs1, op1)
             }
@@ -1125,13 +1138,13 @@ object WorkflowBuilder {
           merge(src1, wb2).map { case (left, right, wb) =>
             ArraySpliceBuilder(wb, combine(
               Array(shape1.map(x => rewriteExprPrefix(x, left))),
-              Expr(-\/($var(right))))(List(_, _)))
+              Expr(\/-($var(right))))(List(_, _)))
           }
         case (GroupBuilderF(_, _, _, _), ArrayBuilderF(_, _)) => delegate
 
         case (ValueBuilderF(Bson.Arr(seq1)), ExprBuilderF(src2, expr2)) =>
           emit(ArraySpliceBuilder(src2, combine(
-            Array(seq1.map(x => -\/($literal(x)))),
+            Array(seq1.map(x => \/-($literal(x)))),
             Expr(expr2))(List(_, _))))
         case (ExprBuilderF(_, _), ValueBuilderF(Bson.Arr(_))) => delegate
 
@@ -1152,7 +1165,7 @@ object WorkflowBuilder {
         case (ExprBuilderF(_, _), ArraySpliceBuilderF(_, _)) => delegate
 
         case (ArraySpliceBuilderF(src1, structure1), ValueBuilderF(bson2)) =>
-          emit(ArraySpliceBuilder(src1, combine(structure1, List(Expr(-\/($literal(bson2)))))(_ ++ _)))
+          emit(ArraySpliceBuilder(src1, combine(structure1, List(Expr(\/-($literal(bson2)))))(_ ++ _)))
         case (ValueBuilderF(_), ArraySpliceBuilderF(_, _)) => delegate
 
         case _ =>
@@ -1168,8 +1181,8 @@ object WorkflowBuilder {
   def flattenObject(wb: WorkflowBuilder): M[WorkflowBuilder] = wb.unFix match {
     case ShapePreservingBuilderF(src, inputs, op) =>
       flattenObject(src).map(ShapePreservingBuilder(_, inputs, op))
-    case GroupBuilderF(src, keys, Expr(-\/($var(DocVar.ROOT(None)))), id) =>
-      flattenObject(src).map(GroupBuilder(_, keys, Expr(-\/($$ROOT)), id))
+    case GroupBuilderF(src, keys, Expr(\/-($var(DocVar.ROOT(None)))), id) =>
+      flattenObject(src).map(GroupBuilder(_, keys, Expr(\/-($$ROOT)), id))
     case _ =>
       expr1(wb)(base =>
         $cond(
@@ -1186,8 +1199,8 @@ object WorkflowBuilder {
   def flattenArray(wb: WorkflowBuilder): M[WorkflowBuilder] = wb.unFix match {
     case ShapePreservingBuilderF(src, inputs, op) =>
       flattenArray(src).map(ShapePreservingBuilder(_, inputs, op))
-    case GroupBuilderF(src, keys, Expr(-\/($var(DocVar.ROOT(None)))), id) =>
-      flattenArray(src).map(GroupBuilder(_, keys, Expr(-\/($$ROOT)), id))
+    case GroupBuilderF(src, keys, Expr(\/-($var(DocVar.ROOT(None)))), id) =>
+      flattenArray(src).map(GroupBuilder(_, keys, Expr(\/-($$ROOT)), id))
     case _ =>
       expr1(wb)(base =>
         $cond(
@@ -1212,11 +1225,11 @@ object WorkflowBuilder {
           x => \/-(ValueBuilder(x)))
       case ValueBuilderF(_) =>
         -\/(UnsupportedFunction(structural.ObjectProject, "value is not a document."))
-      case GroupBuilderF(wb0, key, Expr(-\/($var(DocVar.ROOT(None)))), id) =>
-        projectField(wb0, name).map(GroupBuilder(_, key, Expr(-\/($$ROOT)), id))
-      case GroupBuilderF(wb0, key, Expr(-\/($var(dv))), id) =>
+      case GroupBuilderF(wb0, key, Expr(\/-($var(DocVar.ROOT(None)))), id) =>
+        projectField(wb0, name).map(GroupBuilder(_, key, Expr(\/-($$ROOT)), id))
+      case GroupBuilderF(wb0, key, Expr(\/-($var(dv))), id) =>
         // TODO: check structure of wb0 (#436)
-        \/-(GroupBuilder(wb0, key, Expr(-\/($var(dv \ BsonField.Name(name)))), id))
+        \/-(GroupBuilder(wb0, key, Expr(\/-($var(dv \ BsonField.Name(name)))), id))
       case GroupBuilderF(wb0, key, Doc(doc), id) =>
         doc.get(BsonField.Name(name)).fold[PlannerError \/ WorkflowBuilder](
           -\/(UnsupportedFunction(structural.ObjectProject, "group does not contain a field ‘" + name + "’.")))(
@@ -1225,12 +1238,12 @@ object WorkflowBuilder {
         doc.get(BsonField.Name(name)).fold[PlannerError \/ WorkflowBuilder](
           -\/(UnsupportedFunction(structural.ObjectProject, "document does not contain a field ‘" + name + "’.")))(
           expr => \/-(ExprBuilder(wb, expr)))
-      case ExprBuilderF(wb0,  \/-(js1)) =>
+      case ExprBuilderF(wb0,  -\/(js1)) =>
         \/-(ExprBuilder(wb0,
-          \/-(JsFn(jsBase, DocField(BsonField.Name(name)).toJs(js1(jscore.Ident(jsBase)))))))
-      case ExprBuilderF(wb, -\/($var(DocField(field)))) =>
-        \/-(ExprBuilder(wb, -\/($var(DocField(field \ BsonField.Name(name))))))
-      case _ => \/-(ExprBuilder(wb, -\/($var(DocField(BsonField.Name(name))))))
+          -\/(JsFn(jsBase, DocField(BsonField.Name(name)).toJs(js1(jscore.Ident(jsBase)))))))
+      case ExprBuilderF(wb, \/-($var(DocField(field)))) =>
+        \/-(ExprBuilder(wb, \/-($var(DocField(field \ BsonField.Name(name))))))
+      case _ => \/-(ExprBuilder(wb, \/-($var(DocField(BsonField.Name(name))))))
     }
 
   def projectIndex(wb: WorkflowBuilder, index: Int): PlannerError \/ WorkflowBuilder =
@@ -1273,8 +1286,8 @@ object WorkflowBuilder {
         -\/(UnsupportedFunction(
           structural.DeleteField,
           "value is not a document."))
-      case GroupBuilderF(wb0, key, Expr(-\/($var(DocVar.ROOT(None)))), id) =>
-        deleteField(wb0, name).map(GroupBuilder(_, key, Expr(-\/($$ROOT)), id))
+      case GroupBuilderF(wb0, key, Expr(\/-($var(DocVar.ROOT(None)))), id) =>
+        deleteField(wb0, name).map(GroupBuilder(_, key, Expr(\/-($$ROOT)), id))
       case GroupBuilderF(wb0, key, Doc(doc), id) =>
         \/-(GroupBuilder(wb0, key, Doc(doc - BsonField.Name(name)), id))
       case DocBuilderF(wb0, doc) =>
@@ -1287,13 +1300,13 @@ object WorkflowBuilder {
 
   def groupBy(src: WorkflowBuilder, keys: List[WorkflowBuilder]):
       WorkflowBuilder =
-    GroupBuilder(src, keys, Expr(-\/($$ROOT)), GroupId(src :: keys))
+    GroupBuilder(src, keys, Expr(\/-($$ROOT)), GroupId(src :: keys))
 
   def reduce(wb: WorkflowBuilder)(f: Expression => Accumulator): WorkflowBuilder =
     wb.unFix match {
-      case GroupBuilderF(wb0, keys, Expr(-\/(expr)), id) =>
-        GroupBuilder(wb0, keys, Expr(\/-(f(expr))), id)
-      case ShapePreservingBuilderF(src @ Fix(GroupBuilderF(_, _, Expr(-\/(_)), _)), inputs, op) =>
+      case GroupBuilderF(wb0, keys, Expr(\/-(expr)), id) =>
+        GroupBuilder(wb0, keys, Expr(-\/(f(expr))), id)
+      case ShapePreservingBuilderF(src @ Fix(GroupBuilderF(_, _, Expr(\/-(_)), _)), inputs, op) =>
         ShapePreservingBuilder(reduce(src)(f), inputs, op)
       case _ =>
         // NB: the group must be identified with the source collection, not an
@@ -1305,7 +1318,7 @@ object WorkflowBuilder {
           case ShapePreservingBuilderF(src, _, _) => id(src)
           case _                                  => GroupId(List(wb))
         }
-        GroupBuilder(wb, Nil, Expr(\/-(f($$ROOT))), id(wb))
+        GroupBuilder(wb, Nil, Expr(-\/(f($$ROOT))), id(wb))
     }
 
   def sortBy(
@@ -1363,7 +1376,7 @@ object WorkflowBuilder {
         $var(DocField(side)))
 
     def buildProjection(l: Expression, r: Expression): WorkflowOp =
-      $project(Reshape(ListMap(leftField -> -\/(l), rightField -> -\/(r))))(_)
+      $project(Reshape(ListMap(leftField -> \/-(l), rightField -> \/-(r))))(_)
 
     def buildJoin(src: Workflow, tpe: Func): Workflow =
       tpe match {
@@ -1429,9 +1442,9 @@ object WorkflowBuilder {
     (workflow(DocBuilder(
       reduce(groupBy(left, leftKey))($push(_)),
       ListMap(
-        leftField  -> -\/($$ROOT),
-        rightField -> -\/($literal(Bson.Arr(Nil))),
-        BsonField.Name("_id") -> -\/($include())))) |@|
+        leftField             -> \/-($$ROOT),
+        rightField            -> \/-($literal(Bson.Arr(Nil))),
+        BsonField.Name("_id") -> \/-($include())))) |@|
       workflow(right)) { case ((l, _), (r, _)) =>
         CollectionBuilder(
           chain(
@@ -1498,14 +1511,14 @@ object WorkflowBuilder {
 
     def findKeys(wb: WorkflowBuilder): Option[Reshape.Shape] = {
       def reshape(keys: Iterable[BsonField.Name]): Reshape.Shape =
-        \/-(Reshape(keys.map(_ -> -\/($include())).toList.toListMap))
+        -\/(Reshape(keys.map(_ -> \/-($include())).toList.toListMap))
       wb.unFix match {
         case CollectionBuilderF(_, _, s2)       =>
           s2.map(x => reshape(x.map(BsonField.Name)))
         case DocBuilderF(_, shape)              => Some(reshape(shape.keys))
         case GroupBuilderF(_, _, Doc(obj), _)   => Some(reshape(obj.keys))
         case ShapePreservingBuilderF(src, _, _) => findKeys(src)
-        case ExprBuilderF(_, _)                 => Some(-\/($$ROOT))
+        case ExprBuilderF(_, _)                 => Some(\/-($$ROOT))
         case ValueBuilderF(Bson.Doc(shape))     =>
           Some(reshape(shape.keys.map(BsonField.Name)))
         case _                                  => None
@@ -1531,16 +1544,16 @@ object WorkflowBuilder {
       }
 
       val groupedBy = keys.zip(fields) match {
-        case Nil        => Some(-\/($literal(Bson.Null)))
+        case Nil        => Some(\/-($literal(Bson.Null)))
         case (key, field) :: Nil => field match {
           // If the key is at the document root, we must explicitly
           //  project out the fields so as not to include a meaningless
           // _id in the key:
           case DocVar.ROOT(None) => findKeys(key)
-          case _                     => Some(-\/($var(field)))
+          case _                     => Some(\/-($var(field)))
         }
-        case _          => Some(\/-(Reshape(fields.zipWithIndex.map {
-          case (field, index) => BsonField.Index(index).toName -> -\/($var(field))
+        case _          => Some(-\/(Reshape(fields.zipWithIndex.map {
+          case (field, index) => BsonField.Index(index).toName -> \/-($var(field))
         }.toListMap)))
       }
 
@@ -1555,14 +1568,14 @@ object WorkflowBuilder {
                 ListMap()),
               $group(
                 Grouped(ListMap[BsonField.Leaf, Accumulator](name -> $first($$ROOT) :: keyProjs: _*)),
-                -\/($$ROOT))))(
+                \/-($$ROOT))))(
             gby => chain(
               graph,
               $group(
                 Grouped(ListMap[BsonField.Leaf, Accumulator](name -> $first($var(base \\ value)) :: keyProjs: _*)),
                 gby.bimap(
-                  rewriteExprRefs(_)(prefixBase(base)),
-                  _.rewriteRefs(prefixBase(base)))))),
+                  _.rewriteRefs(prefixBase(base)),
+                  rewriteExprRefs(_)(prefixBase(base)))))),
           DocField(name),
           struct)
 
@@ -1584,15 +1597,15 @@ object WorkflowBuilder {
 
     (left.unFix, right.unFix) match {
       case (
-        ExprBuilderF(src1, -\/($var(base1 @ DocField(_)))),
-        ExprBuilderF(src2, -\/($var(base2 @ DocField(_)))))
+        ExprBuilderF(src1, \/-($var(base1 @ DocField(_)))),
+        ExprBuilderF(src2, \/-($var(base2 @ DocField(_)))))
           if src1 === src2 =>
         emit((base1, base2, src1))
 
       case _ if left === right => emit((DocVar.ROOT(), DocVar.ROOT(), left))
 
       case (ValueBuilderF(bson), ExprBuilderF(src, expr)) =>
-        mergeContents(Expr(-\/($literal(bson))), Expr(expr)).map {
+        mergeContents(Expr(\/-($literal(bson))), Expr(expr)).map {
           case ((lbase, rbase), cont) =>
             (lbase, rbase,
               cont match {
@@ -1603,7 +1616,7 @@ object WorkflowBuilder {
       case (ExprBuilderF(_, _), ValueBuilderF(_)) => delegate
 
       case (ValueBuilderF(bson), DocBuilderF(src, shape)) =>
-        mergeContents(Expr(-\/($literal(bson))), Doc(shape)).map {
+        mergeContents(Expr(\/-($literal(bson))), Doc(shape)).map {
           case ((lbase, rbase), cont) =>
             (lbase, rbase,
               cont match {
@@ -1614,7 +1627,7 @@ object WorkflowBuilder {
       case (DocBuilderF(_, _), ValueBuilderF(_)) => delegate
 
       case (ValueBuilderF(bson), _) =>
-        mergeContents(Expr(-\/($literal(bson))), Expr(-\/($$ROOT))).map {
+        mergeContents(Expr(\/-($literal(bson))), Expr(\/-($$ROOT))).map {
           case ((lbase, rbase), cont) =>
             (lbase, rbase,
               cont match {
@@ -1633,9 +1646,9 @@ object WorkflowBuilder {
                 case Doc(doc)   => DocBuilder(src1, doc)
               })
         }
-      case (ExprBuilderF(src, -\/($var(base @ DocField(_)))), _) if src === right =>
+      case (ExprBuilderF(src, \/-($var(base @ DocField(_)))), _) if src === right =>
         emit((base, DocVar.ROOT(), right))
-      case (_, ExprBuilderF(src, -\/($var(DocField(_))))) if left === src =>
+      case (_, ExprBuilderF(src, \/-($var(DocField(_))))) if left === src =>
         delegate
 
       case (DocBuilderF(src1, shape1), ExprBuilderF(src2, expr2)) if src1 === src2 =>
@@ -1672,8 +1685,8 @@ object WorkflowBuilder {
             splice <- lift(sb.toJs)
           } yield (DocField(lName), DocField(rName),
             DocBuilder(wb, ListMap(
-              lName ->  \/-(lbase.toJs >>> splice),
-              rName -> -\/ ($var(rbase)))))
+              lName -> -\/ (lbase.toJs >>> splice),
+              rName ->  \/-($var(rbase)))))
         }
       case (_, SpliceBuilderF(_, _)) => delegate
 
@@ -1685,14 +1698,14 @@ object WorkflowBuilder {
             splice <- lift(sb.toJs)
           } yield (DocField(lName), DocField(rName),
             DocBuilder(wb, ListMap(
-              lName ->  \/-(lbase.toJs >>> splice),
-              rName -> -\/ ($var(rbase)))))
+              lName -> -\/ (lbase.toJs >>> splice),
+              rName ->  \/-($var(rbase)))))
         }
       case (_, ArraySpliceBuilderF(_, _)) => delegate
 
       case (ExprBuilderF(src, expr), _) =>
         merge(src, right).flatMap { case (lbase, rbase, wb) =>
-          mergeContents(Expr(rewriteExprPrefix(expr, lbase)), Expr(-\/($var(rbase)))).map {
+          mergeContents(Expr(rewriteExprPrefix(expr, lbase)), Expr(\/-($var(rbase)))).map {
             case ((lbase, rbase), cont) =>
               (lbase, rbase,
                 cont match {
@@ -1705,7 +1718,7 @@ object WorkflowBuilder {
 
       case (DocBuilderF(src1, shape1), _) =>
         merge(src1, right).flatMap { case (lbase, rbase, wb) =>
-          mergeContents(Doc(rewriteDocPrefix(shape1, lbase)), Expr(-\/($var(rbase)))).map {
+          mergeContents(Doc(rewriteDocPrefix(shape1, lbase)), Expr(\/-($var(rbase)))).map {
             case ((lbase, rbase), cont) =>
               (lbase, rbase,
                 cont match {
@@ -1719,7 +1732,7 @@ object WorkflowBuilder {
       case (GroupBuilderF(src1, Nil, cont1, id1), CollectionBuilderF(_, _, _)) =>
         merge(src1, right).flatMap { case (lbase, rbase, wb) =>
           val cont1p = rewriteGroupRefs(cont1) { case v => lbase \\ v }
-          mergeContents(cont1p, Expr(-\/($var(rbase)))).map {
+          mergeContents(cont1p, Expr(\/-($var(rbase)))).map {
             case ((lbase, rbase), cont) =>
               (lbase, rbase,
                 GroupBuilder(wb, Nil, cont, id1))
@@ -1757,8 +1770,8 @@ object WorkflowBuilder {
               (DocField(lName), DocField(rName),
                 FlatteningBuilder(
                   DocBuilder(wb, ListMap(
-                    lName -> -\/($var(lbase)),
-                    rName -> -\/($var(rbase)))),
+                    lName -> \/-($var(lbase)),
+                    rName -> \/-($var(rbase)))),
                   fields.map(_.rewrite(DocField(lName) \\ _))))
           else emit((lbase, rbase, FlatteningBuilder(wb, lfields)))
         }
@@ -1795,7 +1808,7 @@ object WorkflowBuilder {
                   (lbase, DocField(rName),
                     CollectionBuilder(
                       chain(src,
-                        $project(Reshape(shape + (rName -> -\/($var(rbase)))))),
+                        $project(Reshape(shape + (rName -> \/-($var(rbase)))))),
                       DocVar.ROOT(),
                       None))))
               case _ => fail(InternalError("couldn’t merge array"))

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowtask.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowtask.scala
@@ -101,7 +101,7 @@ object WorkflowTask {
               src,
               pipeline :+
               $Project((),
-                Reshape(names.map(n => n -> -\/($var(DocField(n)))).toListMap),
+                Reshape(names.map(n => n -> \/-($var(DocField(n)))).toListMap),
                 ExcludeId)))
 
         case None =>
@@ -110,7 +110,7 @@ object WorkflowTask {
               src,
               pipeline :+
                 $Project((),
-                  Reshape(ListMap(Workflow.ExprName -> -\/($var(base)))),
+                  Reshape(ListMap(Workflow.ExprName -> \/-($var(base)))),
                   ExcludeId)))
       }
     case _ => (base, task)

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/optimize.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/optimize.scala
@@ -24,7 +24,7 @@ class OptimizeSpecs extends Specification with TreeMatchers {
        $read(Collection("db", "zips")),
        $project(
          Reshape(ListMap(
-           BsonField.Name("0") -> -\/($toLower($var(DocField(BsonField.Name("city"))))))),
+           BsonField.Name("0") -> \/-($toLower($var(DocField(BsonField.Name("city"))))))),
          IgnoreId),
        $skip(5))
      val exp = chain(
@@ -32,7 +32,7 @@ class OptimizeSpecs extends Specification with TreeMatchers {
       $skip(5),
       $project(
         Reshape(ListMap(
-          BsonField.Name("0") -> -\/($toLower($var(DocField(BsonField.Name("city"))))))),
+          BsonField.Name("0") -> \/-($toLower($var(DocField(BsonField.Name("city"))))))),
         IgnoreId))
 
       reorderOps(op) must beTree(exp)
@@ -80,7 +80,7 @@ class OptimizeSpecs extends Specification with TreeMatchers {
        $read(Collection("db", "zips")),
        $project(
          Reshape(ListMap(
-           BsonField.Name("0") -> -\/($toLower($var(DocField(BsonField.Name("city"))))))),
+           BsonField.Name("0") -> \/-($toLower($var(DocField(BsonField.Name("city"))))))),
          IgnoreId),
        $limit(10))
      val exp = chain(
@@ -88,7 +88,7 @@ class OptimizeSpecs extends Specification with TreeMatchers {
       $limit(10),
       $project(
         Reshape(ListMap(
-          BsonField.Name("0") -> -\/($toLower($var(DocField(BsonField.Name("city"))))))),
+          BsonField.Name("0") -> \/-($toLower($var(DocField(BsonField.Name("city"))))))),
         IgnoreId))
 
       reorderOps(op) must beTree(exp)
@@ -136,7 +136,7 @@ class OptimizeSpecs extends Specification with TreeMatchers {
        $read(Collection("db", "zips")),
        $project(
          Reshape(ListMap(
-           BsonField.Name("city") -> -\/($var(DocField(BsonField.Name("address") \ BsonField.Name("city")))))),
+           BsonField.Name("city") -> \/-($var(DocField(BsonField.Name("address") \ BsonField.Name("city")))))),
          IgnoreId),
        $match(Selector.Doc(
          BsonField.Name("city") -> Selector.Eq(Bson.Text("BOULDER")))))
@@ -146,7 +146,7 @@ class OptimizeSpecs extends Specification with TreeMatchers {
         (BsonField.Name("address") \ BsonField.Name("city")) -> Selector.Eq(Bson.Text("BOULDER")))),
       $project(
         Reshape(ListMap(
-          BsonField.Name("city") -> -\/($var(DocField(BsonField.Name("address") \ BsonField.Name("city")))))),
+          BsonField.Name("city") -> \/-($var(DocField(BsonField.Name("address") \ BsonField.Name("city")))))),
         IgnoreId))
 
       reorderOps(op) must beTree(exp)
@@ -157,7 +157,7 @@ class OptimizeSpecs extends Specification with TreeMatchers {
        $read(Collection("db", "zips")),
        $project(
          Reshape(ListMap(
-           BsonField.Name("__tmp0") -> -\/($var(DocField(BsonField.Name("address")))))),
+           BsonField.Name("__tmp0") -> \/-($var(DocField(BsonField.Name("address")))))),
          IgnoreId),
        $match(Selector.Doc(
          BsonField.Name("__tmp0") \ BsonField.Name("city") -> Selector.Eq(Bson.Text("BOULDER")))))
@@ -167,7 +167,7 @@ class OptimizeSpecs extends Specification with TreeMatchers {
         (BsonField.Name("address") \ BsonField.Name("city")) -> Selector.Eq(Bson.Text("BOULDER")))),
       $project(
         Reshape(ListMap(
-          BsonField.Name("__tmp0") -> -\/($var(DocField(BsonField.Name("address")))))),
+          BsonField.Name("__tmp0") -> \/-($var(DocField(BsonField.Name("address")))))),
         IgnoreId))
 
       reorderOps(op) must beTree(exp)
@@ -178,8 +178,8 @@ class OptimizeSpecs extends Specification with TreeMatchers {
        $read(Collection("db", "zips")),
        $project(
          Reshape(ListMap(
-           BsonField.Name("city") -> -\/($var(DocField(BsonField.Name("city")))),
-           BsonField.Name("__tmp0") -> -\/($toLower($var(DocField(BsonField.Name("city"))))))),
+           BsonField.Name("city") -> \/-($var(DocField(BsonField.Name("city")))),
+           BsonField.Name("__tmp0") -> \/-($toLower($var(DocField(BsonField.Name("city"))))))),
          IgnoreId),
        $match(Selector.Doc(
          BsonField.Name("__tmp0") -> Selector.Eq(Bson.Text("boulder")))))
@@ -306,7 +306,7 @@ class OptimizeSpecs extends Specification with TreeMatchers {
        $read(Collection("db", "zips")),
        $project(
          Reshape(ListMap(
-           BsonField.Name("city") -> -\/($var(DocField(BsonField.Name("__tmp0") \ BsonField.Name("city")))))),
+           BsonField.Name("city") -> \/-($var(DocField(BsonField.Name("__tmp0") \ BsonField.Name("city")))))),
          IgnoreId),
        $sort(NonEmptyList(BsonField.Name("city") -> Ascending)))
 
@@ -318,7 +318,7 @@ class OptimizeSpecs extends Specification with TreeMatchers {
     "inline simple project on group" in {
       val inlined = inlineProjectGroup(
         Reshape(ListMap(
-          BsonField.Name("foo") -> -\/ ($var(DocField(BsonField.Name("value")))))),
+          BsonField.Name("foo") -> \/-($var(DocField(BsonField.Name("value")))))),
         Grouped(ListMap(BsonField.Name("value") -> $sum($literal(Bson.Int32(1))))))
 
       inlined must beSome(Grouped(ListMap(BsonField.Name("foo") -> $sum($literal(Bson.Int32(1))))))
@@ -327,8 +327,8 @@ class OptimizeSpecs extends Specification with TreeMatchers {
     "inline multiple projects on group, dropping extras" in {
         val inlined = inlineProjectGroup(
           Reshape(ListMap(
-            BsonField.Name("foo") -> -\/($var(DocField(BsonField.Name("__sd_tmp_1")))),
-            BsonField.Name("bar") -> -\/($var(DocField(BsonField.Name("__sd_tmp_2")))))),
+            BsonField.Name("foo") -> \/-($var(DocField(BsonField.Name("__sd_tmp_1")))),
+            BsonField.Name("bar") -> \/-($var(DocField(BsonField.Name("__sd_tmp_2")))))),
           Grouped(ListMap(
             BsonField.Name("__sd_tmp_1") -> $sum($literal(Bson.Int32(1))),
             BsonField.Name("__sd_tmp_2") -> $sum($literal(Bson.Int32(2))),
@@ -342,8 +342,8 @@ class OptimizeSpecs extends Specification with TreeMatchers {
     "inline project on group with nesting" in {
         val inlined = inlineProjectGroup(
           Reshape(ListMap(
-            BsonField.Name("bar") -> -\/($var(DocField(BsonField.Name("value") \ BsonField.Name("bar")))),
-            BsonField.Name("baz") -> -\/($var(DocField(BsonField.Name("value") \ BsonField.Name("baz")))))),
+            BsonField.Name("bar") -> \/-($var(DocField(BsonField.Name("value") \ BsonField.Name("bar")))),
+            BsonField.Name("baz") -> \/-($var(DocField(BsonField.Name("value") \ BsonField.Name("baz")))))),
           Grouped(ListMap(
             BsonField.Name("value") -> $push($var(DocField(BsonField.Name("foo")))))))
 

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -69,8 +69,8 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
   def beWorkflow(wf: Workflow) = beRight(equalToWorkflow(wf))
 
   implicit def toBsonField(name: String) = BsonField.Name(name)
-  implicit def toLeftShape(exprOp: Expression): Reshape.Shape = -\/ (exprOp)
-  implicit def toRightShape(shape: Reshape):    Reshape.Shape =  \/-(shape)
+  implicit def toLeftShape(shape: Reshape):      Reshape.Shape = -\/ (shape)
+  implicit def toRightShape(exprOp: Expression): Reshape.Shape =  \/-(exprOp)
 
   "plan from query string" should {
     "plan simple constant example 1" in {
@@ -97,7 +97,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           $read(Collection("db", "foo")),
           $group(
             grouped("0" -> $sum($literal(Bson.Int32(1)))),
-            -\/($literal(Bson.Null)))))
+            \/-($literal(Bson.Null)))))
     }
 
     "plan simple field projection on single set" in {
@@ -281,7 +281,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
         $read(Collection("db", "zips")),
         $group(
           grouped("__tmp0" -> $sum($field("pop"))),
-          -\/($literal(Bson.Null))),
+          \/-($literal(Bson.Null))),
         $project(
           reshape("0" -> $multiply($field("__tmp0"), $literal(Bson.Int64(100)))),
           IgnoreId)))
@@ -536,7 +536,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               Selector.Eq(Bson.Text("56d1caf5d082d1a6840090986e277d36d03f1859")))),
           $group(
             grouped("count" -> $sum($literal(Bson.Int32(1)))),
-            -\/($literal(Bson.Null)))))
+            \/-($literal(Bson.Null)))))
     }
 
     "plan simple having filter" in {
@@ -547,7 +547,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           grouped(
             "city"   -> $push($field("city")),
             "__tmp0" -> $sum($literal(Bson.Int32(1)))),
-          -\/($field("city"))),
+          \/-($field("city"))),
         $unwind(DocField(BsonField.Name("city"))),
         $match(Selector.Doc(
           BsonField.Name("__tmp0") -> Selector.Gt(Bson.Int64(10)))),
@@ -564,7 +564,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           grouped(
             "city" -> $push($field("city")),
             "1"    -> $sum($field("pop"))),
-          -\/($field("city"))),
+          \/-($field("city"))),
         $unwind(DocField(BsonField.Name("city"))),
         $match(Selector.Doc(
           BsonField.Name("1") -> Selector.Gt(Bson.Int64(50000))))))
@@ -854,7 +854,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               grouped(
                 "city" -> $push($field("city")),
                 "cnt"  -> $sum($literal(Bson.Int32(1)))),
-              -\/($literal(Bson.Null))),
+              \/-($literal(Bson.Null))),
             $unwind(DocField("city")),
             $sort(NonEmptyList(BsonField.Name("cnt") -> Descending)))
         }
@@ -872,7 +872,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               grouped(
                 "cnt" -> $sum($literal(Bson.Int32(1))),
                 "1"   -> $push($field("1"))),
-              -\/($literal(Bson.Null))),
+              \/-($literal(Bson.Null))),
             $unwind(DocField("1")))
         }
     }
@@ -881,7 +881,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
       plan("select city from zips group by city") must
       beWorkflow(chain(
         $read(Collection("db", "zips")),
-        $group(grouped("city" -> $push($field("city"))), -\/($field("city"))),
+        $group(grouped("city" -> $push($field("city"))), \/-($field("city"))),
         $unwind(DocField(BsonField.Name("city")))))
     }
 
@@ -889,7 +889,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
       plan("select city from zips group by lower(city)") must
       beWorkflow(chain(
         $read(Collection("db", "zips")),
-        $group(grouped("city" -> $push($field("city"))), -\/($toLower($field("city")))),
+        $group(grouped("city" -> $push($field("city"))), \/-($toLower($field("city")))),
         $unwind(DocField(BsonField.Name("city")))))
     }
 
@@ -906,7 +906,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             grouped(
               "a" -> $avg($field("__tmp0")),
               "m" -> $push($field("__tmp1"))),
-            -\/($field("__tmp1"))),
+            \/-($field("__tmp1"))),
           $unwind(DocField(BsonField.Name("m")))))
     }
 
@@ -927,7 +927,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             $read(Collection("db", "bar")),
             $group(
               grouped("0" -> $sum($literal(Bson.Int32(1)))),
-              -\/($field("baz"))))
+              \/-($field("baz"))))
         }
     }
 
@@ -940,7 +940,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               grouped(
                 "cnt" -> $sum($literal(Bson.Int32(1))),
                 "sm" -> $sum($field("biz"))),
-              -\/($field("baz"))))
+              \/-($field("baz"))))
         }
     }
 
@@ -953,7 +953,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               BsonField.Name("state") -> Selector.Eq(Bson.Text("CO")))),
             $group(
               grouped("sm" -> $sum($field("pop"))),
-              -\/($field("city"))))
+              \/-($field("city"))))
         }
     }
 
@@ -966,7 +966,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               grouped(
                 "cnt"  -> $sum($literal(Bson.Int32(1))),
                 "city" -> $push($field("city"))),
-              -\/($field("city"))),
+              \/-($field("city"))),
             $unwind(DocField(BsonField.Name("city"))))
         }
     }
@@ -986,7 +986,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           grouped(
             "2"      -> $sum($field("__tmp2", "__tmp0")),
             "__tmp1" -> $push($field("__tmp1"))),
-          -\/($literal(Bson.Null))),
+          \/-($literal(Bson.Null))),
         $unwind(DocField("__tmp1")),
         $project(
           reshape(
@@ -1006,7 +1006,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               grouped(
                 "__tmp0" -> $max($field("pop")),
                 "pop"    -> $push($field("pop"))),
-              -\/($literal(Bson.Null))),
+              \/-($literal(Bson.Null))),
             $unwind(DocField("pop")),
             $project(
               reshape(
@@ -1031,7 +1031,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           grouped(
             "1"      -> $sum($field("__tmp1", "pop")),
             "__tmp0" -> $push($field("__tmp0"))),
-          -\/($literal(Bson.Null))),
+          \/-($literal(Bson.Null))),
         $unwind(DocField("__tmp0")),
         $project(
           reshape(
@@ -1049,7 +1049,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           grouped(
             "city"   -> $push($field("city")),
             "__tmp2" -> $sum($subtract($field("pop"), $literal(Bson.Int64(1))))),
-          -\/($field("city"))),
+          \/-($field("city"))),
         $unwind(DocField(BsonField.Name("city"))),
         $project(
           reshape(
@@ -1066,7 +1066,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             grouped(
               "state" -> $push($field("state")),
               "__tmp0" -> $min($field("city"))),
-            -\/($field("state"))),
+            \/-($field("state"))),
             $unwind(DocField("state")),
           $simpleMap(NonEmptyList(
             MapExpr(JsFn(Name("x"), obj(
@@ -1093,7 +1093,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             grouped(
               "len" -> $push($field("__tmp0")),
               "cnt" -> $sum($literal(Bson.Int32(1)))),
-            -\/($field("__tmp0"))),
+            \/-($field("__tmp0"))),
           $unwind(DocField(BsonField.Name("len")))))
     }
 
@@ -1393,7 +1393,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               grouped(
                 "city" -> $push($field("city")),
                 "pop"  -> $sum($field("pop"))),
-              -\/($field("city"))),
+              \/-($field("city"))),
             $unwind(DocField(BsonField.Name("city"))),
             $sort(NonEmptyList(BsonField.Name("pop") -> Ascending)))
         }
@@ -1420,7 +1420,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             grouped(
               "0" -> $avg($field("pop")),
               "1" -> $min($field("city"))),
-            -\/($literal(Bson.Null)))))
+            \/-($literal(Bson.Null)))))
     }
 
     "plan simple distinct" in {
@@ -1435,7 +1435,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             IgnoreId),
           $group(
             grouped("__tmp0" -> $first($$ROOT)),
-            \/-(reshape(
+            -\/(reshape(
               "city"  -> $field("city"),
               "state" -> $field("state")))),
           $project(
@@ -1451,10 +1451,10 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           $read(Collection("db", "zips")),
           $group(
             grouped(),
-            -\/($field("city"))),
+            \/-($field("city"))),
           $group(
             grouped("0" -> $sum($literal(Bson.Int32(1)))),
-            -\/($literal(Bson.Null)))))
+            \/-($literal(Bson.Null)))))
     }
 
     "plan distinct of expression as expression" in {
@@ -1463,14 +1463,14 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
           $read(Collection("db", "zips")),
           $group(
             grouped(),
-            -\/(
+            \/-(
               $substr(
                 $field("city"),
                 $literal(Bson.Int64(0)),
                 $literal(Bson.Int64(1))))),
           $group(
             grouped("0" -> $sum($literal(Bson.Int32(1)))),
-            -\/($literal(Bson.Null)))))
+            \/-($literal(Bson.Null)))))
     }
 
     "plan distinct of wildcard" in {
@@ -1498,7 +1498,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               grouped(
                 "__tmp0" -> $first($$ROOT),
                 "__sd_key_0" -> $first($field("city"))),
-              \/-(reshape("city" -> $field("city")))),
+              -\/(reshape("city" -> $field("city")))),
             $sort(NonEmptyList(BsonField.Name("__sd_key_0") -> Ascending)),
             $project(
               reshape("city" -> $field("__tmp0", "city")),
@@ -1521,7 +1521,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
                 grouped(
                   "__tmp0"     -> $first($$ROOT),
                   "__sd_key_0" -> $first($field("__sd__0"))),
-                \/-(reshape("city" -> $field("city")))),
+                -\/(reshape("city" -> $field("city")))),
               $sort(NonEmptyList(
                 BsonField.Name("__sd_key_0") -> Descending)),
               $project(
@@ -1543,11 +1543,11 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             grouped(
               "totalPop" -> $sum($field("pop")),
               "city"     -> $push($field("city"))),
-            -\/($field("city"))),
+            \/-($field("city"))),
           $unwind(DocField(BsonField.Name("city"))),
           $group(
             grouped("__tmp0" -> $first($$ROOT)),
-            \/-(reshape(
+            -\/(reshape(
               "totalPop" -> $field("totalPop"),
               "city"     -> $field("city")))),
           $project(
@@ -1566,14 +1566,14 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
               grouped(
                 "totalPop" -> $sum($field("pop")),
                 "city"     -> $push($field("city"))),
-              -\/($field("city"))),
+              \/-($field("city"))),
             $unwind(DocField(BsonField.Name("city"))),
             $sort(NonEmptyList(BsonField.Name("totalPop") -> Descending)),
             $group(
               grouped(
                 "__tmp0"     -> $first($$ROOT),
                 "__sd_key_0" -> $first($field("totalPop"))),
-              \/-(reshape(
+              -\/(reshape(
                 "totalPop" -> $field("totalPop"),
                 "city"     -> $field("city")))),
             $sort(NonEmptyList(BsonField.Name("__sd_key_0") -> Descending)),
@@ -2347,7 +2347,7 @@ class PlannerSpec extends Specification with ScalaCheck with CompilerHelpers wit
             ListMap()),
           $group(
             grouped("__tmp0" -> $first($$ROOT)),
-            -\/($$ROOT)),
+            \/-($$ROOT)),
           $project(
             reshape("value" -> $field("__tmp0")),
             ExcludeId)))

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -44,7 +44,7 @@ class WorkflowBuilderSpec
       op must beRightDisjOrDiff(chain(
         $read(Collection("db", "zips")),
         $project(Reshape(ListMap(
-          BsonField.Name("city") -> -\/($field("city")))),
+          BsonField.Name("city") -> \/-($field("city")))),
           IgnoreId)))
     }
 
@@ -62,7 +62,7 @@ class WorkflowBuilderSpec
         DocBuilder(
           WorkflowBuilder.read(Collection("db", "zips")),
           ListMap(BsonField.Name("0") ->
-            -\/($concat($concat($field("city"), $literal(Bson.Text(", "))), $field("state"))))))
+            \/-($concat($concat($field("city"), $literal(Bson.Text(", "))), $field("state"))))))
     }
 
     "make nested expression under shape preserving in single step" in {
@@ -82,10 +82,10 @@ class WorkflowBuilderSpec
           DocBuilder(
             WorkflowBuilder.read(Collection("db", "zips")),
             ListMap(BsonField.Name("0") ->
-              -\/($concat($concat($field("city"), $literal(Bson.Text(", "))), $field("state"))))),
+              \/-($concat($concat($field("city"), $literal(Bson.Text(", "))), $field("state"))))),
           List(ExprBuilder(
             WorkflowBuilder.read(Collection("db", "zips")),
-            -\/($field("pop")))),
+            \/-($field("pop")))),
           { case f :: Nil => $match(Selector.Doc(f -> Selector.Lt(Bson.Int32(1000)))) }))
     }
 
@@ -155,8 +155,8 @@ class WorkflowBuilderSpec
       op must beRightDisjOrDiff(chain(
           $read(Collection("db", "zips")),
           $project(Reshape(ListMap(
-            BsonField.Name("city") -> -\/($field("city")),
-            BsonField.Name("pop")  -> -\/($field("pop")))),
+            BsonField.Name("city") -> \/-($field("city")),
+            BsonField.Name("pop")  -> \/-($field("pop")))),
             IgnoreId)))
     }
 
@@ -213,12 +213,12 @@ class WorkflowBuilderSpec
         $group(
           Grouped(ListMap(
             BsonField.Name("__tmp0") -> $sum($field("pop")))),
-          \/-(Reshape(ListMap(
-            BsonField.Name("0") -> -\/($field("city")),
-            BsonField.Name("1") -> -\/($field("state")))))),
+          -\/(Reshape(ListMap(
+            BsonField.Name("0") -> \/-($field("city")),
+            BsonField.Name("1") -> \/-($field("state")))))),
         $project(
           Reshape(ListMap(
-            BsonField.Name("value") -> -\/($field("__tmp0")))),
+            BsonField.Name("value") -> \/-($field("__tmp0")))),
             ExcludeId)))
     }
 
@@ -234,15 +234,15 @@ class WorkflowBuilderSpec
       op must beRightDisjOrDiff(chain(
           $read(Collection("db", "zips")),
           $project(Reshape(ListMap(
-            BsonField.Name("city") -> -\/($field("city")))),
+            BsonField.Name("city") -> \/-($field("city")))),
             IgnoreId),
           $group(
             Grouped(ListMap(
               BsonField.Name("__tmp0") -> $first($$ROOT))),
-            \/-(Reshape(ListMap(
-              BsonField.Name("city") -> -\/($field("city")))))),
+            -\/(Reshape(ListMap(
+              BsonField.Name("city") -> \/-($field("city")))))),
           $project(Reshape(ListMap(
-            BsonField.Name("city") -> -\/($field("__tmp0", "city")))),
+            BsonField.Name("city") -> \/-($field("__tmp0", "city")))),
             ExcludeId)))
     }
 
@@ -266,16 +266,16 @@ class WorkflowBuilderSpec
           Grouped(ListMap(
             BsonField.Name("total") -> $sum($$ROOT),
             BsonField.Name("city")  -> $push($field("city")))),
-          -\/($field("city"))),
+          \/-($field("city"))),
         $unwind(DocField(BsonField.Name("city"))),
         $group(
           Grouped(ListMap(BsonField.Name("__tmp0") -> $first($$ROOT))),
-          \/-(Reshape(ListMap(
-            BsonField.Name("total") -> -\/($field("total")),
-            BsonField.Name("city")  -> -\/($field("city")))))),
+          -\/(Reshape(ListMap(
+            BsonField.Name("total") -> \/-($field("total")),
+            BsonField.Name("city")  -> \/-($field("city")))))),
         $project(Reshape(ListMap(
-          BsonField.Name("total") -> -\/($field("__tmp0", "total")),
-          BsonField.Name("city")  -> -\/($field("__tmp0", "city")))),
+          BsonField.Name("total") -> \/-($field("__tmp0", "total")),
+          BsonField.Name("city")  -> \/-($field("__tmp0", "city")))),
           ExcludeId)))
     }
 
@@ -299,8 +299,8 @@ class WorkflowBuilderSpec
       op must beRightDisjOrDiff(chain(
         $read(Collection("db", "zips")),
         $project(Reshape(ListMap(
-          BsonField.Name("city") -> -\/($field("city")),
-          BsonField.Name("state") -> -\/($field("state")))),
+          BsonField.Name("city") -> \/-($field("city")),
+          BsonField.Name("state") -> \/-($field("state")))),
           IgnoreId),
         $sort(NonEmptyList(
           BsonField.Name("city") -> Ascending,
@@ -311,15 +311,15 @@ class WorkflowBuilderSpec
             BsonField.Name("__tmp0")     -> $first($$ROOT),
             BsonField.Name("__sd_key_0") -> $first($field("city")),
             BsonField.Name("__sd_key_1") -> $first($field("state")))),
-          \/-(Reshape(ListMap(
-            BsonField.Name("city") -> -\/($field("city")),
-            BsonField.Name("state") -> -\/($field("state")))))),
+          -\/(Reshape(ListMap(
+            BsonField.Name("city") -> \/-($field("city")),
+            BsonField.Name("state") -> \/-($field("state")))))),
         $sort(NonEmptyList(
           BsonField.Name("__sd_key_0") -> Ascending,
           BsonField.Name("__sd_key_1") -> Ascending)),
         $project(Reshape(ListMap(
-          BsonField.Name("city")  -> -\/($field("__tmp0", "city")),
-          BsonField.Name("state") -> -\/($field("__tmp0", "state")))),
+          BsonField.Name("city")  -> \/-($field("__tmp0", "city")),
+          BsonField.Name("state") -> \/-($field("__tmp0", "state")))),
           ExcludeId)))
     }
 
@@ -338,7 +338,7 @@ class WorkflowBuilderSpec
           $group(
             Grouped(ListMap(
               BsonField.Name("total") -> $sum($field("pop")))),
-            -\/($literal(Bson.Null)))))
+            \/-($literal(Bson.Null)))))
     }
 
     "group constant in proj" in {
@@ -354,7 +354,7 @@ class WorkflowBuilderSpec
           $group(
             Grouped(ListMap(
               BsonField.Name("total") -> $sum($literal(Bson.Int32(1))))),
-            -\/($literal(Bson.Null)))))
+            \/-($literal(Bson.Null)))))
     }
 
     "group in two projs" in {
@@ -376,7 +376,7 @@ class WorkflowBuilderSpec
             Grouped(ListMap(
               BsonField.Name("count") -> $sum($literal(Bson.Int32(1))),
               BsonField.Name("total") -> $sum($field("pop")))),
-            -\/($literal(Bson.Null)))))
+            \/-($literal(Bson.Null)))))
     }
 
     "group on a field" in {
@@ -395,7 +395,7 @@ class WorkflowBuilderSpec
           $group(
             Grouped(ListMap(
               BsonField.Name("total") -> $sum($field("pop")))),
-            -\/($field("city")))))
+            \/-($field("city")))))
     }
 
     "group on a field, with un-grouped projection" in {
@@ -418,7 +418,7 @@ class WorkflowBuilderSpec
             Grouped(ListMap(
               BsonField.Name("total") -> $sum($field("pop")),
               BsonField.Name("city")  -> $push($field("city")))),
-            -\/($field("city"))),
+            \/-($field("city"))),
           $unwind(DocField(BsonField.Name("city")))))
     }
 
@@ -438,10 +438,10 @@ class WorkflowBuilderSpec
           $group(
             Grouped(ListMap(
               BsonField.Name("__tmp2") -> $sum($field("pop")))),
-            -\/($literal(Bson.Null))),
-            $project(Reshape(ListMap(
-              BsonField.Name("totalInK") ->
-                -\/($divide($field("__tmp2"), $literal(Bson.Int32(1000)))))),
+            \/-($literal(Bson.Null))),
+          $project(Reshape(ListMap(
+            BsonField.Name("totalInK") ->
+              \/-($divide($field("__tmp2"), $literal(Bson.Int32(1000)))))),
           IgnoreId)))
     }
 
@@ -453,13 +453,13 @@ class WorkflowBuilderSpec
           DocBuilder(
             readFoo,
             ListMap(
-              BsonField.Name("__tmp") -> \/-(jscore.JsFn(jscore.Name("x"), jscore.Literal(Js.Bool(true)))))),
+              BsonField.Name("__tmp") -> -\/(jscore.JsFn(jscore.Name("x"), jscore.Literal(Js.Bool(true)))))),
           ListMap(
-            BsonField.Name("0") -> -\/($var(DocField(BsonField.Name("__tmp"))))))
+            BsonField.Name("0") -> \/-($var(DocField(BsonField.Name("__tmp"))))))
         val exp = DocBuilder(
           readFoo,
           ListMap(
-            BsonField.Name("0") -> \/-(jscore.JsFn(jscore.Name("y"), jscore.Literal(Js.Bool(true))))))
+            BsonField.Name("0") -> -\/(jscore.JsFn(jscore.Name("y"), jscore.Literal(Js.Bool(true))))))
 
         normalize(w) must_== exp
       }
@@ -469,13 +469,13 @@ class WorkflowBuilderSpec
           DocBuilder(
             readFoo,
             ListMap(
-              BsonField.Name("__tmp") -> -\/($var(DocField(BsonField.Name("foo")))))),
+              BsonField.Name("__tmp") -> \/-($var(DocField(BsonField.Name("foo")))))),
           ListMap(
-            BsonField.Name("0") -> -\/($toLower($var(DocField(BsonField.Name("__tmp")))))))
+            BsonField.Name("0") -> \/-($toLower($var(DocField(BsonField.Name("__tmp")))))))
         val exp = DocBuilder(
           readFoo,
           ListMap(
-            BsonField.Name("0") -> -\/($toLower($var(DocField(BsonField.Name("foo")))))))
+            BsonField.Name("0") -> \/-($toLower($var(DocField(BsonField.Name("foo")))))))
 
         normalize(w) must_== exp
       }
@@ -485,13 +485,13 @@ class WorkflowBuilderSpec
           DocBuilder(
             readFoo,
             ListMap(
-              BsonField.Name("__tmp") -> \/-(jscore.JsFn(jscore.Name("x"), jscore.Literal(Js.Str("ABC")))))),
+              BsonField.Name("__tmp") -> -\/(jscore.JsFn(jscore.Name("x"), jscore.Literal(Js.Str("ABC")))))),
           ListMap(
-            BsonField.Name("0") -> -\/($toLower($var(DocField(BsonField.Name("__tmp")))))))
+            BsonField.Name("0") -> \/-($toLower($var(DocField(BsonField.Name("__tmp")))))))
         val exp = DocBuilder(
           readFoo,
           ListMap(
-            BsonField.Name("0") -> \/-(jscore.JsFn(jscore.Name("x"),
+            BsonField.Name("0") -> -\/(jscore.JsFn(jscore.Name("x"),
               jscore.Call(
                 jscore.Select(jscore.Literal(Js.Str("ABC")), "toLowerCase"),
                 List())))))
@@ -504,13 +504,13 @@ class WorkflowBuilderSpec
           DocBuilder(
             readFoo,
             ListMap(
-              BsonField.Name("__tmp") -> -\/($$ROOT))),
+              BsonField.Name("__tmp") -> \/-($$ROOT))),
           ListMap(
-            BsonField.Name("foo") -> -\/($var(DocField(BsonField.Name("__tmp") \ BsonField.Name("foo"))))))
+            BsonField.Name("foo") -> \/-($var(DocField(BsonField.Name("__tmp") \ BsonField.Name("foo"))))))
         val exp = DocBuilder(
           readFoo,
           ListMap(
-            BsonField.Name("foo") -> -\/($var(DocField(BsonField.Name("foo"))))))
+            BsonField.Name("foo") -> \/-($var(DocField(BsonField.Name("foo"))))))
 
         normalize(w) must_== exp
       }
@@ -520,15 +520,15 @@ class WorkflowBuilderSpec
           DocBuilder(
             readFoo,
             ListMap(
-              BsonField.Name("__tmp") -> -\/($var(DocField(BsonField.Name("foo")))))),
+              BsonField.Name("__tmp") -> \/-($var(DocField(BsonField.Name("foo")))))),
           ListMap(
-            BsonField.Name("0") -> \/-(jscore.JsFn(jscore.Name("x"),
+            BsonField.Name("0") -> -\/(jscore.JsFn(jscore.Name("x"),
               jscore.Select(jscore.Select(jscore.ident("x"), "__tmp"), "length")))))
 
         val exp = DocBuilder(
           readFoo,
           ListMap(
-            BsonField.Name("0") -> \/-(jscore.JsFn(jscore.Name("y"),
+            BsonField.Name("0") -> -\/(jscore.JsFn(jscore.Name("y"),
               jscore.Select(jscore.Select(jscore.ident("y"), "foo"), "length")))))
 
         normalize(w) must_== exp
@@ -559,7 +559,7 @@ class WorkflowBuilderSpec
           |├─ By
           |│  ╰─ ValueBuilder(Int32(1))
           |├─ Content
-          |│  ╰─ \/-
+          |│  ╰─ -\/
           |│     ╰─ AccumOp($sum($varF(DocVar.ROOT())))
           |╰─ Id(9a1be37c)""".stripMargin)
     }

--- a/core/src/test/scala/slamdata/engine/physical/mongodb/workflowop.scala
+++ b/core/src/test/scala/slamdata/engine/physical/mongodb/workflowop.scala
@@ -91,10 +91,10 @@ class WorkflowSpec extends Specification with TreeMatchers {
         $group(
           Grouped(ListMap(
             BsonField.Name("value") -> $push($field("rIght")))),
-          -\/($field("lEft"))),
+          \/-($field("lEft"))),
         $unwind(DocField(BsonField.Name("value"))),
         $project(Reshape(ListMap(
-          BsonField.Name("city") -> -\/($field("value", "city")))),
+          BsonField.Name("city") -> \/-($field("value", "city")))),
           IncludeId))
 
       val expected = chain(
@@ -102,7 +102,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
         $group(
           Grouped(ListMap(
             BsonField.Name("city") -> $push($field("rIght", "city")))),
-          -\/($field("lEft"))),
+          \/-($field("lEft"))),
         $unwind(DocField(BsonField.Name("city"))))
 
       given must beTree(expected: Workflow)
@@ -114,10 +114,10 @@ class WorkflowSpec extends Specification with TreeMatchers {
         $group(
           Grouped(ListMap(
             BsonField.Name("value") -> $push($field("rIght")))),
-          -\/($field("lEft"))),
+          \/-($field("lEft"))),
         $unwind(DocField(BsonField.Name("value"))),
         $project(Reshape(ListMap(
-          BsonField.Name("city") -> -\/($field("value", "city")))),
+          BsonField.Name("city") -> \/-($field("value", "city")))),
           ExcludeId))
 
       given must beTree(given: Workflow)
@@ -126,14 +126,14 @@ class WorkflowSpec extends Specification with TreeMatchers {
     "resolve `Include`" in {
       chain($read(Collection("db", "zips")),
         $project(Reshape(ListMap(
-          BsonField.Name("bar") -> -\/($include()))),
+          BsonField.Name("bar") -> \/-($include()))),
           ExcludeId),
         $project(Reshape(ListMap(
-          BsonField.Name("_id") -> -\/($field("bar")))),
+          BsonField.Name("_id") -> \/-($field("bar")))),
           IncludeId)) must_==
       chain($read(Collection("db", "zips")),
         $project(Reshape(ListMap(
-          BsonField.Name("_id") -> -\/($field("bar")))),
+          BsonField.Name("_id") -> \/-($field("bar")))),
           IncludeId))
     }
 
@@ -141,54 +141,54 @@ class WorkflowSpec extends Specification with TreeMatchers {
       chain($read(Collection("db", "zips")),
         $project(Reshape(ListMap(
           BsonField.Name("bar") ->
-            -\/($divide(
+            \/-($divide(
               $field("baz"),
               $literal(Bson.Int32(92)))))),
           IncludeId),
         $project(Reshape(ListMap(
-          BsonField.Name("bar") -> -\/($include()))),
+          BsonField.Name("bar") -> \/-($include()))),
           IncludeId)) must_==
       chain($read(Collection("db", "zips")),
         $project(Reshape(ListMap(
           BsonField.Name("bar") ->
-            -\/($divide($field("baz"), $literal(Bson.Int32(92)))))),
+            \/-($divide($field("baz"), $literal(Bson.Int32(92)))))),
           IncludeId))
     }
 
     "resolve implied `_id`" in {
       chain($read(Collection("db", "zips")),
         $project(Reshape(ListMap(
-          BsonField.Name("bar") -> -\/($field("bar")),
+          BsonField.Name("bar") -> \/-($field("bar")),
           BsonField.Name("_id") ->
-            -\/($field("baz")))),
+            \/-($field("baz")))),
           IncludeId),
         $project(Reshape(ListMap(
           BsonField.Name("bar") ->
-            -\/($field("bar")))),
+            \/-($field("bar")))),
           IncludeId)) must_==
       chain($read(Collection("db", "zips")),
         $project(Reshape(ListMap(
-          BsonField.Name("bar") -> -\/($field("bar")),
+          BsonField.Name("bar") -> \/-($field("bar")),
           BsonField.Name("_id") ->
-            -\/($field("baz")))),
+            \/-($field("baz")))),
           IncludeId))
     }
 
     "not resolve excluded `_id`" in {
       chain($read(Collection("db", "zips")),
         $project(Reshape(ListMap(
-          BsonField.Name("bar") -> -\/($field("bar")),
+          BsonField.Name("bar") -> \/-($field("bar")),
           BsonField.Name("_id") ->
-            -\/($field("baz")))),
+            \/-($field("baz")))),
           IncludeId),
         $project(Reshape(ListMap(
           BsonField.Name("bar") ->
-            -\/($field("bar")))),
+            \/-($field("bar")))),
           ExcludeId)) must_==
       chain($read(Collection("db", "zips")),
         $project(Reshape(ListMap(
           BsonField.Name("bar") ->
-            -\/($field("bar")))),
+            \/-($field("bar")))),
           ExcludeId))
     }
   }
@@ -201,7 +201,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
       val given = chain(
         readZips,
         $project(Reshape(ListMap(
-          BsonField.Name("value") -> -\/($$ROOT))),
+          BsonField.Name("value") -> \/-($$ROOT))),
           IncludeId),
         $map($Map.mapNOP, ListMap()))
 
@@ -221,7 +221,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
       val given = chain(
         readZips,
         $project(Reshape(ListMap(
-          BsonField.Name("value") -> -\/($$ROOT))),
+          BsonField.Name("value") -> \/-($$ROOT))),
           IncludeId),
         $flatMap(
           Js.AnonFunDecl(List("key", "value"), List(
@@ -269,7 +269,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
       val given = chain(
         readZips,
         $project(Reshape(ListMap(
-          BsonField.Name("value") -> -\/($$ROOT))),
+          BsonField.Name("value") -> \/-($$ROOT))),
           IncludeId),
         $reduce($Reduce.reduceNOP, ListMap()))
 
@@ -402,7 +402,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
 
       val expected = $foldLeft(
         chain(readZips, $project(Reshape(ListMap(
-          BsonField.Name("value") -> -\/($$ROOT))),
+          BsonField.Name("value") -> \/-($$ROOT))),
           IncludeId)),
         chain(readZips, $reduce($Reduce.reduceFoldLeft, ListMap())))
 
@@ -419,7 +419,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
         chain(
           readZips,
           $project(Reshape(ListMap(
-            BsonField.Name("value") -> -\/($$ROOT))),
+            BsonField.Name("value") -> \/-($$ROOT))),
             IncludeId)),
         chain(readZips, $reduce($Reduce.reduceNOP, ListMap())))
 
@@ -442,8 +442,8 @@ class WorkflowSpec extends Specification with TreeMatchers {
             "second" -> Select(ident("x"), "city"))))),
           ListMap()),
         $project(Reshape(ListMap(
-          BsonField.Name("first") -> -\/($include()),
-          BsonField.Name("second") -> -\/($include()))),
+          BsonField.Name("first") -> \/-($include()),
+          BsonField.Name("second") -> \/-($include()))),
           IgnoreId))))
     }
 
@@ -467,8 +467,8 @@ class WorkflowSpec extends Specification with TreeMatchers {
             FlatExpr(JsFn(Name("x"), Select(ident("x"), "city")))),
           ListMap()),
         $project(Reshape(ListMap(
-          BsonField.Name("first") -> -\/($include()),
-          BsonField.Name("second") -> -\/($include()))),
+          BsonField.Name("first") -> \/-($include()),
+          BsonField.Name("second") -> \/-($include()))),
           IgnoreId))))
     }
 
@@ -488,7 +488,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
           ListMap()),
         $project(
           Reshape(ListMap(
-            BsonField.Name("0") -> -\/($include()))),
+            BsonField.Name("0") -> \/-($include()))),
           IgnoreId))))
     }
 
@@ -496,7 +496,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
       crystallize(chain(
         $read(Collection("db", "zips")),
         $project(Reshape(ListMap(
-            BsonField.Name("loc") -> -\/($var(DocField(BsonField.Name("loc")))))),
+            BsonField.Name("loc") -> \/-($var(DocField(BsonField.Name("loc")))))),
           IgnoreId),
         $unwind(DocField(BsonField.Name("loc"))),
         $simpleMap(
@@ -505,7 +505,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
         beTree(Crystallized(chain(
           $read(Collection("db", "zips")),
           $project(Reshape(ListMap(
-              BsonField.Name("loc") -> -\/($var(DocField(BsonField.Name("loc")))))),
+              BsonField.Name("loc") -> \/-($var(DocField(BsonField.Name("loc")))))),
             IgnoreId),
           $unwind(DocField(BsonField.Name("loc"))),
           $simpleMap(
@@ -514,7 +514,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
             ListMap()),
           $project(
             Reshape(ListMap(
-              BsonField.Name("0") -> -\/($include()))),
+              BsonField.Name("0") -> \/-($include()))),
             IgnoreId))))
     }
 
@@ -541,8 +541,8 @@ class WorkflowSpec extends Specification with TreeMatchers {
           ListMap()),
         $project(
           Reshape(ListMap(
-            BsonField.Name("0") -> -\/($include()),
-            BsonField.Name("1") -> -\/($include()))),
+            BsonField.Name("0") -> \/-($include()),
+            BsonField.Name("1") -> \/-($include()))),
           IgnoreId))))
     }
 
@@ -550,7 +550,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
       crystallize(chain(
         $read(Collection("db", "foo")),
         $project(Reshape(ListMap(
-            BsonField.Name("loc") -> -\/($var(DocField(BsonField.Name("loc")))))),
+            BsonField.Name("loc") -> \/-($var(DocField(BsonField.Name("loc")))))),
           IgnoreId),
         $unwind(DocField(BsonField.Name("bar"))),
         $unwind(DocField(BsonField.Name("baz"))),
@@ -563,7 +563,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
       beTree(Crystallized(chain(
         $read(Collection("db", "foo")),
         $project(Reshape(ListMap(
-            BsonField.Name("loc") -> -\/($var(DocField(BsonField.Name("loc")))))),
+            BsonField.Name("loc") -> \/-($var(DocField(BsonField.Name("loc")))))),
           IgnoreId),
         $unwind(DocField(BsonField.Name("bar"))),
         $unwind(DocField(BsonField.Name("baz"))),
@@ -575,8 +575,8 @@ class WorkflowSpec extends Specification with TreeMatchers {
           ListMap()),
         $project(
           Reshape(ListMap(
-            BsonField.Name("0") -> -\/($include()),
-            BsonField.Name("1") -> -\/($include()))),
+            BsonField.Name("0") -> \/-($include()),
+            BsonField.Name("1") -> \/-($include()))),
           IgnoreId))))
     }
   }
@@ -606,11 +606,11 @@ class WorkflowSpec extends Specification with TreeMatchers {
         $group(
           Grouped(ListMap(
             BsonField.Name("__sd_tmp_1") -> $push($field("lEft")))),
-          -\/($literal(Bson.Int32(1)))),
+          \/-($literal(Bson.Int32(1)))),
         $project(Reshape(ListMap(
-          BsonField.Name("a")      -> -\/($include()),
-          BsonField.Name("b")      -> -\/($include()),
-          BsonField.Name("equal?") -> -\/($eq($field("a"), $field("b"))))),
+          BsonField.Name("a")      -> \/-($include()),
+          BsonField.Name("b")      -> \/-($include()),
+          BsonField.Name("equal?") -> \/-($eq($field("a"), $field("b"))))),
           IncludeId),
         $match(Selector.Doc(
           BsonField.Name("equal?") -> Selector.Eq(Bson.Bool(true)))),
@@ -618,8 +618,8 @@ class WorkflowSpec extends Specification with TreeMatchers {
         $limit(100),
         $skip(5),
         $project(Reshape(ListMap(
-          BsonField.Name("a") -> -\/($include()),
-          BsonField.Name("b") -> -\/($include()))),
+          BsonField.Name("a") -> \/-($include()),
+          BsonField.Name("b") -> \/-($include()))),
           IncludeId)))) must
       beTree[WorkflowTask](
         PipelineTask(ReadTask(Collection("db", "zips")),
@@ -627,12 +627,12 @@ class WorkflowSpec extends Specification with TreeMatchers {
             $Group((),
               Grouped(ListMap(
                 BsonField.Name("__sd_tmp_1") -> $push($field("lEft")))),
-              -\/($literal(Bson.Null))),
+              \/-($literal(Bson.Null))),
             $Project((),
               Reshape(ListMap(
-                BsonField.Name("a")      -> -\/($field("a")),
-                BsonField.Name("b")      -> -\/($field("b")),
-                BsonField.Name("equal?") -> -\/($eq($field("a"), $field("b"))))),
+                BsonField.Name("a")      -> \/-($field("a")),
+                BsonField.Name("b")      -> \/-($field("b")),
+                BsonField.Name("equal?") -> \/-($eq($field("a"), $field("b"))))),
               IncludeId),
             $Match((),
               Selector.Doc(
@@ -642,8 +642,8 @@ class WorkflowSpec extends Specification with TreeMatchers {
             $Skip((), 5),
             $Project((),
               Reshape(ListMap(
-                BsonField.Name("a") -> -\/($field("a")),
-                BsonField.Name("b") -> -\/($field("b")))),
+                BsonField.Name("a") -> \/-($field("a")),
+                BsonField.Name("b") -> \/-($field("b")))),
               IncludeId))))
     }
 
@@ -772,7 +772,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
           List(
             $Project((),
               Reshape(ListMap(
-                BsonField.Name("0") -> -\/($field("value", "0")))),
+                BsonField.Name("0") -> \/-($field("value", "0")))),
               IgnoreId))))
     }
 
@@ -826,8 +826,8 @@ class WorkflowSpec extends Specification with TreeMatchers {
           List(
             $Project((),
               Reshape(ListMap(
-                BsonField.Name("0") -> -\/($field("value", "0")),
-                BsonField.Name("1") -> -\/($field("value", "1")))),
+                BsonField.Name("0") -> \/-($field("value", "0")),
+                BsonField.Name("1") -> \/-($field("value", "1")))),
               IgnoreId))))
     }
   }
@@ -889,7 +889,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
       val op = chain(readFoo,
         $project(
           Reshape(ListMap(
-            BsonField.Name("bar") -> -\/($field("baz")))),
+            BsonField.Name("bar") -> \/-($field("baz")))),
           IncludeId))
 
       render(op) must_==
@@ -904,8 +904,8 @@ class WorkflowSpec extends Specification with TreeMatchers {
       val op = chain(readFoo,
         $project(
           Reshape(ListMap(
-            BsonField.Name("bar") -> \/-(Reshape(ListMap(
-              BsonField.Name("0") -> -\/($field("baz"))))))),
+            BsonField.Name("bar") -> -\/(Reshape(ListMap(
+              BsonField.Name("0") -> \/-($field("baz"))))))),
           IncludeId))
 
       render(op) must_==
@@ -921,7 +921,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
       val op = chain(readFoo,
         $map(Js.AnonFunDecl(List("key"), Nil), ListMap()),
         $project(Reshape(ListMap(
-          BsonField.Name("bar") -> -\/($field("baz")))),
+          BsonField.Name("bar") -> \/-($field("baz")))),
           IncludeId),
         $flatMap(Js.AnonFunDecl(List("key"), Nil), ListMap()),
         $reduce(
@@ -951,7 +951,7 @@ class WorkflowSpec extends Specification with TreeMatchers {
         $foldLeft(
           chain(readFoo,
             $project(Reshape(ListMap(
-              BsonField.Name("bar") -> -\/($field("baz")))),
+              BsonField.Name("bar") -> \/-($field("baz")))),
               IncludeId)),
           chain(readFoo,
             $map(Js.AnonFunDecl(List("key"), Nil), ListMap()),


### PR DESCRIPTION
Expression tends to be the “default” state, and so we’ve been doing
things like `.map(_.swap)` and `.fold(Some(_), None)`. This eliminates
that extra hoop to jump through.

The three types changed are `WorkflowBuilder.Expr`,
`WorkflowBuilder.GroupValue`, and `Reshape.Shape`.

Also, update Scala to 2.11.7 (some dependency was forcing it anyway) and
add a missing `SpliceBuilder` case to `WorkflowBuilder.objectConcat`.