### PR TITLE
Update the start script's success check

### DIFF
--- a/scripts/startSlamEngine
+++ b/scripts/startSlamEngine
@@ -37,7 +37,7 @@ tail slamengine.out
 echo
 
 
-expected=$(tail -n 3 slamengine.out | grep 'Embedded server listening')
+expected=$(tail -n 3 slamengine.out | grep 'Server started listening')
 if [ "$expected" == "" ]; then
   echo "Server did not start"
   exit 1


### PR DESCRIPTION
A recent PR slightly modified the output of the server on startup, which caused the `startSlamEngine` script's success check to begin failing with a false-negative. This fixes the immediate issue to make jenkins happy.

In general, it'd be nice to come up with a more robust way of detecting success as the current method is a bit brittle. I didn't see an expedient way of DRYing up `testJar` and `startSlamEngine` whilst keeping `startSlamEngine` independent of the rest of the scripts (I assumed it should remain independent, but if it is ok that it depends on being in the scripts dir, then we could dry things up a bit by having the two share success criteria).