### PR TITLE
Project a single value for any expression appearing in the group keys

### DIFF
--- a/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/planner.scala
@@ -642,6 +642,7 @@ object MongoDbPlanner extends Planner[Crystallized] with Conversions {
         case Avg        => groupExpr1($avg(_))
         case Min        => groupExpr1($min(_))
         case Max        => groupExpr1($max(_))
+        case Arbitrary  => groupExpr1($first(_))
 
         case Or         => expr2($or(_, _))
         case And        => expr2($and(_, _))

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/workflowbuilder.scala
@@ -970,6 +970,18 @@ object WorkflowBuilder {
           delegate
 
         case (
+          GroupBuilderF(_, _, Doc(cont1), _),
+          GroupBuilderF(_, Nil, _, id2)) =>
+          impl(
+            GroupBuilder(wb1, Nil, Doc(cont1.map { case (n, _) => n -> -\/($var(DocField(n))) }), id2),
+            wb2,
+            combine)
+        case (
+          GroupBuilderF(_, Nil, _, _),
+          GroupBuilderF(_, _, _, _)) =>
+          delegate
+
+        case (
           DocBuilderF(_, shape),
           DocBuilderF(Fix(GroupBuilderF(_, Nil, _, id2)), _)) =>
           impl(

--- a/core/src/main/scala/slamdata/engine/std/agg.scala
+++ b/core/src/main/scala/slamdata/engine/std/agg.scala
@@ -58,6 +58,11 @@ trait AggLib extends Library {
     constTyper(Type.Dec),
     NumericUnary)
 
-  def functions = Count :: Sum :: Min :: Max :: Avg :: Nil
+  val Arbitrary = Reduction("ARBITRARY", "Returns an arbitrary value from a set", Type.Top :: Nil,
+    noSimplification,
+    reflexiveTyper,
+    reflexiveUnary(Type.Top))
+
+  def functions = Count :: Sum :: Min :: Max :: Avg :: Arbitrary :: Nil
 }
 object AggLib extends AggLib

--- a/it/src/test/resources/tests/aliasedFieldSortedByOriginal.test
+++ b/it/src/test/resources/tests/aliasedFieldSortedByOriginal.test
@@ -1,7 +1,7 @@
 {
     "name": "select aliased field sorted by original name",
     "data": "zips.data",
-    "query": "SELECT distinct state AS \"Result Alias\", COUNT(*) FROM zips GROUP BY state ORDER BY state",
+    "query": "SELECT state AS \"Result Alias\", COUNT(*) FROM zips GROUP BY state ORDER BY state",
     "predicate": "containsAtLeast",
     "expected": [{ "Result Alias": "AK", "1":  195 },
                  { "Result Alias": "AL", "1":  567 },

--- a/it/src/test/resources/tests/boulderLikePop.test
+++ b/it/src/test/resources/tests/boulderLikePop.test
@@ -3,7 +3,7 @@
 
   "data": "zips.data",
 
-  "query": "select distinct city, state, sum(pop) as totalPop from zips where city like 'BOULDER%' group by city, state",
+  "query": "select city, state, sum(pop) as totalPop from zips where city like 'BOULDER%' group by city, state",
 
   "predicate": "containsExactly",
 

--- a/it/src/test/resources/tests/citiesByTotalPopulation.test
+++ b/it/src/test/resources/tests/citiesByTotalPopulation.test
@@ -3,7 +3,7 @@
 
   "data": "zips.data",
 
-  "query": "select distinct city, state, sum(pop) as population from zips group by city, state order by population desc limit 5",
+  "query": "select city, state, sum(pop) as population from zips group by city, state order by population desc limit 5",
 
   "predicate": "equalsExactly",
 

--- a/it/src/test/resources/tests/groupByExpression.test
+++ b/it/src/test/resources/tests/groupByExpression.test
@@ -3,7 +3,7 @@
 
   "data": "zips.data",
 
-  "query": "select distinct substring(city, 0, 1) as \"first\", count(*) as numZips from zips group by substring(city, 0, 1)",
+  "query": "select substring(city, 0, 1) as \"first\", count(*) as numZips from zips group by substring(city, 0, 1)",
 
   "predicate": "containsAtLeast",
   "expected": [{ "first": "X", "numZips":    2 },

--- a/it/src/test/resources/tests/groupByFlatten.test
+++ b/it/src/test/resources/tests/groupByFlatten.test
@@ -1,7 +1,7 @@
 {
     "name": "group by flattened field",
     "data": "slamengine_commits.data",
-    "query": "select distinct substring(parents[*].sha, 0, 1), count(*) from slamengine_commits group by substring(parents[*].sha, 0, 1)",
+    "query": "select substring(parents[*].sha, 0, 1), count(*) from slamengine_commits group by substring(parents[*].sha, 0, 1)",
     "predicate": "containsExactly",
     "expected": [{ "0": "0", "1": 1 },
                  { "0": "1", "1": 2 },

--- a/it/src/test/resources/tests/groupedJoin.test
+++ b/it/src/test/resources/tests/groupedJoin.test
@@ -1,7 +1,7 @@
 {
     "name": "count grouped joined tables",
     "data": "slamengine_commits.data",
-    "query": "SELECT distinct p.author.login, COUNT(*) FROM slamengine_commits p INNER JOIN slamengine_commits c ON p.sha = c.sha GROUP BY p.author.login",
+    "query": "SELECT p.author.login, COUNT(*) FROM slamengine_commits p INNER JOIN slamengine_commits c ON p.sha = c.sha GROUP BY p.author.login",
     "predicate": "containsExactly",
     "expected": [{ "login": "mossprescott", "1": 15 },
                  { "login": "sellout",      "1":  9 },

--- a/it/src/test/resources/tests/largestCities.test
+++ b/it/src/test/resources/tests/largestCities.test
@@ -1,0 +1,21 @@
+{
+    "name": "largest cities",
+
+    "data": "zips.data",
+
+    "query": "select city, state, sum(pop) from zips group by city, state order by sum(pop) desc limit 10",
+
+    "predicate": "equalsExactly",
+    "expected": [
+      { "city": "CHICAGO",      "state": "IL", "2": 2452177 },
+      { "city": "BROOKLYN",     "state": "NY", "2": 2300504 },
+      { "city": "LOS ANGELES",  "state": "CA", "2": 2102295 },
+      { "city": "HOUSTON",      "state": "TX", "2": 2095918 },
+      { "city": "PHILADELPHIA", "state": "PA", "2": 1610956 },
+      { "city": "NEW YORK",     "state": "NY", "2": 1476790 },
+      { "city": "BRONX",        "state": "NY", "2": 1209548 },
+      { "city": "SAN DIEGO",    "state": "CA", "2": 1049298 },
+      { "city": "DETROIT",      "state": "MI", "2":  963243 },
+      { "city": "DALLAS",       "state": "TX", "2":  940191 }
+    ]
+}

--- a/it/src/test/resources/tests/projectIndexFromGroup.test
+++ b/it/src/test/resources/tests/projectIndexFromGroup.test
@@ -1,6 +1,7 @@
 {
     "name": "project index from group",
-    "query": "select distinct parents[0].sha, count(parents[0].sha) as count from slamengine_commits group by parents[0].sha",
+    "data": "slamengine_commits.data",
+    "query": "select parents[0].sha, count(*) as count from slamengine_commits group by parents[0].sha",
     "predicate": "containsAtLeast",
     "expected": [
         { "sha": "b812837ee2f72be3aaee582b42e3ad901d1f7371", "count": 1 },

--- a/it/src/test/resources/tests/projectIndexFromGroupWithFilter.test
+++ b/it/src/test/resources/tests/projectIndexFromGroupWithFilter.test
@@ -1,6 +1,7 @@
 {
     "name": "project index from group with filter",
-    "query": "select distinct parents[0].sha, count(parents[0].sha) as count from slamengine_commits where parents[0].sha like '5%' group by parents[0].sha",
+    "data": "slamengine_commits.data",
+    "query": "select parents[0].sha, count(*) as count from slamengine_commits where parents[0].sha like '5%' group by parents[0].sha",
     "predicate": "containsExactly",
     "expected": [
         { "sha": "53d2e5684d9403194dff1cc63423c2590038d1c0", "count": 1 },

--- a/it/src/test/resources/tests/statesByShortestFirstCity.test
+++ b/it/src/test/resources/tests/statesByShortestFirstCity.test
@@ -4,7 +4,7 @@
 
   "data": "zips.data",
 
-  "query": "select distinct state, min(city) as first, length(min(city)) as len from zips group by state order by len, first, state limit 5",
+  "query": "select state, min(city) as first, length(min(city)) as len from zips group by state order by len, first, state limit 5",
 
   "predicate": "equalsExactly",
 

--- a/it/src/test/resources/tests/zipsByCityLength.test
+++ b/it/src/test/resources/tests/zipsByCityLength.test
@@ -3,7 +3,7 @@
 
   "data": "zips.data",
 
-  "query": "select distinct length(city) as len, count(*) as cnt
+  "query": "select length(city) as len, count(*) as cnt
     from zips
     where state != 'MI'
     group by length(city)",


### PR DESCRIPTION
Fixes #459.

New Func `Arbitrary`, to select a single value from a set. Translated to $first for MongoDB.

During compilation, keep track of the compiled form of each grouping key, and then when any of them occurs in a projection (even embedded in a larger expression), wrap with `Arbitrary(...)` to simulate SQL semantics.

Handle an additional case in objectConcat that arises from the new shape.

Update query generator to avoid generating anything that would (correctly) lead to a plan with two consecutive group ops, because that pattern is flagged as a common characteristic of busted plans.

Update integration test queries to remove DISTINCT where it's no longer needed.