### PR TITLE
update to http4s 0.8.6

### DIFF
--- a/web/build.sbt
+++ b/web/build.sbt
@@ -2,7 +2,7 @@ name := "Web"
 
 mainClass in Compile := Some("slamdata.engine.api.Server")
 
-val http4sVersion     = "0.8.3"
+val http4sVersion     = "0.8.6"
 
 libraryDependencies ++= Seq(
   "org.http4s"           %% "http4s-dsl"       % http4sVersion % "compile, test",


### PR DESCRIPTION
Fixes #886 (now known as SD-888), a stack overflow when reading several
thousand rows via the API with gzip encoding.

The bug was fixed in http4s, which is updated here. This commit adds
integration tests of the backend and of the API implementation, showing that
each is capable of emitting a 100k rows result set.