### PR TITLE
Document and test behavior of Backend.scan

### DIFF
--- a/core/src/main/scala/slamdata/engine/backend.scala
+++ b/core/src/main/scala/slamdata/engine/backend.scala
@@ -121,16 +121,33 @@ sealed trait Backend { self =>
 
   // Filesystem stuff
 
+  /**
+   * A stream of data found at the specified path
+   * @param path The path for which to retrieve the specified data
+   * @param offset The offset from which to start streaming the Data. If the collection contains 10 elements, specifying
+   *               an offset of 5 will stream the last 5 data elements in the collection. offset must be a positive
+   *               number or else this method returns a failed `Process` with the error `InvalidOffsetError`
+   * @param limit The maximum amount of elements to stream.
+   * @return A stream of data contained on the collection found at the specified path.
+   */
   final def scan(path: Path, offset: Long, limit: Option[Long]):
       Process[ETask[ResultError, ?], Data] =
     (offset, limit) match {
       // NB: skip < 0 is an error in the driver
       case (o, _)       if o < 0 => Process.eval[ETask[ResultError, ?], Data](EitherT.left(Task.now(InvalidOffsetError(o))))
-      // NB: limit == 0 means no limit, and limit < 0 means request only a single batch (which we use below)
+      // NB: limit < 1 is also an error in the driver
       case (_, Some(l)) if l < 1 => Process.eval[ETask[ResultError, ?], Data](EitherT.left(Task.now(InvalidLimitError(l))))
       case _                     => scan0(path.asRelative, offset, limit)
     }
 
+  /**
+   * Implementation of scan. A `Backend` needs to supply an implementation for this method.
+   * The implementation can take for granted that the domain of the arguments are correct.
+   * @param path The path for which to retrieve the specified data
+   * @param offset A non-negative number that represents the offset at which to start streaming
+   * @param limit The maximum amount of elements to stream
+   * @return A stream of data contained on the collection found at the specified path.
+   */
   def scan0(path: Path, offset: Long, limit: Option[Long]):
       Process[ETask[ResultError, ?], Data]
 

--- a/core/src/main/scala/slamdata/engine/physical/mongodb/filesystem.scala
+++ b/core/src/main/scala/slamdata/engine/physical/mongodb/filesystem.scala
@@ -37,6 +37,10 @@ trait MongoDbFileSystem extends PlannerBackend[Workflow.Crystallized] {
       e => Process.eval[ETask[ResultError, ?], Data](EitherT.left(Task.now(ResultPathError(e)))),
       col => {
         val skipper = (it: com.mongodb.client.FindIterable[org.bson.Document]) => it.skip(offset.toInt)
+        // NB As per the MondoDB documentation, we inverse the value of limit in order to retrieve a single batch.
+        // The documentation around this is very confusing, but it would appear that proceeding this way allows us
+        // to retrieve the data in a single batch. Behavior of the limit parameter on large datasets is tested in
+        // FileSystemSpecs and appears to work as expected.
         val limiter = (it: com.mongodb.client.FindIterable[org.bson.Document]) => limit.map(v => it.limit(-v.toInt)).getOrElse(it)
 
         val skipperAndLimiter = skipper andThen limiter

--- a/it/src/test/scala/slamdata/engine/fs/filesystem.scala
+++ b/it/src/test/scala/slamdata/engine/fs/filesystem.scala
@@ -377,6 +377,22 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers {
           }).run
         }
 
+        "read large data with limit" in {
+          val COUNT = 10000
+          val LIMIT = 9000
+          val data = Process.range(0, COUNT).map(n => Data.Obj(ListMap("a" -> Data.Int(n))))
+
+          (for {
+            tmp <- genTempFile
+            _   <- fs.save(TestDir ++ tmp, data).run
+
+            t   = fs.scan(TestDir ++ tmp, 0, Some(LIMIT)).map(_ => 1).sum.runLast
+            ds  <- t.run
+          } yield {
+              ds must beRightDisjunction(Some(LIMIT))
+            }).run
+        }
+
         "read very large data, encode, and zip" in {
           // NB: test as many layers as we can without the API, including
           // reading from the backend, encoding the results, and gzipping the

--- a/it/src/test/scala/slamdata/engine/fs/filesystem.scala
+++ b/it/src/test/scala/slamdata/engine/fs/filesystem.scala
@@ -377,22 +377,6 @@ class FileSystemSpecs extends BackendTest with DisjunctionMatchers {
           }).run
         }
 
-        "read large data with limit" in {
-          val COUNT = 10000
-          val LIMIT = 9000
-          val data = Process.range(0, COUNT).map(n => Data.Obj(ListMap("a" -> Data.Int(n))))
-
-          (for {
-            tmp <- genTempFile
-            _   <- fs.save(TestDir ++ tmp, data).run
-
-            t   = fs.scan(TestDir ++ tmp, 0, Some(LIMIT)).map(_ => 1).sum.runLast
-            ds  <- t.run
-          } yield {
-              ds must beRightDisjunction(Some(LIMIT))
-            }).run
-        }
-
         "read very large data, encode, and zip" in {
           // NB: test as many layers as we can without the API, including
           // reading from the backend, encoding the results, and gzipping the


### PR DESCRIPTION
Implementation of scan contained some bizarre wizardry that I believe is worthwhile to document and test. Update comment that was out of date.